### PR TITLE
Add Warp skillpack build/install support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,17 @@ jobs:
       - name: Run local eval harness
         run: node eval/harness/run.mjs
 
-      - name: Build skillpacks (Codex + VS Code)
-        run: node shared/scripts/skillpack-build.mjs --clean --out=dist --targets=codex,vscode
+      - name: Build skillpacks (Codex + VS Code + Warp)
+        run: node shared/scripts/skillpack-build.mjs --clean --out=dist --targets=codex,vscode,warp
 
       - name: Install skillpacks (smoke)
         run: |
           rm -rf /tmp/skillpack-install-test
           mkdir -p /tmp/skillpack-install-test
-          node shared/scripts/skillpack-install.mjs --from=dist --dest=/tmp/skillpack-install-test --targets=codex,vscode
+          node shared/scripts/skillpack-install.mjs --from=dist --dest=/tmp/skillpack-install-test --targets=codex,vscode,warp
           test -f /tmp/skillpack-install-test/.codex/skills/wordpress-router/SKILL.md
           test -f /tmp/skillpack-install-test/.github/skills/wordpress-router/SKILL.md
+          test -f /tmp/skillpack-install-test/.agents/skills/wordpress-router/SKILL.md
 
       - uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Teach AI coding assistants how to build WordPress the right way.**
 
-Agent Skills are portable bundles of instructions, checklists, and scripts that help AI assistants (Claude, Copilot, Codex, Cursor, etc.) understand WordPress development patterns, avoid common mistakes, and follow best practices.
+Agent Skills are portable bundles of instructions, checklists, and scripts that help AI assistants (Claude, Copilot, Codex, Cursor, Warp, etc.) understand WordPress development patterns, avoid common mistakes, and follow best practices.
 
 > **AI Authorship Disclosure:** These skills were generated using GPT-5.2 Codex (High Reasoning) from official Gutenberg and WordPress documentation, then reviewed and edited by WordPress contributors. We tested skills with AI assistants and iterated based on results. This is v1, and skills will improve as the community uses them and contributes fixes. See [docs/ai-authorship.md](docs/ai-authorship.md) for details. ([WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/))
 
@@ -130,7 +130,7 @@ cd agent-skills
 node shared/scripts/skillpack-build.mjs --clean
 
 # Install into your WordPress project
-node shared/scripts/skillpack-install.mjs --dest=../your-wp-project --targets=codex,vscode,claude,cursor
+node shared/scripts/skillpack-install.mjs --dest=../your-wp-project --targets=codex,vscode,claude,cursor,warp
 ```
 
 This copies skills into:
@@ -138,6 +138,7 @@ This copies skills into:
 - `.github/skills/` for VS Code / GitHub Copilot
 - `.claude/skills/` for Claude Code (project-level)
 - `.cursor/skills/` for Cursor (project-level)
+- `.agents/skills/` for Warp (project-level, recommended)
 
 Antigravity is opt-in for project-level installs. To also copy skills into `.agents/skills/`, include `antigravity` when building and installing:
 
@@ -162,6 +163,13 @@ node shared/scripts/skillpack-install.mjs --targets=antigravity-global
 ```
 
 This installs skills to `~/.gemini/antigravity/skills/` where Antigravity will discover them.
+### Install globally for Warp
+
+```bash
+node shared/scripts/skillpack-install.mjs --targets=warp-global
+```
+
+This installs skills to `~/.agents/skills/` where Warp will discover them.
 
 ### Available options
 
@@ -172,8 +180,8 @@ node shared/scripts/skillpack-install.mjs --list
 # Dry run (preview without installing)
 node shared/scripts/skillpack-install.mjs --global --dry-run
 
