### PR TITLE
fix: gracefully skip AI skill updates when ANTHROPIC_API_KEY is missing

### DIFF
--- a/.github/workflows/ai-skill-maintenance.yml
+++ b/.github/workflows/ai-skill-maintenance.yml
@@ -86,6 +86,13 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AI_DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "⚠️ ANTHROPIC_API_KEY is not configured. Skipping AI skill updates."
+            echo "Configure it under Settings → Secrets and variables → Actions."
+            echo "has_updates=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           node shared/scripts/ai-generate-updates.mjs
 
           # Check if any skill files changed


### PR DESCRIPTION
## Summary

- Adds a guard in the `generate-updates` job to gracefully skip when `ANTHROPIC_API_KEY` is not configured, instead of crashing with exit code 1
- Logs a clear message telling the admin where to configure the secret
- Sets `has_updates=false` so the `create-index-pr` fallback job still triggers for index-only changes

## Problem

The `ai-skill-maintenance` workflow fails with `ERROR: ANTHROPIC_API_KEY environment variable is required` when the secret is not set. This blocks the entire workflow, including the `create-index-pr` fallback job that doesn't need the API key at all.

## Testing

- Verified the guard logic handles the empty/missing case correctly
- The `create-index-pr` job condition (`always() && needs.generate-updates.result == 'skipped' || ...`) continues to work since the job now succeeds with `has_updates=false`

## Review Checklist

- [ ] Confirm graceful degradation is the desired behavior
- [ ] Verify the `create-index-pr` fallback still triggers correctly