### PR TITLE
Add block context/Query Loop reference and expand supports guidance

### DIFF
--- a/skills/wp-block-development/SKILL.md
+++ b/skills/wp-block-development/SKILL.md
@@ -110,6 +110,9 @@ Read:
 - `references/supports-and-wrappers.md`
 - `references/dynamic-rendering.md` (if dynamic)
 
+If the block reads per-post data (content, meta, title, excerpt, etc.), read the context reference to ensure the editor component works inside Query Loop:
+- `references/context-and-query-loop.md`
+
 ### 7) Inner blocks (block composition)
 
 If your block is a “container” that nests other blocks, treat Inner Blocks as a first-class feature:

--- a/skills/wp-block-development/references/context-and-query-loop.md
+++ b/skills/wp-block-development/references/context-and-query-loop.md
@@ -1,0 +1,101 @@
+# Block context and Query Loop
+
+Use this file when your block reads per-post data (content, meta, title, excerpt, etc.) and must work inside Query Loop as well as standalone.
+
+## Canonical references
+
+- Block context: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/
+- Query Loop block: https://developer.wordpress.org/block-editor/reference-guides/core-blocks/#query-loop
+- Entity records: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-core-data/
+
+## How block context works
+
+Blocks declare the context they consume via `usesContext` and the context they provide via `providesContext` in `block.json`.
+
+Query Loop (`core/post-template`) provides `postId` and `postType` to every inner block. When your block declares `usesContext: ["postId", "postType"]`, WordPress passes those values automatically.
+
+### block.json example
+
+```json
+{
+  "usesContext": [ "postId", "postType" ]
+}
+```
+
+No `providesContext` is needed unless your block in turn passes data to its own inner blocks.
+
+## Editor pattern (edit.js)
+
+Consume the `context` prop and use `getEditedEntityRecord` from the `core` store to fetch post data that reflects unsaved edits:
+
+```js
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function Edit( { context } ) {
+  const { postId, postType } = context;
+
+  const post = useSelect(
+    ( select ) =>
+      postId
+        ? select( coreStore ).getEditedEntityRecord( 'postType', postType, postId )
+        : undefined,
+    [ postId, postType ]
+  );
+
+  const blockProps = useBlockProps();
+
+  if ( ! post ) {
+    return <div { ...blockProps }>{ /* placeholder or spinner */ }</div>;
+  }
+
+  return (
+    <div { ...blockProps }>
+      { /* render using post.title, post.meta, etc. */ }
+    </div>
+  );
+}
+```
+
+Key points:
+
+- `context.postId` is `undefined` when the block is used standalone outside Query Loop. Handle this case (e.g., fall back to the current post via `select( 'core/editor' ).getCurrentPostId()`).
+- Always pass `[ postId, postType ]` as the dependency array for `useSelect`.
+
+## Render pattern (render.php)
+
+Access context via `$block->context` and fall back to `get_the_ID()` for standalone use:
+
+```php
+$post_id = isset( $block->context['postId'] )
+    ? (int) $block->context['postId']
+    : get_the_ID();
+```
+
+- Cast to `int` to avoid type issues downstream.
+- `get_the_ID()` returns the correct post ID when the block is placed directly in a template or post content outside Query Loop.
+
+## Antipattern: using `core/editor` store in context-aware blocks
+
+Do **not** use `select( 'core/editor' ).getEditedPostContent()` or similar `core/editor` selectors to fetch post data when the block declares `usesContext`. The `core/editor` store always returns data for the *top-level post being edited*, not the iterated post inside Query Loop. This causes every loop iteration to display the same (wrong) data.
+
+Use `select( 'core' ).getEditedEntityRecord()` with the context-provided `postId` and `postType` instead.
+
+## Verification
+
+Test both scenarios:
+
+1. **Standalone:** Insert the block directly in a post or page. Confirm it reads data from that post.
+2. **Query Loop:** Insert the block inside a Query Loop block (e.g., in a template or a post that contains a Query Loop). Confirm each iteration shows data for its respective post, not the parent post.
+
+## Common blocks that need this pattern
+
+Any block that displays per-post data should declare `usesContext` and follow the patterns above. Examples:
+
+- Reading time estimate
+- Author bio / avatar
+- Share count
+- Custom field display (post meta)
+- Excerpt derivatives (truncated content, summary)
+- Related post metadata (publish date, categories, tags)

--- a/skills/wp-block-development/references/supports-and-wrappers.md
+++ b/skills/wp-block-development/references/supports-and-wrappers.md
@@ -2,17 +2,95 @@
 
 Use this file when changing `supports` or when your block wrapper styling behaves unexpectedly.
 