-# Install specific skills to a project (e.g. Claude + Cursor)
-node shared/scripts/skillpack-install.mjs --dest=../my-repo --targets=claude,cursor --skills=wp-wpcli-and-ops
+# Install specific skills to a project (e.g. Claude + Cursor + Warp)
+node shared/scripts/skillpack-install.mjs --dest=../my-repo --targets=claude,cursor,warp --skills=wp-wpcli-and-ops
 ```
 
 ### Manual installation

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -16,6 +16,7 @@ Outputs:
 - `dist/vscode/.github/skills/*` (VS Code / Copilot repo layout)
 - `dist/claude/.claude/skills/*` (Claude Code repo layout)
 - `dist/cursor/.cursor/skills/*` (Cursor repo layout)
+- `dist/warp/.agents/skills/*` (Warp repo layout)
 
 Antigravity is opt-in. Add `--targets=codex,vscode,claude,cursor,antigravity` to also build:
 
@@ -26,7 +27,7 @@ Antigravity is opt-in. Add `--targets=codex,vscode,claude,cursor,antigravity` to
 1. Build dist (above).
 2. Install into a destination repo:
 
-- `node shared/scripts/skillpack-install.mjs --dest=../some-repo --targets=codex,vscode,claude,cursor`
+- `node shared/scripts/skillpack-install.mjs --dest=../some-repo --targets=codex,vscode,claude,cursor,warp`
 
 To include Antigravity, build it first and include it in the install targets:
 

--- a/eval/scenarios/skillpack-build-and-install.json
+++ b/eval/scenarios/skillpack-build-and-install.json
@@ -1,11 +1,11 @@
 {
   "name": "Build and install skillpacks",
   "skills": [],
-  "query": "Package this repo's skills for Codex, VS Code, Claude, and Cursor and install them into another repository.",
+  "query": "Package this repo's skills for Codex, VS Code, Claude, Cursor, and Warp and install them into another repository.",
   "expected_behavior": [
-    "Step 1: Run build command: node shared/scripts/skillpack-build.mjs --clean --targets=codex,vscode,claude,cursor",
+    "Step 1: Run build command: node shared/scripts/skillpack-build.mjs --clean --targets=codex,vscode,claude,cursor,warp",
     "Step 2: Verify build output in dist/ directory",
-    "Step 3: Run install command: node shared/scripts/skillpack-install.mjs --from=dist --dest=<repo-root> --targets=codex,vscode,claude,cursor",
+    "Step 3: Run install command: node shared/scripts/skillpack-install.mjs --from=dist --dest=<repo-root> --targets=codex,vscode,claude,cursor,warp",
     "Step 4: Verify skills installed in target repository",
     "Step 5: Confirm no symlinks in installed skills (files are copied)"
   ],
@@ -14,6 +14,6 @@
     "Output created in dist/ directory",
     "Install command copies to target repository",
     "No symlinks in installed skills",
-    "Codex, vscode, claude, and cursor targets supported"
+    "Codex, vscode, claude, cursor, and warp targets supported"
   ]
 }

--- a/shared/scripts/skillpack-build.mjs
+++ b/shared/scripts/skillpack-build.mjs
@@ -5,17 +5,18 @@ function usage() {
   process.stderr.write(
     [
       "Usage:",
-      "  node shared/scripts/skillpack-build.mjs [--out=dist] [--targets=codex,vscode,claude,cursor] [--skills=skill1,skill2] [--clean]",
+      "  node shared/scripts/skillpack-build.mjs [--out=dist] [--targets=codex,vscode,claude,cursor,warp] [--skills=skill1,skill2] [--clean]",
       "",
       "Outputs:",
       "  - <out>/codex/.codex/skills/<skill>/SKILL.md",
       "  - <out>/vscode/.github/skills/<skill>/SKILL.md",
       "  - <out>/claude/.claude/skills/<skill>/SKILL.md",
       "  - <out>/cursor/.cursor/skills/<skill>/SKILL.md",
+      "  - <out>/warp/.agents/skills/<skill>/SKILL.md",
       "  - <out>/antigravity/.agents/skills/<skill>/SKILL.md",
       "",
       "Options:",
-      "  --targets    Comma-separated list of targets (codex, vscode, claude, cursor; opt-in: antigravity). Default: codex,vscode,claude,cursor",
+      "  --targets    Comma-separated list of targets (codex, vscode, claude, cursor, warp; opt-in: antigravity). Default: codex,vscode,claude,cursor,warp",
       "  --skills     Comma-separated list of skill names to build. Default: all skills",
       "  --clean      Remove target directories before building",
       "",
@@ -27,7 +28,7 @@ function usage() {
 }
 
 function parseArgs(argv) {
-  const args = { out: "dist", targets: ["codex", "vscode", "claude", "cursor"], skills: [], clean: false };
+  const args = { out: "dist", targets: ["codex", "vscode", "claude", "cursor", "warp"], skills: [], clean: false };
   for (const a of argv) {
     if (a === "--help" || a === "-h") args.help = true;
     else if (a === "--clean") args.clean = true;
@@ -102,6 +103,7 @@ function buildTarget({ repoRoot, outDir, target, skillDirs }) {
     vscode: path.join(outDir, "vscode", ".github", "skills"),
     claude: path.join(outDir, "claude", ".claude", "skills"),
     cursor: path.join(outDir, "cursor", ".cursor", "skills"),
+    warp: path.join(outDir, "warp", ".agents", "skills"),
     antigravity: path.join(outDir, "antigravity", ".agents", "skills"),
   };
   const destSkillsRoot = rootByTarget[target];
@@ -119,7 +121,7 @@ function buildTarget({ repoRoot, outDir, target, skillDirs }) {
   process.stdout.write(`OK: built ${target} skillpack at ${rel}\n`);
 }
 
-const VALID_TARGETS = ["codex", "vscode", "claude", "cursor", "antigravity"];
+const VALID_TARGETS = ["codex", "vscode", "claude", "cursor", "warp", "antigravity"];
 
 function main() {
   const args = parseArgs(process.argv.slice(2));

--- a/shared/scripts/skillpack-install.mjs
+++ b/shared/scripts/skillpack-install.mjs
@@ -11,7 +11,7 @@ function usage() {
       "Options:",
       "  --dest=<path>       Destination repo root (required, unless using --global)",
       "  --from=<path>       Source directory (default: dist)",
-      "  --targets=<list>    Comma-separated targets: codex, vscode, claude, claude-global, cursor, cursor-global, antigravity, antigravity-global (default: codex,vscode)",
+      "  --targets=<list>    Comma-separated targets: codex, vscode, claude, claude-global, cursor, cursor-global, warp, warp-global, antigravity, antigravity-global (default: codex,vscode)",
       "  --skills=<list>     Comma-separated skill names to install (default: all)",
       "  --mode=<mode>       'replace' (default) or 'merge'",
       "  --global            Shorthand for --targets=claude-global (installs to ~/.claude/skills)",
@@ -25,13 +25,15 @@ function usage() {
       "  claude-global       Install to ~/.claude/skills/ (user-level, ignores --dest)",
       "  cursor              Install to <dest>/.cursor/skills/",
       "  cursor-global       Install to ~/.cursor/skills/ (user-level, ignores --dest)",
+      "  warp                Install to <dest>/.agents/skills/ (project-level, recommended for Warp)",
+      "  warp-global         Install to ~/.agents/skills/ (user-level, ignores --dest)",
       "  antigravity         Install to <dest>/.agents/skills/",
       "  antigravity-global  Install to ~/.gemini/antigravity/skills/ (user-level, ignores --dest)",
       "",
       "Examples:",
       "  # Build and install to a WordPress project",
       "  node shared/scripts/skillpack-build.mjs --clean",
-      "  node shared/scripts/skillpack-install.mjs --dest=../my-wp-repo --targets=codex,vscode,claude,cursor",
+      "  node shared/scripts/skillpack-install.mjs --dest=../my-wp-repo --targets=codex,vscode,claude,cursor,warp",
       "",
       "  # Install globally for Claude Code (all skills)",
       "  node shared/scripts/skillpack-install.mjs --global",
@@ -39,11 +41,14 @@ function usage() {
       "  # Install globally for Cursor (all skills)",
       "  node shared/scripts/skillpack-install.mjs --targets=cursor-global",
       "",
+      "  # Install globally for Warp (all skills)",
+      "  node shared/scripts/skillpack-install.mjs --targets=warp-global",
+      "",
       "  # Install specific skills globally",
       "  node shared/scripts/skillpack-install.mjs --global --skills=wp-playground,wp-block-development",
       "",
       "  # Install to project with specific skills",
-      "  node shared/scripts/skillpack-install.mjs --dest=../my-repo --targets=claude,cursor --skills=wp-wpcli-and-ops",
+      "  node shared/scripts/skillpack-install.mjs --dest=../my-repo --targets=claude,cursor,warp --skills=wp-wpcli-and-ops",
       "",
     ].join("\n")
   );
@@ -135,17 +140,19 @@ function listSkillDirs(skillsRoot) {
     .filter((d) => fs.existsSync(path.join(d, "SKILL.md")));
 }
 
-const VALID_TARGETS = ["codex", "vscode", "claude", "claude-global", "cursor", "cursor-global", "antigravity", "antigravity-global"];
+const VALID_TARGETS = ["codex", "vscode", "claude", "claude-global", "cursor", "cursor-global", "warp", "warp-global", "antigravity", "antigravity-global"];
 
 // Map target to source subdirectory in dist
 function getSourceDir(fromDir, target) {
   // claude-global uses the same source as claude; cursor-global uses the same as cursor;
-  // antigravity-global uses the same source as antigravity
+  // warp-global uses the same source as warp; antigravity-global uses the same source as antigravity
   const sourceTarget =
     target === "claude-global"
       ? "claude"
       : target === "cursor-global"
       ? "cursor"
+      : target === "warp-global"
+      ? "warp"
       : target === "antigravity-global"
       ? "antigravity"
       : target;
@@ -154,6 +161,7 @@ function getSourceDir(fromDir, target) {
     vscode: path.join(fromDir, "vscode", ".github", "skills"),
     claude: path.join(fromDir, "claude", ".claude", "skills"),
     cursor: path.join(fromDir, "cursor", ".cursor", "skills"),
+    warp: path.join(fromDir, "warp", ".agents", "skills"),
     antigravity: path.join(fromDir, "antigravity", ".agents", "skills"),
   };
   return targetDirMap[sourceTarget];
@@ -168,6 +176,9 @@ function getDestDir(destRepoRoot, target) {
   if (target === "cursor-global") {
     return path.join(os.homedir(), ".cursor", "skills");
   }
+  if (target === "warp-global") {
+    return path.join(os.homedir(), ".agents", "skills");
+  }
   if (target === "antigravity-global") {
     return path.join(os.homedir(), ".gemini", "antigravity", "skills");
   }
@@ -178,6 +189,7 @@ function getDestDir(destRepoRoot, target) {
     vscode: path.join(destRepoRoot, ".github", "skills"),
     claude: path.join(destRepoRoot, ".claude", "skills"),
     cursor: path.join(destRepoRoot, ".cursor", "skills"),
+    warp: path.join(destRepoRoot, ".agents", "skills"),
     antigravity: path.join(destRepoRoot, ".agents", "skills"),
   };
   return destDirMap[target];
@@ -230,6 +242,7 @@ function installTarget({ fromDir, destRepoRoot, target, skillsFilter, mode, dryR
   const isGlobal =
     target === "claude-global" ||
     target === "cursor-global" ||
+    target === "warp-global" ||
     target === "antigravity-global";
   const location = isGlobal ? destSkillsRoot : path.relative(destRepoRoot, destSkillsRoot) || ".";
   process.stdout.write(`OK: installed ${skillDirs.length} skill(s) to ${location}\n`);
@@ -237,7 +250,7 @@ function installTarget({ fromDir, destRepoRoot, target, skillsFilter, mode, dryR
 
 function listAvailableSkills(fromDir) {
   // Check all possible target sources
-  const sources = ["codex", "vscode", "claude", "cursor", "antigravity"]
+  const sources = ["codex", "vscode", "claude", "cursor", "warp", "antigravity"]
     .map((t) => getSourceDir(fromDir, t))
     .filter((p) => fs.existsSync(p));
 
@@ -276,7 +289,7 @@ function main() {
   }
 
   // --dest is required unless only using global targets
-  const globalTargets = new Set(["claude-global", "cursor-global", "antigravity-global"]);
+  const globalTargets = new Set(["claude-global", "cursor-global", "warp-global", "antigravity-global"]);
   const needsDest = targets.some((t) => !globalTargets.has(t));
   if (needsDest && !args.dest) {
     process.stderr.write("Error: --dest is required for non-global targets.\n\n");


### PR DESCRIPTION
## Summary
- add `warp` build target with output at `dist/warp/.agents/skills/*`
- add `warp` and `warp-global` install targets:
  - project: `.agents/skills/`
  - global: `~/.agents/skills/`
- update README, packaging docs, CI smoke test, and eval scenario

## Validation
- `node shared/scripts/skillpack-build.mjs --clean --out=dist --targets=warp`
- `node shared/scripts/skillpack-install.mjs --from=dist --dest=/Users/jr/Dev/n.phototool.test --targets=warp --mode=merge --dry-run`
- `node shared/scripts/skillpack-install.mjs --from=dist --dest=/Users/jr/Dev/n.phototool.test --targets=warp --mode=merge`
- `node eval/harness/run.mjs`

Co-Authored-By: Oz <oz-agent@warp.dev>
