### PR TITLE
Add AI authorship disclosure per WordPress AI Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Agent Skills are portable bundles of instructions, checklists, and scripts that help AI assistants (Claude, Copilot, Codex, Cursor, etc.) understand WordPress development patterns, avoid common mistakes, and follow best practices.
 
+> **AI Authorship Disclosure:** These skills were generated using GPT-5.2 Codex (High Reasoning) from official Gutenberg and WordPress documentation, then reviewed and edited by WordPress contributors. We tested skills with AI assistants and iterated based on results. This is v1, and skills will improve as the community uses them and contributes fixes. See [docs/ai-authorship.md](docs/ai-authorship.md) for details. ([WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/))
+
 ## Why Agent Skills?
 
 AI coding assistants are powerful, but they often:

--- a/docs/ai-authorship.md
+++ b/docs/ai-authorship.md
@@ -20,7 +20,7 @@ This document describes how AI tools were used to create the skills in this repo
 
 3. **Contributor Review**: WordPress contributors reviewed each skill for accuracy, alignment with current best practices, and completeness.
 
-4. **AI-Assisted Testing**: Skills were tested by using them with AI coding assistants (Codex and Claude Code) on real WordPress development tasks, sourced from [WP Bench](https://make.wordpress.org/ai/2026/01/14/introducing-wp-bench-a-wordpress-ai-benchmark/) to verify they produce correct guidance. That said, skills have not (yet) been run across a formal evaluation system, as one does not exist. 
+4. **AI-Assisted Testing**: Skills were tested by using them with AI coding assistants (Codex and Claude Code) on real WordPress development tasks, sourced from [WP Bench](https://make.wordpress.org/ai/2026/01/14/introducing-wp-bench-a-wordpress-ai-benchmark/) to verify they produce correct guidance. That said, skills have not (yet) been run across a formal evaluation system, *as one does not exist*.
 
 5. **Iteration**: Based on testing results, skills were refined before the v1 release.
 
@@ -28,21 +28,21 @@ This document describes how AI tools were used to create the skills in this repo
 
 All v1 skills followed the same process described above. As skills diverge in their development history, this table will be updated.
 
-| Skill | AI Generated | Human Reviewed | Tested | Notes |
-|-------|--------------|----------------|--------|-------|
-| wordpress-router | Yes | Yes | Yes | Routes to appropriate workflows |
-| wp-project-triage | Yes | Yes | Yes | Includes detection scripts |
-| wp-block-development | Yes | Yes | Yes | Core Gutenberg block patterns |
-| wp-block-themes | Yes | Yes | Yes | theme.json, templates, patterns |
-| wp-plugin-development | Yes | Yes | Yes | Hooks, settings API, security |
-| wp-rest-api | Yes | Yes | Yes | REST endpoints and auth |
-| wp-interactivity-api | Yes | Yes | Yes | data-wp-* directives |
-| wp-abilities-api | Yes | Yes | Yes | Capability-based permissions |
-| wp-wpcli-and-ops | Yes | Yes | Yes | CLI commands and automation |
-| wp-performance | Yes | Yes | Yes | Profiling, caching, optimization |
-| wp-phpstan | Yes | Yes | Yes | Static analysis configuration |
-| wp-playground | Yes | Yes | Yes | Local dev environments |
-| wpds | Yes | Yes | Yes | WordPress Design System |
+| Skill | AI Generated | Human Reviewed | Tested |
+|-------|--------------|----------------|--------|
+| [wordpress-router](../skills/wordpress-router/SKILL.md) | Yes | Yes | Yes |
+| [wp-project-triage](../skills/wp-project-triage/SKILL.md) | Yes | Yes | Yes |
+| [wp-block-development](../skills/wp-block-development/SKILL.md) | Yes | Yes | Yes |
+| [wp-block-themes](../skills/wp-block-themes/SKILL.md) | Yes | Yes | Yes |
+| [wp-plugin-development](../skills/wp-plugin-development/SKILL.md) | Yes | Yes | Yes |
+| [wp-rest-api](../skills/wp-rest-api/SKILL.md) | Yes | Yes | Yes |
+| [wp-interactivity-api](../skills/wp-interactivity-api/SKILL.md) | Yes | Yes | Yes |
+| [wp-abilities-api](../skills/wp-abilities-api/SKILL.md) | Yes | Yes | Yes |
+| [wp-wpcli-and-ops](../skills/wp-wpcli-and-ops/SKILL.md) | Yes | Yes | Yes |
+| [wp-performance](../skills/wp-performance/SKILL.md) | Yes | Yes | Yes |
+| [wp-phpstan](../skills/wp-phpstan/SKILL.md) | Yes | Yes | Yes |
+| [wp-playground](../skills/wp-playground/SKILL.md) | Yes | Yes | Yes |
+| [wpds](../skills/wpds/SKILL.md) | Yes | Yes | Yes |
 
 ## Quality Commitment
 

--- a/docs/ai-authorship.md
+++ b/docs/ai-authorship.md
@@ -1,0 +1,60 @@
+# AI Authorship Disclosure
+
+This document describes how AI tools were used to create the skills in this repository, in accordance with the [WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/).
+
+## Summary
+
+| Aspect | Details |
+|--------|---------|
+| **AI Tool** | GPT-5.2 Codex (High Reasoning) |
+| **Source Material** | Official Gutenberg trunk documentation, WordPress developer docs |
+| **Human Review** | All skills reviewed and edited by WordPress contributors |
+| **Testing** | Skills tested with AI assistants (Claude, Copilot, Codex) |
+| **License** | GPL-2.0-or-later (compatible with WordPress) |
+
+## Process
+
+1. **Source Collection**: Up-to-date documentation was gathered from Gutenberg trunk and official WordPress developer resources.
+
+2. **AI Generation**: GPT-5.2 Codex (High Reasoning) processed the documentation to create semantically dense skill files, distilling large doc sets into actionable instructions AI assistants can follow.
+
+3. **Contributor Review**: WordPress contributors reviewed each skill for accuracy, alignment with current best practices, and completeness.
+
+4. **AI-Assisted Testing**: Skills were tested by using them with AI coding assistants (Codex and Claude Code) on real WordPress development tasks, sourced from [WP Bench](https://make.wordpress.org/ai/2026/01/14/introducing-wp-bench-a-wordpress-ai-benchmark/) to verify they produce correct guidance. That said, skills have not (yet) been run across a formal evaluation system, as one does not exist. 
+
+5. **Iteration**: Based on testing results, skills were refined before the v1 release.
+
+## Per-Skill Breakdown
+
+All v1 skills followed the same process described above. As skills diverge in their development history, this table will be updated.
+
+| Skill | AI Generated | Human Reviewed | Tested | Notes |
+|-------|--------------|----------------|--------|-------|
+| wordpress-router | Yes | Yes | Yes | Routes to appropriate workflows |
+| wp-project-triage | Yes | Yes | Yes | Includes detection scripts |
+| wp-block-development | Yes | Yes | Yes | Core Gutenberg block patterns |
+| wp-block-themes | Yes | Yes | Yes | theme.json, templates, patterns |
+| wp-plugin-development | Yes | Yes | Yes | Hooks, settings API, security |
+| wp-rest-api | Yes | Yes | Yes | REST endpoints and auth |
+| wp-interactivity-api | Yes | Yes | Yes | data-wp-* directives |
+| wp-abilities-api | Yes | Yes | Yes | Capability-based permissions |
+| wp-wpcli-and-ops | Yes | Yes | Yes | CLI commands and automation |
+| wp-performance | Yes | Yes | Yes | Profiling, caching, optimization |
+| wp-phpstan | Yes | Yes | Yes | Static analysis configuration |
+| wp-playground | Yes | Yes | Yes | Local dev environments |
+| wpds | Yes | Yes | Yes | WordPress Design System |
+
+## Quality Commitment
+
+These skills are curated distillations of official documentation, reviewed by people who understand WordPress development. That said:
+
+- Skills will contain errors. Please [report issues](https://github.com/WordPress/agent-skills/issues).
+- Skills will improve over time as the community uses them and contributes fixes.
+- We welcome PRs that improve accuracy, fix outdated patterns, or add missing guidance.
+
+## Evolution
+
+This disclosure will be updated as:
+- Individual skills receive significant human rewrites
+- New skills are added with different authorship processes
+- Community feedback identifies areas needing clarification


### PR DESCRIPTION
## Summary

- Adds AI authorship disclosure to README (above the fold)
- Creates docs/ai-authorship.md with detailed breakdown of skill creation process
- Documents tools used, source material, review process, and testing methodology

Addresses the requirements in the WordPress AI Guidelines for transparent disclosure of AI-assisted contributions.

Fixes #6