-## Required patterns
+## Canonical references
+
+- Block supports: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/
+- theme.json: https://developer.wordpress.org/block-editor/how-to-guides/themes/global-settings-and-styles/
+- `get_block_wrapper_attributes()`: https://developer.wordpress.org/reference/functions/get_block_wrapper_attributes/
+
+## Required wrapper patterns
 
 - In `edit()`, use `useBlockProps()`.
 - In `save()`, use `useBlockProps.save()`.
+- In dynamic render (PHP), use `get_block_wrapper_attributes()`.
 
-If the block is dynamic (PHP render), use:
+These functions apply the classes and inline styles that WordPress generates from `supports`. Omitting them causes support-driven styles (colors, spacing, typography) to silently fail.
 
-- `get_block_wrapper_attributes()`
+## Recommended default supports for new blocks
 
-Upstream reference:
+New blocks should enable color, typography, and spacing supports unless there is a specific reason not to. This ensures the block integrates with the site's design system and works across themes without custom CSS.
 
-- https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/
-- https://developer.wordpress.org/reference/functions/get_block_wrapper_attributes/
+```json
+{
+  "supports": {
+    "color": {
+      "background": true,
+      "text": true,
+      "link": true
+    },
+    "typography": {
+      "fontSize": true,
+      "lineHeight": true
+    },
+    "spacing": {
+      "margin": true,
+      "padding": true
+    }
+  }
+}
+```
 
+**Why this matters:** Themes define palettes, font sizes, and spacing scales in `theme.json`. When a block declares these supports, users can style it using the same controls they use for core blocks. Without supports, users resort to custom CSS or the block ships with hardcoded values that clash with other themes.
+
+## When to add align support
+
+Add `align` support when the block is intended to be used as a top-level layout element that may need wide or full-width presentation:
+
+```json
+{
+  "supports": {
+    "align": [ "wide", "full" ]
+  }
+}
+```
+
+Avoid adding `align` to small inline or nested blocks where width alignment is not meaningful.
+
+## CSS custom properties over hardcoded values
+
+Block styles should reference design tokens from `theme.json` via CSS custom properties rather than hardcoding colors, font sizes, or spacing values.
+
+**Antipattern — hardcoded values:**
+
+```css
+.wp-block-example {
+  color: #666;
+  font-size: 14px;
+  padding: 20px;
+}
+```
+
+**Correct pattern — CSS custom properties:**
+
+```css
+.wp-block-example {
+  color: var(--wp--preset--color--contrast, #666);
+  font-size: var(--wp--preset--font-size--small, 14px);
+  padding: var(--wp--preset--spacing--20, 20px);
+}
+```
+
+The fallback value after the comma ensures the block still renders sensibly if the preset is not defined, but the custom property allows themes to override the value through `theme.json`.
+
+## When supports can eliminate SCSS
+
+If a block's only visual customization is colors, typography, and spacing, `supports` alone may be sufficient — no SCSS or CSS file is needed. WordPress generates the necessary inline styles from the block's attributes.
+
+You still need SCSS or a stylesheet when:
+
+- The block has layout-specific styles (grid, flexbox, positioning).
+- The block uses pseudo-elements, animations, or transitions.
+- The block requires responsive breakpoints beyond what layout supports provide.
+- The block has interactive states (hover, focus) that go beyond color changes.
+
+When in doubt, start with supports only and add a stylesheet when you encounter a styling need that supports cannot express.


### PR DESCRIPTION
## Summary

- **New file:** `references/context-and-query-loop.md` — covers the `usesContext` API, how blocks should consume context in both editor (`getEditedEntityRecord`) and render.php (`$block->context`), the antipattern of using `core/editor` store in context-aware blocks, and verification guidance for Query Loop scenarios.
- **Expanded:** `references/supports-and-wrappers.md` — from ~15 lines of wrapper docs to comprehensive guidance on default supports for new blocks, CSS custom properties vs hardcoded values, and when supports can eliminate SCSS.
- **Updated:** `SKILL.md` Step 6 — now references the context guide for blocks that read per-post data.

## Motivation

Blocks that render per-post data (reading time, author bio, custom field display, etc.) need to work inside Query Loop, not just the single-post editor. Without guidance on `usesContext` and the `getEditedEntityRecord` pattern, blocks default to pulling from `core/editor` store which shows the template's data for every iterated post.

Similarly, new blocks frequently ship with hardcoded colors and minimal `supports`, making them incompatible with theme design systems. The expanded supports reference provides actionable defaults.

## Test plan

- [ ] Verify `context-and-query-loop.md` code examples are valid against WordPress 6.9+ APIs
- [ ] Verify `supports-and-wrappers.md` JSON example validates against block.json schema
- [ ] Verify SKILL.md change doesn't break step numbering or reference links

🤖 Generated with [Claude Code](https://claude.com/claude-code)