### PR TITLE
wp-abilities-api: add three strategy-layer references (domain-vs-projection, shared-core-service, grouping-heuristic)

### DIFF
--- a/skills/wp-abilities-api/SKILL.md
+++ b/skills/wp-abilities-api/SKILL.md
@@ -23,6 +23,8 @@ Use this skill when the task involves:
 
 ## Procedure
 
+Before deciding what to register, read `references/domain-vs-projection.md` — abilities live at the domain capability layer; MCP / Command Palette / REST exposure is a projection. Registration shape and exposure shape are different decisions, and conflating them forces re-registration every time a consumer's constraints change.
+
 ### 1) Confirm availability and version constraints
 
 - If this is WP core work, check `signals.isWpCoreCheckout` and `versions.wordpress.core`.
@@ -46,6 +48,10 @@ If none exist, decide whether you’re introducing Abilities API fresh (new regi
 If you need a logical grouping, register an ability category early (see `references/php-registration.md`).
 
 ### 4) Register abilities (PHP)
+
+For grouping decisions (how many abilities to register, and where to put filters vs. new ability names), read `references/grouping-heuristic.md` first — it keeps you from shipping one atomic ability per REST operation.
+
+To avoid drift between the ability and the existing UI / REST code path, see `references/shared-core-service.md` — abilities, REST handlers, CLI commands, and UI controllers should be thin adapters over a shared service. The reference also covers the metric trap (REST handlers that emit usage telemetry) and the `AGENTS.md` rule for keeping registrations in sync when underlying code paths change.
 
 Implement the ability in PHP registration with:
 

--- a/skills/wp-abilities-api/references/domain-vs-projection.md
+++ b/skills/wp-abilities-api/references/domain-vs-projection.md
@@ -1,0 +1,111 @@
+# Domain capability vs projection — picking the layer to register at
+
+> Three layers in this model: **domain**, **projection**, and an optional **workflow** layer that composes abilities into multi-step tasks. The title names the two primary decisions; workflow is introduced where it earns its keep.
+
+The Abilities API can be used at two heights. You can register abilities as the surface an MCP/REST/Command-Palette client will consume directly. Or you can register abilities at the domain layer — "what can this plugin do, transport-neutrally?" — and let each consumer see a projection of that surface that suits its constraints. This reference covers why the second framing pays off, the three-layer model that operationalizes it, and how to use it when deciding what to register.
+
+## Why this matters
+
+Treating MCP exposure as the registration target conflates two decisions:
+
+1. What capabilities does this plugin offer?
+2. How should each consumer see them?
+
+The first decision is stable. The second is volatile — token budgets shift, MCP clients improve, Command Palette gains new conventions, large plugins outgrow flat tool lists and adopt nested-discovery patterns. Coupling the two means re-registering abilities every time the projection question is reopened.
+
+Decoupling them means registrations stay where they are while projections evolve underneath.
+
+## The three layers
+
+| Layer | Purpose | Examples |
+|---|---|---|
+| **Domain capability** | Stable, transport-neutral, permission-checked. The plugin's contract for "what can this do." | `myplugin/list-things`, `myplugin/update-thing`, `myplugin/get-overview` |
+| **Workflow** *(optional)* | Compositions of one or more abilities into a human- or agent-friendly task. | "Onboard a new merchant" = `verify-account` → `enable-feature` → `send-welcome` |
+| **Projection** | Consumer-specific view of the domain layer. Token-efficient compression for MCP, curated workflows for Command Palette, discoverable execution surface for REST, forms for admin UI, chainable commands for CLI. | An MCP projection might expose three meta-tools (`tools-list` / `tools-describe` / `tools-invoke`) over the same set of domain abilities that Command Palette shows flat. |
+
+The domain layer is what the registry holds. The projection layer is what each consumer sees. The workflow layer is optional and exists when a user-or-agent-meaningful task needs more than one ability.
+
+## The use-case-contract test
+
+A registered ability is a use-case contract — a natural-language shortcut to an action a human can already perform in the UI. REST endpoints and CLI commands are transport contracts; they expose plumbing. Abilities expose actions.
+
+Two consequences fall out of that framing:
+
+### 1. Inclusion test — "would a human ever do this in admin?"
+
+If yes, the operation is a candidate for an ability. If no, it stays an endpoint or a CLI command. Internal-only plumbing (cache invalidation, scheduler ticks, debug hooks) does not belong as an ability — even if it has a clean schema.
+
+The test is asymmetric: not everything an admin can do should be an ability either (rule 1 in `grouping-heuristic.md` covers grouping). But anything that isn't admin-meaningful almost certainly isn't ability-meaningful.
+
+### 2. Same code path as the UI
+
+If the ability mirrors a UI action, it must share the UI's permissions, validation, and business rules. The mechanism for keeping that promise is in `shared-core-service.md`. The framing is here: the ability is the use-case; UI / REST / CLI / MCP are thin adapters over it.
+
+## Implications
+
+### You may register abilities you do NOT expose via MCP
+
+The Abilities API is a WordPress core primitive. It establishes a formal contract for "run this code with these inputs under this permission check." MCP, REST, and Command Palette are exposure layers on top. You opt in.
+
+This means a plugin can register abilities that the Command Palette uses but MCP does not see, or vice versa. The registration is transport-neutral; exposure is per-consumer.
+
+### The same domain ability can appear in multiple projections with different shapes
+
+A small plugin might expose its three abilities flat in MCP and flat in Command Palette. A larger plugin might keep the same three domain abilities but project them through a nested-discovery facade for MCP (three meta-tools that traverse to the underlying registrations) while showing them flat in the Command Palette where token budget is not a constraint.
+
+The domain layer does not change. The projection layer does the consumer-specific work.
+
+### Token-efficiency tradeoffs live at the projection layer
+
+The choice between flat-with-full-schemas, semantic-grouping, single-tool-facade, and nested-discovery is a *projection* decision. Different shapes serve different consumer constraints. None of those shapes require changing what abilities are registered at the domain layer; they change how a consumer sees the registered set.
+
+This is what "pattern-agnostic" means in practice: the registration is one decision, the projection is another, and a redesign of the second does not invalidate the first.
+
+## Decision order
+
+When designing a plugin's ability surface, work in this order:
+
+1. **Domain first.** What can this plugin do, transport-neutrally? Use the inclusion test. Apply `grouping-heuristic.md` to pick the right granularity (semantic-intent over REST-atomization).
+2. **Projection second.** Which surfaces does each capability appear on, and in what shape? For most plugins under ~10 abilities, flat-in-every-projection works. For larger plugins, consider nested-discovery for MCP while keeping flat for Command Palette and REST.
+3. **Workflow third (only if needed).** Are there multi-ability tasks worth composing into a single user-or-agent-facing entry point? If yes, the workflow lives above the domain layer and references multiple abilities.
+
+Most plugins never need step 3.
+
+## Worked example — generic Notifications plugin
+
+A "Notifications" plugin manages a per-user notification feed. It supports listing, marking read, and dismissing all.
+
+### Domain layer
+
+Three abilities, registered once:
+
+- `notifications/list` — read; filter by `unread_only`, `since`, `category`.
+- `notifications/mark-read` — write; takes a `notification_id`.
+- `notifications/dismiss-all` — write; zero-arg.
+
+These are use-case contracts. They are transport-neutral. They do not assume MCP or Command Palette or REST.
+
+### Projection — MCP
+
+Small surface, flat works. The MCP projection exposes the three abilities as-is. No nested-discovery needed.
+
+### Projection — Command Palette
+
+The Command Palette projection adds a small workflow that wraps `notifications/list` with default filters (`unread_only=true`) and opens the admin notifications page on selection. The other two abilities remain visible as flat commands. The domain registration did not change; the Command Palette layer added the workflow on top.
+
+### Projection — REST
+
+The REST projection exposes only the read ability. Writes go through admin UI for security-review reasons. The domain registration is unchanged; the REST layer just doesn't expose two of the three.
+
+Same three registrations, three different projections, no re-registration as projection decisions evolve.
+
+## Escape hatch — tiny plugins
+
+For plugins with one to three admin-only abilities and no other surfaces, the projection layer is trivially the identity function. You don't need to *implement* layers; you need to *think* in layers so you don't paint yourself into a corner when the plugin grows or when MCP token budgets become a constraint.
+
+Concretely: name the abilities at the domain level (`myplugin/get-thing`, not `myplugin-mcp/get-thing`), keep the registration permission-checked and transport-neutral, and skip the projection layer until something needs it.
+
+## Related references
+
+- `grouping-heuristic.md` — within-domain decisions: how many abilities, where to put filters.
+- `shared-core-service.md` — the implementation mechanism for "same code path as the UI."

--- a/skills/wp-abilities-api/references/domain-vs-projection.md
+++ b/skills/wp-abilities-api/references/domain-vs-projection.md
@@ -31,11 +31,13 @@ A registered ability is a use-case contract — a natural-language shortcut to a
 
 Two consequences fall out of that framing:
 
-### 1. Inclusion test — "would a human ever do this in admin?"
+### 1. Inclusion test — "would a human intentionally do this through a supported UI or workflow?"
 
-If yes, the operation is a candidate for an ability. If no, it stays an endpoint or a CLI command. Internal-only plumbing (cache invalidation, scheduler ticks, debug hooks) does not belong as an ability — even if it has a clean schema.
+If yes, the operation is a candidate for an ability. The lens is broader than wp-admin alone: a "supported UI or workflow" covers admin screens, public-facing UIs (storefront, account dashboard, course viewer, appointment booker), end-user self-service flows on the site front-end, and supported workflows in which another plugin or an agent calls the operation as part of a chain of actions. Abilities like `store/get-my-orders`, `events/list-available-tickets`, or `profile/update-public-profile` qualify just as much as admin-side abilities like `myplugin/list-pending-orders` or `myplugin/approve-submission`.
 
-The test is asymmetric: not everything an admin can do should be an ability either (rule 1 in `grouping-heuristic.md` covers grouping). But anything that isn't admin-meaningful almost certainly isn't ability-meaningful.
+If no, the operation stays a REST endpoint, a CLI command, or an internal hook. Internal-only plumbing — cache invalidation, scheduler ticks, debug snapshots, lifecycle bookkeeping — does not belong as an ability even when it has a clean schema. There is no meaningful human invocation point, so there is no use-case contract to register.
+
+The test is asymmetric: not everything a UI exposes should be an ability either (rule 1 in `grouping-heuristic.md` covers grouping). But anything that has no human-meaningful invocation surface almost certainly is not ability-meaningful.
 
 ### 2. Same code path as the UI
 

--- a/skills/wp-abilities-api/references/domain-vs-projection.md
+++ b/skills/wp-abilities-api/references/domain-vs-projection.md
@@ -21,7 +21,7 @@ Decoupling them means registrations stay where they are while projections evolve
 |---|---|---|
 | **Domain capability** | Stable, transport-neutral, permission-checked. The plugin's contract for "what can this do." | `myplugin/list-things`, `myplugin/update-thing`, `myplugin/get-overview` |
 | **Workflow** *(optional)* | Compositions of one or more abilities into a human- or agent-friendly task. | "Onboard a new merchant" = `verify-account` → `enable-feature` → `send-welcome` |
-| **Projection** | Consumer-specific view of the domain layer. Token-efficient compression for MCP, curated workflows for Command Palette, discoverable execution surface for REST, forms for admin UI, chainable commands for CLI. | An MCP projection might expose three meta-tools (`tools-list` / `tools-describe` / `tools-invoke`) over the same set of domain abilities that Command Palette shows flat. |
+| **Projection** | Consumer-specific view of the domain layer. Token-efficient compression for MCP, curated workflows for Command Palette, discoverable execution surface for REST, forms for admin UI, chainable commands for CLI. | The bundled WordPress MCP adapter projects every published ability through three meta-abilities (`mcp-adapter/discover-abilities`, `mcp-adapter/execute-ability`, `mcp-adapter/get-ability-info`) — agents traverse those three rather than seeing the full registry flat. Command Palette, by contrast, can show the same domain abilities flat because token budget is not a constraint. |
 
 The domain layer is what the registry holds. The projection layer is what each consumer sees. The workflow layer is optional and exists when a user-or-agent-meaningful task needs more than one ability.
 

--- a/skills/wp-abilities-api/references/grouping-heuristic.md
+++ b/skills/wp-abilities-api/references/grouping-heuristic.md
@@ -10,7 +10,7 @@ How to decide WHAT to register when a plugin already has a REST (or internal ser
 |---|---|---|---|
 | **Action-bundle** | One ability bundles many sub-operations behind an action string. | `my_plugin_account` with `action: "get" \| "update" \| "delete"`. | **Avoid.** Hides the ability surface from the agent's tool-list and defeats the Abilities API's introspection model — agents can't see what a bundle can do until they invoke it. |
 | **REST-atomization** | One ability per HTTP method per resource (typically 5 per resource: list, get, create, update, delete). | `orders-list`, `orders-get`, `orders-create`, `orders-update`, `orders-delete`. | **Avoid as the registration shape.** Couples ability names to HTTP plumbing rather than user intent — and forces re-registration if the projection layer ever needs to compress the surface. |
-| **Semantic-intent** | One ability per real-world question or state transition. Filter parameters in `input_schema` collapse N variants into 1. | Jetpack Forms `jetpack-forms/get-responses` with `status`, `is_unread`, `search`, date-range — 1 ability replaces what would be 8+ atomized variants. | **Recommended for the domain layer.** |
+| **Semantic-intent** | One ability per real-world question or state transition. Filter parameters in `input_schema` collapse N variants into 1. | One `feedback/get-responses` ability with `status`, `is_unread`, `search`, and date-range filters in `input_schema` — replaces what would be 8+ atomized variants. | **Recommended for the domain layer.** |
 
 ## Why semantic-intent wins at the domain layer
 
@@ -47,19 +47,17 @@ When enumerating the backing surface, specifically look for zero-argument aggreg
 
 Every ability's `label` + `description` should fit in an agent's tool-selection prompt. If you can't describe the ability in one sentence without "and", that's usually a sign it's two abilities.
 
-## Worked example A — Jetpack Forms: 3 abilities for the whole responses surface
+## Worked example A — feedback/responses: 3 abilities for the whole responses surface
 
-Jetpack Forms' responses surface in the WP admin exposes: a list with 8+ filters, a detail view, bulk status changes (spam/trash/publish), read/unread toggles, and a count-by-status dashboard summary.
+Consider a generic feedback or form-response plugin. Its admin screens expose: a list with 8+ filters, a detail view, bulk status changes (spam / trash / publish), read/unread toggles, and a count-by-status dashboard summary.
 
-REST-atomization would ship ~6 abilities (list, get, delete, update, bulk-update, count). Jetpack Forms instead registers **three**:
+REST-atomization would ship ~6 abilities (list, get, delete, update, bulk-update, count). Semantic-intent registers **three**:
 
-- `jetpack-forms/get-responses` — list/search, with `status`, `is_unread`, `search`, `before`, `after`, `parent` in `input_schema`.
-- `jetpack-forms/update-response` — one write that covers status changes AND read-state toggles on a single response (semantically "modify a response").
-- `jetpack-forms/get-status-counts` — the dashboard summary ability. Zero-arg-friendly (only optional filters).
+- `feedback/get-responses` — list/search, with `status`, `is_unread`, `search`, `before`, `after`, `parent` in `input_schema`.
+- `feedback/update-response` — one write that covers status changes AND read-state toggles on a single response (semantically "modify a response").
+- `feedback/get-status-counts` — the dashboard summary ability. Zero-arg-friendly (only optional filters).
 
 Why three works: a user asking "show me spam responses from last week" uses one ability. An agent updating one response to `spam` uses one ability. The dashboard-style "how many unread?" uses one ability. The entire product surface fits in three tool-list entries.
-
-Canonical file: [`Automattic/jetpack/projects/packages/forms/src/abilities/class-forms-abilities.php`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/abilities/class-forms-abilities.php).
 
 ## Worked example B — generic Tickets plugin: one ability with a status filter, not eight
 

--- a/skills/wp-abilities-api/references/grouping-heuristic.md
+++ b/skills/wp-abilities-api/references/grouping-heuristic.md
@@ -1,0 +1,91 @@
+# Grouping heuristic — domain-layer granularity
+
+How to decide WHAT to register when a plugin already has a REST (or internal service) surface. The hard part of adopting the Abilities API is not the registration syntax — it's picking the right *domain-layer granularity* so abilities map to user-meaningful actions instead of HTTP plumbing.
+
+> **Scope note.** This reference governs *domain-layer* decisions: how many abilities to register, where to put filters vs. where to introduce a new ability name. It does NOT govern projection-layer choices (flat-with-full-schemas vs single-tool facade vs nested-discovery vs semantic grouping in the consumer view). Those are separate decisions made *after* the domain layer is settled — see `domain-vs-projection.md` for the layering. A domain layer chosen well is reusable across multiple projections; conflating the two means re-registering every time a consumer's constraints change.
+
+## Three observed approaches
+
+| Approach | Shape | Example | Verdict (domain-layer) |
+|---|---|---|---|
+| **Action-bundle** | One ability bundles many sub-operations behind an action string. | `my_plugin_account` with `action: "get" \| "update" \| "delete"`. | **Avoid.** Hides the ability surface from the agent's tool-list and defeats the Abilities API's introspection model — agents can't see what a bundle can do until they invoke it. |
+| **REST-atomization** | One ability per HTTP method per resource (typically 5 per resource: list, get, create, update, delete). | `orders-list`, `orders-get`, `orders-create`, `orders-update`, `orders-delete`. | **Avoid as the registration shape.** Couples ability names to HTTP plumbing rather than user intent — and forces re-registration if the projection layer ever needs to compress the surface. |
+| **Semantic-intent** | One ability per real-world question or state transition. Filter parameters in `input_schema` collapse N variants into 1. | Jetpack Forms `jetpack-forms/get-responses` with `status`, `is_unread`, `search`, date-range — 1 ability replaces what would be 8+ atomized variants. | **Recommended for the domain layer.** |
+
+## Why semantic-intent wins at the domain layer
+
+1. **Users think in questions, not HTTP verbs.** "Which form responses are unread?" maps cleanly to one ability with an `is_unread` filter. It does NOT map to 8 abilities (`get-unread-responses`, `get-spam-responses`, `get-trashed-responses`, ...). Ability names are *use-case contracts* — see `./domain-vs-projection.md`.
+2. **The Abilities API's `input_schema` is designed for rich inputs.** Enum constraints, date-time formats, and required-field validation do the variant-splitting job that atomization would delegate to the ability name.
+3. **Writes stay narrow anyway.** A write ability should already be one state transition; atomization and semantic-intent converge for writes.
+4. **Tool-list token cost is a downstream consequence, not the reason.** Semantic-intent registrations also serialize cheaper in flat MCP projections — but token cost is a *projection-layer* concern. If registrations are cheap by accident because the use-case framing happened to compress them, that's a happy side-effect; if they're expensive, the fix is at the projection layer (single-tool facade, nested-discovery), not by re-grouping the domain.
+
+## Rules that make it work
+
+### 1. Group reads by the question a user would type
+
+Draft the question in plain English. That question is the ability. The filter parameters go in `input_schema`.
+
+- WRONG: one ability per status value.
+- RIGHT: one `get-<resource>` ability with `status: { type: "string", enum: [...] }`.
+
+### 2. Keep writes narrow — one state transition per ability
+
+A write ability should do exactly one thing the agent can reason about in isolation and explain to a user. Different state transitions → different abilities (different consequences, different annotations, different permission implications).
+
+- WRONG: `update-resource` that branches internally on an action enum.
+- RIGHT: `submit-evidence` and `close-resource` as separate abilities.
+
+### 3. Prefer 1 ability with filter params over N abilities with no params
+
+Ask: "if the backing added a new filter value, would that create a new ability?" If not, the filter belongs in `input_schema`, not in the ability name.
+
+### 4. Zero-arg overview abilities are high-leverage
+
+When enumerating the backing surface, specifically look for zero-argument aggregate or "overview" endpoints — "what's my balance?", "what's my next payout?", "what's my form response count?". These answer the highest-frequency user questions with zero input and zero room for agent error. Flag them even if they weren't in the original plan.
+
+### 5. Don't ship abilities you can't explain in one sentence
+
+Every ability's `label` + `description` should fit in an agent's tool-selection prompt. If you can't describe the ability in one sentence without "and", that's usually a sign it's two abilities.
+
+## Worked example A — Jetpack Forms: 3 abilities for the whole responses surface
+
+Jetpack Forms' responses surface in the WP admin exposes: a list with 8+ filters, a detail view, bulk status changes (spam/trash/publish), read/unread toggles, and a count-by-status dashboard summary.
+
+REST-atomization would ship ~6 abilities (list, get, delete, update, bulk-update, count). Jetpack Forms instead registers **three**:
+
+- `jetpack-forms/get-responses` — list/search, with `status`, `is_unread`, `search`, `before`, `after`, `parent` in `input_schema`.
+- `jetpack-forms/update-response` — one write that covers status changes AND read-state toggles on a single response (semantically "modify a response").
+- `jetpack-forms/get-status-counts` — the dashboard summary ability. Zero-arg-friendly (only optional filters).
+
+Why three works: a user asking "show me spam responses from last week" uses one ability. An agent updating one response to `spam` uses one ability. The dashboard-style "how many unread?" uses one ability. The entire product surface fits in three tool-list entries.
+
+Canonical file: [`Automattic/jetpack/projects/packages/forms/src/abilities/class-forms-abilities.php`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/abilities/class-forms-abilities.php).
+
+## Worked example B — generic Tickets plugin: one ability with a status filter, not eight
+
+A hypothetical `myplugin-tickets` plugin manages a support-ticket queue. Its REST endpoint `GET /myplugin/v1/tickets` accepts `status`, `priority`, `assigned_to`, `tag`, `date_before`, `date_after`, `search`. Status values include `new`, `triaged`, `in_progress`, `waiting_customer`, `waiting_internal`, `resolved`, `closed`, `reopened` — eight in total.
+
+- Atomization would ship ~8 abilities (`get-tickets-new`, `get-tickets-resolved`, `get-tickets-closed`, ...).
+- Semantic-intent ships **one** — `myplugin-tickets/get-tickets` with `status: { type: "string", enum: ["new", "triaged", "in_progress", "waiting_customer", "waiting_internal", "resolved", "closed", "reopened"] }`.
+
+The user question "which tickets are waiting on the customer?" becomes one ability invocation with `status: "waiting_customer"`. The agent doesn't scan a list of 8 near-identical tool names; it scans one, and the enum documents what values are valid.
+
+The same plugin also registers a zero-arg `myplugin-tickets/get-queue-summary` ability (open count + average response time + oldest unresolved) because "how is the queue today?" is the highest-frequency support-team question and the backing endpoint takes no arguments. That one ability has outsized value for one line of registration code — rule 4 in action.
+
+## Escape hatch — when per-operation granularity is right (for reads)
+
+Two cases where one-ability-per-operation IS appropriate on the read
+side, despite the recommendation against REST-atomization for reads:
+
+1. **Genuinely different permission models.** If `list-<resource>` and `search-<resource>` require different capabilities or different confirmation flows, splitting is honest.
+2. **Different destructive / idempotent annotations.** An ability that both reads and writes cannot honestly declare `readonly: true`; split the read-only part into its own ability.
+
+For writes, this escape hatch isn't needed: rule 2 ("one state
+transition per ability") already establishes per-operation granularity
+as the default. Splitting `submit-evidence` and `close-resource` into
+separate abilities isn't an exception — it's rule 2 in action.
+
+## Related references
+
+- `domain-vs-projection.md` — granularity governs *domain-layer* decisions; that reference covers the projection layer where token-efficiency tradeoffs and consumer-shape choices live.
+- `shared-core-service.md` — implementation mechanism for keeping abilities, REST handlers, CLI commands, and UI in lockstep on the domain layer.

--- a/skills/wp-abilities-api/references/php-registration.md
+++ b/skills/wp-abilities-api/references/php-registration.md
@@ -32,6 +32,9 @@ add_action( 'wp_abilities_api_init', function() {
         'permission_callback' => 'my_plugin_get_info_permissions',
         'meta'                => [
             'show_in_rest' => true,
+            'mcp'          => [
+                'public' => true, // Expose via the bundled WordPress MCP adapter.
+            ],
             'annotations'  => [
                 'readonly'    => true,
                 'destructive' => false,
@@ -58,12 +61,23 @@ add_action( 'wp_abilities_api_init', function() {
 | `permission_callback` | **Required** | Function that checks whether the current user may execute. Receives the same mixed input as `execute_callback`; returns `bool` or `WP_Error`. WP core throws `InvalidArgumentException` if this is missing — there is no implicit default. |
 | `input_schema` | Optional | JSON Schema for expected input (enables validation). Required when the ability accepts input. |
 | `output_schema` | Optional | JSON Schema for returned output (enables validation of the result). |
-| `meta.show_in_rest` | Optional (default `false`) | Set `true` to expose via the `wp-abilities/v1` REST API. |
+| `meta.show_in_rest` | Optional (default `false`) | Set `true` to expose via the `wp-abilities/v1` REST API namespace. |
+| `meta.mcp.public` | Optional (default `false`) | Set `true` to expose the ability as a tool via the bundled WordPress MCP adapter. Independent from `show_in_rest`. |
+| `meta.mcp.type` | Optional (default `'tool'`) | One of `'tool'`, `'resource'`, `'prompt'`. Controls how the bundled MCP adapter projects the ability. Values outside this enum silently coerce to `'tool'`. |
 | `meta.annotations.readonly` | Optional (default `null`) | `true` if the ability does not modify its environment. |
 | `meta.annotations.destructive` | Optional (default `null`) | `true` if the ability may perform destructive updates. `false` for additive-only updates. |
 | `meta.annotations.idempotent` | Optional (default `null`) | `true` if calling the ability repeatedly with the same arguments has no additional effect. |
 
 The three annotations under `meta.annotations` are *hints* for tooling and documentation — core does not enforce them at runtime. Plugins are expected to populate them honestly so MCP / Command Palette / agent surfaces can reason about ability behavior without invoking it.
+
+### `show_in_rest` vs `mcp.public` — they target different surfaces
+
+These two meta keys answer different questions and do not imply each other:
+
+- `show_in_rest` controls visibility on the WordPress core REST namespace `wp-abilities/v1` (the abilities REST API). Clients that talk to that namespace see the ability iff this is `true`.
+- `mcp.public` is read by the bundled WordPress MCP adapter package. The adapter's default MCP server only surfaces abilities whose `meta.mcp.public` is strictly `true`. Without it, the ability is registered but invisible to MCP clients connecting through that adapter.
+
+A plugin can set both, either, or neither. If you want the ability discoverable to agents through MCP, set `mcp.public => true`. If you also want it on the abilities REST namespace (for tooling that talks to `wp-abilities/v1` directly), set `show_in_rest => true`. The two surfaces are independent.
 
 ## Recommended patterns
 
@@ -77,3 +91,4 @@ The three annotations under `meta.annotations` are *hints* for tooling and docum
 
 - Abilities API handbook: https://developer.wordpress.org/apis/abilities-api/
 - Dev note: https://make.wordpress.org/core/2025/11/10/abilities-api-in-wordpress-6-9/
+- WordPress MCP adapter package — source of `meta.mcp.public` / `meta.mcp.type` contract. The adapter ships as a packaged dependency; verify the meta-key names against the package version your plugin pulls in.

--- a/skills/wp-abilities-api/references/php-registration.md
+++ b/skills/wp-abilities-api/references/php-registration.md
@@ -64,11 +64,11 @@ add_action( 'wp_abilities_api_init', function() {
 | `meta.show_in_rest` | Optional (default `false`) | Set `true` to expose via the `wp-abilities/v1` REST API namespace. |
 | `meta.mcp.public` | Optional (default `false`) | Set `true` to expose the ability as a tool via the bundled WordPress MCP adapter. Independent from `show_in_rest`. |
 | `meta.mcp.type` | Optional (default `'tool'`) | One of `'tool'`, `'resource'`, `'prompt'`. Controls how the bundled MCP adapter projects the ability. Values outside this enum silently coerce to `'tool'`. |
-| `meta.annotations.readonly` | Optional (default `null`) | `true` if the ability does not modify its environment. |
-| `meta.annotations.destructive` | Optional (default `null`) | `true` if the ability may perform destructive updates. `false` for additive-only updates. |
-| `meta.annotations.idempotent` | Optional (default `null`) | `true` if calling the ability repeatedly with the same arguments has no additional effect. |
+| `meta.annotations.readonly` | **Strongly recommended** (default `null`) | `true` if the ability does not modify its environment. |
+| `meta.annotations.destructive` | **Strongly recommended** (default `null`) | `true` if the ability may perform destructive updates. `false` for additive-only updates. |
+| `meta.annotations.idempotent` | **Strongly recommended** (default `null`) | `true` if calling the ability repeatedly with the same arguments has no additional effect. |
 
-The three annotations under `meta.annotations` are *hints* for tooling and documentation — core does not enforce them at runtime. Plugins are expected to populate them honestly so MCP / Command Palette / agent surfaces can reason about ability behavior without invoking it.
+The three annotations under `meta.annotations` are *hints* for tooling and documentation — core does not enforce them at runtime, so a missing or `null` value is silently legal. That permissiveness is exactly why every registration should populate them explicitly: MCP / Command Palette / agent surfaces and review tooling reason about ability safety from these values *without* invoking the callback. A `readonly: null` ability is treated as "behavior unknown," which is a worse signal than either `true` or `false`. Treat the absence of an annotation as a bug, not a default.
 
 ### `show_in_rest` vs `mcp.public` — they target different surfaces
 
@@ -85,7 +85,7 @@ A plugin can set both, either, or neither. If you want the ability discoverable 
 - Treat IDs as stable API; changing an ID is a breaking change for any consumer that holds a reference.
 - Use `input_schema` and `output_schema` for validation and to help AI agents understand usage.
 - **Always include a `permission_callback`.** It is required on every registration — there is no implicit default.
-- Populate all three `meta.annotations` keys (`readonly`, `destructive`, `idempotent`) on every registration so consumers can reason about ability behavior without invoking it.
+- **Always set all three `meta.annotations` keys (`readonly`, `destructive`, `idempotent`) explicitly.** Leaving them at the `null` default broadcasts "behavior unknown" to every consumer that reads this metadata before invoking the ability. The cost of writing them is three lines; the cost of omitting them is opaque safety surface.
 
 ## References
 

--- a/skills/wp-abilities-api/references/php-registration.md
+++ b/skills/wp-abilities-api/references/php-registration.md
@@ -25,11 +25,19 @@ add_action( 'wp_abilities_api_categories_init', function() {
 // 2. Then register abilities
 add_action( 'wp_abilities_api_init', function() {
     wp_register_ability( 'my-plugin/get-info', [
-        'label'       => __( 'Get Site Info', 'my-plugin' ),
-        'description' => __( 'Returns basic site information.', 'my-plugin' ),
-        'category'    => 'my-plugin',
-        'execute_callback' => 'my_plugin_get_info_callback',
-        'meta'        => [ 'show_in_rest' => true ],
+        'label'               => __( 'Get Site Info', 'my-plugin' ),
+        'description'         => __( 'Returns basic site information.', 'my-plugin' ),
+        'category'            => 'my-plugin',
+        'execute_callback'    => 'my_plugin_get_info_callback',
+        'permission_callback' => 'my_plugin_get_info_permissions',
+        'meta'                => [
+            'show_in_rest' => true,
+            'annotations'  => [
+                'readonly'    => true,
+                'destructive' => false,
+                'idempotent'  => true,
+            ],
+        ],
     ] );
 } );
 ```
@@ -41,24 +49,29 @@ add_action( 'wp_abilities_api_init', function() {
 
 ## Key arguments for `wp_register_ability()`
 
-| Argument | Description |
-|----------|-------------|
-| `label` | Human-readable name for UI (e.g., command palette) |
-| `description` | What the ability does |
-| `category` | Category ID (must be registered first) |
-| `execute_callback` | Function that executes the ability |
-| `input_schema` | JSON Schema for expected input (enables validation) |
-| `output_schema` | JSON Schema for returned output |
-| `permission_callback` | Optional function to check if current user can execute |
-| `meta.show_in_rest` | Set `true` to expose via REST API |
-| `meta.readonly` | Set `true` if ability is informational only |
+| Argument | Required? | Description |
+|----------|-----------|-------------|
+| `label` | **Required** | Human-readable name for UI (e.g., command palette). |
+| `description` | **Required** | What the ability does. |
+| `category` | **Required** | Category ID (must be registered first via `wp_abilities_api_categories_init`). |
+| `execute_callback` | **Required** | Function that runs when the ability is invoked. Receives mixed input (per `input_schema`), returns mixed result or `WP_Error`. |
+| `permission_callback` | **Required** | Function that checks whether the current user may execute. Receives the same mixed input as `execute_callback`; returns `bool` or `WP_Error`. WP core throws `InvalidArgumentException` if this is missing — there is no implicit default. |
+| `input_schema` | Optional | JSON Schema for expected input (enables validation). Required when the ability accepts input. |
+| `output_schema` | Optional | JSON Schema for returned output (enables validation of the result). |
+| `meta.show_in_rest` | Optional (default `false`) | Set `true` to expose via the `wp-abilities/v1` REST API. |
+| `meta.annotations.readonly` | Optional (default `null`) | `true` if the ability does not modify its environment. |
+| `meta.annotations.destructive` | Optional (default `null`) | `true` if the ability may perform destructive updates. `false` for additive-only updates. |
+| `meta.annotations.idempotent` | Optional (default `null`) | `true` if calling the ability repeatedly with the same arguments has no additional effect. |
+
+The three annotations under `meta.annotations` are *hints* for tooling and documentation — core does not enforce them at runtime. Plugins are expected to populate them honestly so MCP / Command Palette / agent surfaces can reason about ability behavior without invoking it.
 
 ## Recommended patterns
 
-- Namespace IDs (e.g. `my-plugin:feature.edit`).
-- Treat IDs as stable API; changing IDs is a breaking change.
+- Namespace ability IDs as `<plugin-slug>/<verb-noun>` (e.g., `my-plugin/get-info`, `my-plugin/update-thing`). Slash-separated.
+- Treat IDs as stable API; changing an ID is a breaking change for any consumer that holds a reference.
 - Use `input_schema` and `output_schema` for validation and to help AI agents understand usage.
-- Always include a `permission_callback` for abilities that modify data.
+- **Always include a `permission_callback`.** It is required on every registration — there is no implicit default.
+- Populate all three `meta.annotations` keys (`readonly`, `destructive`, `idempotent`) on every registration so consumers can reason about ability behavior without invoking it.
 
 ## References
 

--- a/skills/wp-abilities-api/references/shared-core-service.md
+++ b/skills/wp-abilities-api/references/shared-core-service.md
@@ -1,6 +1,6 @@
 # Shared core service — keeping abilities in lockstep with REST and UI
 
-When an ability mirrors something a human can already do in the admin, the ability MUST consume the same code path as the UI — same permissions, same validation, same business rules. Three call sites for the same operation (UI, REST, ability — possibly CLI too) drift apart over time unless they all delegate to a shared service. This reference covers when to delegate to an existing REST controller (the `delegate_to_rest_controller` route), when to extract a service class instead, and the metric trap that makes that distinction matter.
+When an ability mirrors something a human can already do through a supported UI or workflow, the ability MUST consume the same code path as that UI or workflow — same permissions, same validation, same business rules. Three call sites for the same operation (UI, REST, ability — possibly CLI too) drift apart over time unless they all delegate to a shared service. This reference covers when to delegate to an existing REST controller (the `delegate_to_rest_controller` route), when to extract a service class instead, and the metric trap that makes that distinction matter.
 
 Read `domain-vs-projection.md` first — abilities are use-case contracts at the domain layer; UI/REST/CLI/MCP are projections. This reference is the implementation mechanism that keeps those projections honest.
 

--- a/skills/wp-abilities-api/references/shared-core-service.md
+++ b/skills/wp-abilities-api/references/shared-core-service.md
@@ -1,0 +1,151 @@
+# Shared core service — keeping abilities in lockstep with REST and UI
+
+When an ability mirrors something a human can already do in the admin, the ability MUST consume the same code path as the UI — same permissions, same validation, same business rules. Three call sites for the same operation (UI, REST, ability — possibly CLI too) drift apart over time unless they all delegate to a shared service. This reference covers when to delegate to an existing REST controller (the `delegate_to_rest_controller` route), when to extract a service class instead, and the metric trap that makes that distinction matter.
+
+Read `domain-vs-projection.md` first — abilities are use-case contracts at the domain layer; UI/REST/CLI/MCP are projections. This reference is the implementation mechanism that keeps those projections honest.
+
+## Why this matters
+
+A registered ability that re-implements logic instead of calling into existing code paths is a drift hazard. The drift surfaces in predictable ways:
+
+- A new filter added to the UI listing doesn't propagate to the ability.
+- A permission tightened on the REST controller leaves the ability under-gated.
+- A validation rule added to the admin form is missing from the ability.
+- A status transition gains a side-effect (audit log, webhook) that fires on UI-driven writes but not ability-driven writes.
+
+None of these break the ability immediately. They become discoverable only when an agent invokes the ability and the result quietly diverges from what the same operation in the UI would produce. By that point the ability is in production and the divergence is hard to detect without a contract test you almost certainly do not have.
+
+The fix is to keep one source of business logic and treat ability/REST/UI/CLI as adapters over it.
+
+## Three shapes for the ability execute callback
+
+| Shape | Example | Verdict |
+|---|---|---|
+| **Re-implement** the logic in the execute callback. | The callback runs its own SQL, applies its own permission checks, builds its own response. | **Avoid.** Guaranteed drift the first time the original code path changes. |
+| **Delegate to the existing REST controller** via `WP_REST_Request`. | `delegate_to_rest_controller( '...REST_Things_Controller', 'get_things', '/myplugin/v1/things', $input )`. | **OK for low-stakes reads** — but read "the metric trap" below first. |
+| **Extract a service class** that ability + REST controller + UI handler all consume. | `My_Plugin::get_things_service()->list( $args )` called from the ability, the REST controller, and an admin-side handler. | **Recommended** for writes and for any read whose backing endpoint records usage metrics. |
+
+The middle row is fine when the backing endpoint is light, read-only, and metric-neutral. The third row is what removes drift entirely; it is also more invasive because it usually means refactoring the existing REST controller to call the service rather than embed the logic.
+
+## The metric trap
+
+Most production REST endpoints in real plugins emit usage telemetry — analytics events, structured log emitters, custom event hooks. These metrics drive product decisions (which endpoints are hot, which are abandoned, which are slow).
+
+Routing an ability through `delegate_to_rest_controller` re-uses the REST controller's full code path, including its telemetry emission. Every agent invocation now counts as a UI-driven REST call. The metric is no longer a measure of human-driven usage; it is contaminated by agent traffic, and the contamination has no provenance label distinguishing the two.
+
+The fix is the third row of the table above:
+
+- Extract the business logic into a service class.
+- Have the REST controller call the service AND emit telemetry as a thin adapter.
+- Have the ability call the service directly, NOT the REST controller. The ability either emits its own ability-tagged telemetry or emits none.
+
+This way the dashboards stay clean and the ability still consumes the same business logic as the UI.
+
+If the existing REST endpoint emits no metrics, `delegate_to_rest_controller` is a fine shortcut.
+
+## MCP exposure rule
+
+Do not expose REST AND ability for the same operation to the same MCP client. Pick one.
+
+The ability is the agent contract: schema-typed, permission-gated, semantic-intent-named. The REST endpoint stays in place for non-agent integrations (UI, third-party clients that already exist, internal services that consume the JSON contract). The MCP layer surfaces the ability and elides the REST endpoint.
+
+Exposing both produces a "which surface should I use?" question for any LLM that sees both — and the answer affects metrics, logging, and error handling. Pick the ability.
+
+## The `AGENTS.md` rule
+
+Add a line to the plugin's `AGENTS.md` (under whichever H2 covers "when changing code in this area"):
+
+> When you change the code path behind a registered ability, check whether the ability needs to update too. A new filter on the underlying listing usually means the ability should expose the same filter. A permission change means the ability's gate likely needs to follow. A new side-effect on a write may change what we promise the ability does.
+
+This shifts the burden from "remember to update the ability" to "be reminded by the LLM working on the change." It costs nothing at write time and prevents the most common source of drift.
+
+## Worked example — extracting a service
+
+Generic plugin with a `Things` resource. Before extraction, the REST controller embeds the listing logic and the ability re-runs the same filter/sort/paginate code:
+
+```php
+// includes/admin/class-rest-things-controller.php
+class My_Plugin_REST_Things_Controller {
+    public function get_things( WP_REST_Request $request ) {
+        $args = self::sanitize_query_args( $request->get_params() );
+        $rows = $this->repo->find( $args );
+
+        // Telemetry: emitted on every UI-driven call.
+        my_plugin_track_event( 'things_listed', [ 'count' => count( $rows ) ] );
+
+        return rest_ensure_response( array_map( [ $this, 'format' ], $rows ) );
+    }
+}
+
+// src/Internal/Abilities/Abilities_Registrar.php
+public static function execute_get_things( $input = null ) {
+    // PROBLEM: re-implements sanitization, repo call, formatting.
+    // Drifts the first time the controller's get_things() changes.
+    $args = MyPlugin\Sanitize::query_args( (array) $input );
+    $rows = ( new MyPlugin\Things_Repo() )->find( $args );
+    return array_map( [ MyPlugin\Things_Formatter::class, 'format' ], $rows );
+}
+```
+
+After extraction, both paths consume `Things_Service::list()`:
+
+```php
+// src/Service/class-things-service.php
+class Things_Service {
+    public function list_things( array $args ) {
+        $clean = Sanitize::query_args( $args );
+        $rows  = $this->repo->find( $clean );
+        return array_map( array( Things_Formatter::class, 'format' ), $rows );
+    }
+}
+
+// includes/admin/class-rest-things-controller.php
+class My_Plugin_REST_Things_Controller {
+    public function get_things( WP_REST_Request $request ) {
+        $rows = $this->service->list_things( $request->get_params() );
+
+        // Telemetry stays on the REST adapter — clean.
+        my_plugin_track_event( 'things_listed', array( 'count' => count( $rows ), 'source' => 'rest' ) );
+
+        return rest_ensure_response( $rows );
+    }
+}
+
+// src/Internal/Abilities/Abilities_Registrar.php
+public static function execute_get_things( $input = null ) {
+    if ( ! class_exists( '\MyPlugin\Things_Service' ) ) {
+        return new WP_Error( 'myplugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
+    }
+    return MyPlugin::get_things_service()->list_things( (array) $input );
+}
+```
+
+The ability and the REST endpoint now share business logic. Telemetry stays on the REST adapter and does not double-count agent traffic. The next person to add a filter parameter changes one place — the service — and both call sites pick it up.
+
+## Rule of thumb
+
+- **Read with no telemetry, light logic** → route the ability through the existing REST handler (the `delegate_to_rest_controller` pattern). Cheapest. Drift risk is bounded because the REST controller is one short hop away.
+- **Read with telemetry on the REST handler** → extract a service. Don't contaminate metrics.
+- **Write of any kind** → extract a service. Drift is most damaging on writes (lost validation, missing audit hooks).
+- **No existing REST endpoint** → start at the service. The first ability you ship is also the right time to add the structure that a future REST endpoint will consume.
+
+The telemetry and write rules **override** the lighter "if the backing
+takes a `WP_REST_Request`, just delegate" heuristic. The signature test
+is sufficient only when telemetry is absent and the operation is a
+read. If the REST handler emits telemetry or the operation writes,
+extract a service even when delegating would otherwise be the easy
+path.
+
+## Escape hatch — when re-implementation is OK
+
+Two narrow cases:
+
+1. **The ability is read-only and the backing has no extractable shape.** Sometimes the "logic" is one line — `get_option( 'something' )` — and a service class is overkill. Inline it.
+2. **The plugin is single-purpose and will not grow surfaces.** A 200-line plugin with one ability and no REST surface to drift against can keep logic in the execute callback. The drift risk only shows up at 2+ adapters.
+
+In both cases, leave a `// TODO: extract to service if a REST/UI surface gets added` comment so the next person sees the trigger condition.
+
+## Related references
+
+- `domain-vs-projection.md` — the layer model that puts shared services at the domain layer and projections (REST / MCP / CLI / UI) above.
+- `grouping-heuristic.md` — orthogonal: this reference covers "same code path"; that one covers "how many abilities."

--- a/skills/wp-abilities-api/references/shared-core-service.md
+++ b/skills/wp-abilities-api/references/shared-core-service.md
@@ -58,6 +58,7 @@ A delegating ability re-uses the REST controller's full code path, including any
 - **Custom-event hooks** (`do_action(...)`) — listeners on those hooks now fire on every ability invocation, with surprise side-effects in unrelated subsystems.
 - **Email / notification dispatch** — agent-driven calls trigger user-visible notifications that should not have been sent.
 - **Cache invalidation, schedule rescheduling, lock acquisition** — harmless when intended; harmful when fired by traffic the original handler did not anticipate.
+- **First-call REST bootstrap cost** (performance, not semantics). `rest_do_request()` calls `rest_get_server()`, which lazily instantiates `WP_REST_Server` and fires `rest_api_init` the first time it's invoked in a request lifecycle. In a normal HTTP REST request the cost is paid before the abilities layer even runs; in CLI / cron / agent / non-REST MCP transports, the *first* ability that delegates pays it — every plugin's `register_rest_route()` callback wires up at this point. The cost is one-time per request lifecycle (`rest_get_server()` guards on `if ( empty( $wp_rest_server ) )`), but on a cold path the first invocation is measurably slow. If the ability is expected to run predominantly outside REST contexts, prefer calling the underlying service or request class directly over going through `rest_do_request()`.
 
 The fix is the third row of the table above:
 
@@ -150,17 +151,20 @@ The ability and the REST endpoint now share business logic. Side effects (audit,
 
 ## Rule of thumb
 
-- **Read with no side effects on the REST path, light logic** → route the ability through the existing REST handler via the delegation pattern. Cheapest. Drift risk is bounded because the REST controller is one short hop away.
+- **Read with no side effects on the REST path, light logic, predominantly invoked through REST** → route the ability through the existing REST handler via the delegation pattern. Cheapest. Drift risk is bounded because the REST controller is one short hop away.
 - **Read where the REST handler does more than data-fetch** (audit, hooks, notifications, telemetry) → extract a service. Don't fire UI-scoped side effects on agent invocations.
+- **Read predominantly invoked outside REST** (CLI, cron, agent, non-REST MCP transport) → prefer direct invocation of the service or the underlying request class. Delegation pays the first-call REST bootstrap cost on every cold path.
 - **Write of any kind** → extract a service. Drift is most damaging on writes (lost validation, missing audit hooks).
 - **No existing REST endpoint** → start at the service. The first ability you ship is also the right time to add the structure that a future REST endpoint will consume.
 
-The side-effect and write rules **override** the lighter "if the
-backing takes a `WP_REST_Request`, just delegate" heuristic. The
-signature test is sufficient only when the REST handler is a pure
-data-fetch and the operation is a read. If the handler emits side
-effects or the operation writes, extract a service even when
-delegating would otherwise be the easy path.
+The side-effect, write, and non-REST-context rules **override** the
+lighter "if the backing takes a `WP_REST_Request`, just delegate"
+heuristic. The signature test is sufficient only when the REST handler
+is a pure data-fetch, the operation is a read, and the ability runs
+mostly inside REST contexts. If the handler emits side effects, the
+operation writes, or the ability runs predominantly through CLI / cron /
+agent paths, extract a service even when delegating would otherwise be
+the easy path.
 
 ## Escape hatch — when re-implementation is OK
 

--- a/skills/wp-abilities-api/references/shared-core-service.md
+++ b/skills/wp-abilities-api/references/shared-core-service.md
@@ -1,6 +1,6 @@
 # Shared core service — keeping abilities in lockstep with REST and UI
 
-When an ability mirrors something a human can already do through a supported UI or workflow, the ability MUST consume the same code path as that UI or workflow — same permissions, same validation, same business rules. Three call sites for the same operation (UI, REST, ability — possibly CLI too) drift apart over time unless they all delegate to a shared service. This reference covers when to delegate to an existing REST controller (the delegation pattern), when to extract a service class instead, and the metric trap that makes that distinction matter.
+When an ability mirrors something a human can already do through a supported UI or workflow, the ability MUST consume the same code path as that UI or workflow — same permissions, same validation, same business rules. Three call sites for the same operation (UI, REST, ability — possibly CLI too) drift apart over time unless they all delegate to a shared service. This reference covers when to delegate to an existing REST controller (the delegation pattern), when to extract a service class instead, and the side effects on the existing REST path that often force the second choice.
 
 Read `domain-vs-projection.md` first — abilities are use-case contracts at the domain layer; UI/REST/CLI/MCP are projections. This reference is the implementation mechanism that keeps those projections honest.
 
@@ -22,7 +22,7 @@ The fix is to keep one source of business logic and treat ability/REST/UI/CLI as
 | Shape | Example | Verdict |
 |---|---|---|
 | **Re-implement** the logic in the execute callback. | The callback runs its own SQL, applies its own permission checks, builds its own response. | **Avoid.** Guaranteed drift the first time the original code path changes. |
-| **Delegate to the existing REST controller** via `WP_REST_Request`. | The ability builds a `WP_REST_Request` from its input, dispatches via `rest_do_request()`, and returns the response data. The dispatched request flows through the registered controller's permission check, validation, and handler. | **OK for low-stakes reads** — but read "the metric trap" below first. |
+| **Delegate to the existing REST controller** via `WP_REST_Request`. | The ability builds a `WP_REST_Request` from its input, dispatches via `rest_do_request()`, and returns the response data. The dispatched request flows through the registered controller's permission check, validation, and handler. | **OK for low-stakes reads** — but read "Side effects on the existing REST path" below first. |
 | **Extract a service class** that ability + REST controller + UI handler all consume. | `My_Plugin::get_things_service()->list( $args )` called from the ability, the REST controller, and an admin-side handler. | **Recommended** for writes and for any read whose backing endpoint records usage metrics. |
 
 The middle row is fine when the backing endpoint is light, read-only, and metric-neutral. The third row is what removes drift entirely; it is also more invasive because it usually means refactoring the existing REST controller to call the service rather than embed the logic.
@@ -49,21 +49,25 @@ The five moves: construct the `WP_REST_Request` with the right HTTP method and r
 
 In a real codebase you would usually extract this into a small private helper so multiple ability callbacks can share the boilerplate. The shape of that helper is out of scope for this reference — the point here is that the delegation pattern is mechanically simple and does not depend on any particular framework helper to be in place.
 
-## The metric trap
+## Side effects on the existing REST path
 
-Most production REST endpoints in real plugins emit usage telemetry — analytics events, structured log emitters, custom event hooks. These metrics drive product decisions (which endpoints are hot, which are abandoned, which are slow).
+A delegating ability re-uses the REST controller's full code path, including any side effects the controller emits on every call:
 
-Routing an ability through the delegation pattern re-uses the REST controller's full code path, including its telemetry emission. Every agent invocation now counts as a UI-driven REST call. The metric is no longer a measure of human-driven usage; it is contaminated by agent traffic, and the contamination has no provenance label distinguishing the two.
+- **Usage telemetry / analytics events** — the ability inflates dashboards with agent traffic and the human-vs-agent provenance signal is lost. Metric double-counting is the silent failure mode — the system "works" while the dashboards drift.
+- **Audit logs** — entries get attributed to a "REST" actor that is actually an agent. Forensics gets noisier.
+- **Custom-event hooks** (`do_action(...)`) — listeners on those hooks now fire on every ability invocation, with surprise side-effects in unrelated subsystems.
+- **Email / notification dispatch** — agent-driven calls trigger user-visible notifications that should not have been sent.
+- **Cache invalidation, schedule rescheduling, lock acquisition** — harmless when intended; harmful when fired by traffic the original handler did not anticipate.
 
 The fix is the third row of the table above:
 
 - Extract the business logic into a service class.
-- Have the REST controller call the service AND emit telemetry as a thin adapter.
-- Have the ability call the service directly, NOT the REST controller. The ability either emits its own ability-tagged telemetry or emits none.
+- Have the REST controller call the service AND emit its side effects as a thin adapter.
+- Have the ability call the service directly, NOT the REST controller. The ability emits its own ability-tagged side effects, or none.
 
-This way the dashboards stay clean and the ability still consumes the same business logic as the UI.
+This way side effects stay scoped to the surface that triggers them, and the ability still consumes the same business logic as the UI.
 
-If the existing REST endpoint emits no metrics, the delegation pattern is a fine shortcut.
+If the existing REST endpoint is a pure data-fetch with no side effects, the delegation pattern is a fine shortcut.
 
 ## MCP exposure rule
 
@@ -92,8 +96,8 @@ class My_Plugin_REST_Things_Controller {
         $args = self::sanitize_query_args( $request->get_params() );
         $rows = $this->repo->find( $args );
 
-        // Telemetry: emitted on every UI-driven call.
-        my_plugin_track_event( 'things_listed', [ 'count' => count( $rows ) ] );
+        // Side effects (audit log, hooks, notifications) live on the REST adapter.
+        do_action( 'my_plugin/things_listed', $rows );
 
         return rest_ensure_response( array_map( [ $this, 'format' ], $rows ) );
     }
@@ -126,8 +130,8 @@ class My_Plugin_REST_Things_Controller {
     public function get_things( WP_REST_Request $request ) {
         $rows = $this->service->list_things( $request->get_params() );
 
-        // Telemetry stays on the REST adapter — clean.
-        my_plugin_track_event( 'things_listed', array( 'count' => count( $rows ), 'source' => 'rest' ) );
+        // Side effects (audit log, hooks, notifications) stay on the REST adapter — clean.
+        do_action( 'my_plugin/things_listed', $rows );
 
         return rest_ensure_response( $rows );
     }
@@ -142,21 +146,21 @@ public static function execute_get_things( $input = null ) {
 }
 ```
 
-The ability and the REST endpoint now share business logic. Telemetry stays on the REST adapter and does not double-count agent traffic. The next person to add a filter parameter changes one place — the service — and both call sites pick it up.
+The ability and the REST endpoint now share business logic. Side effects (audit, hooks, notifications, any telemetry) stay on the REST adapter and do not fire on agent-driven invocations. The next person to add a filter parameter changes one place — the service — and both call sites pick it up.
 
 ## Rule of thumb
 
-- **Read with no telemetry, light logic** → route the ability through the existing REST handler via the delegation pattern. Cheapest. Drift risk is bounded because the REST controller is one short hop away.
-- **Read with telemetry on the REST handler** → extract a service. Don't contaminate metrics.
+- **Read with no side effects on the REST path, light logic** → route the ability through the existing REST handler via the delegation pattern. Cheapest. Drift risk is bounded because the REST controller is one short hop away.
+- **Read where the REST handler does more than data-fetch** (audit, hooks, notifications, telemetry) → extract a service. Don't fire UI-scoped side effects on agent invocations.
 - **Write of any kind** → extract a service. Drift is most damaging on writes (lost validation, missing audit hooks).
 - **No existing REST endpoint** → start at the service. The first ability you ship is also the right time to add the structure that a future REST endpoint will consume.
 
-The telemetry and write rules **override** the lighter "if the backing
-takes a `WP_REST_Request`, just delegate" heuristic. The signature test
-is sufficient only when telemetry is absent and the operation is a
-read. If the REST handler emits telemetry or the operation writes,
-extract a service even when delegating would otherwise be the easy
-path.
+The side-effect and write rules **override** the lighter "if the
+backing takes a `WP_REST_Request`, just delegate" heuristic. The
+signature test is sufficient only when the REST handler is a pure
+data-fetch and the operation is a read. If the handler emits side
+effects or the operation writes, extract a service even when
+delegating would otherwise be the easy path.
 
 ## Escape hatch — when re-implementation is OK
 

--- a/skills/wp-abilities-api/references/shared-core-service.md
+++ b/skills/wp-abilities-api/references/shared-core-service.md
@@ -1,6 +1,6 @@
 # Shared core service — keeping abilities in lockstep with REST and UI
 
-When an ability mirrors something a human can already do through a supported UI or workflow, the ability MUST consume the same code path as that UI or workflow — same permissions, same validation, same business rules. Three call sites for the same operation (UI, REST, ability — possibly CLI too) drift apart over time unless they all delegate to a shared service. This reference covers when to delegate to an existing REST controller (the `delegate_to_rest_controller` route), when to extract a service class instead, and the metric trap that makes that distinction matter.
+When an ability mirrors something a human can already do through a supported UI or workflow, the ability MUST consume the same code path as that UI or workflow — same permissions, same validation, same business rules. Three call sites for the same operation (UI, REST, ability — possibly CLI too) drift apart over time unless they all delegate to a shared service. This reference covers when to delegate to an existing REST controller (the delegation pattern), when to extract a service class instead, and the metric trap that makes that distinction matter.
 
 Read `domain-vs-projection.md` first — abilities are use-case contracts at the domain layer; UI/REST/CLI/MCP are projections. This reference is the implementation mechanism that keeps those projections honest.
 
@@ -22,16 +22,38 @@ The fix is to keep one source of business logic and treat ability/REST/UI/CLI as
 | Shape | Example | Verdict |
 |---|---|---|
 | **Re-implement** the logic in the execute callback. | The callback runs its own SQL, applies its own permission checks, builds its own response. | **Avoid.** Guaranteed drift the first time the original code path changes. |
-| **Delegate to the existing REST controller** via `WP_REST_Request`. | `delegate_to_rest_controller( '...REST_Things_Controller', 'get_things', '/myplugin/v1/things', $input )`. | **OK for low-stakes reads** — but read "the metric trap" below first. |
+| **Delegate to the existing REST controller** via `WP_REST_Request`. | The ability builds a `WP_REST_Request` from its input, dispatches via `rest_do_request()`, and returns the response data. The dispatched request flows through the registered controller's permission check, validation, and handler. | **OK for low-stakes reads** — but read "the metric trap" below first. |
 | **Extract a service class** that ability + REST controller + UI handler all consume. | `My_Plugin::get_things_service()->list( $args )` called from the ability, the REST controller, and an admin-side handler. | **Recommended** for writes and for any read whose backing endpoint records usage metrics. |
 
 The middle row is fine when the backing endpoint is light, read-only, and metric-neutral. The third row is what removes drift entirely; it is also more invasive because it usually means refactoring the existing REST controller to call the service rather than embed the logic.
+
+## What the delegation pattern looks like
+
+The middle row of the table — "delegate to the existing REST controller" — is a pattern, not a single canonical helper. The minimal shape is small enough to inline in an ability's `execute_callback`:
+
+```php
+public static function execute_get_things( $input = null ) {
+    $request = new WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+    $request->set_query_params( (array) $input );
+
+    $response = rest_do_request( $request );
+    if ( $response->is_error() ) {
+        return $response->as_error();
+    }
+
+    return $response->get_data();
+}
+```
+
+The five moves: construct the `WP_REST_Request` with the right HTTP method and route; copy the ability's `$input` onto the request as query params (or body params for writes); dispatch via `rest_do_request()`, which routes through the registered controller including its `permission_callback` and any side effects; convert an error response back to a `WP_Error` so the ability's caller sees a normal error; otherwise return the data.
+
+In a real codebase you would usually extract this into a small private helper so multiple ability callbacks can share the boilerplate. The shape of that helper is out of scope for this reference — the point here is that the delegation pattern is mechanically simple and does not depend on any particular framework helper to be in place.
 
 ## The metric trap
 
 Most production REST endpoints in real plugins emit usage telemetry — analytics events, structured log emitters, custom event hooks. These metrics drive product decisions (which endpoints are hot, which are abandoned, which are slow).
 
-Routing an ability through `delegate_to_rest_controller` re-uses the REST controller's full code path, including its telemetry emission. Every agent invocation now counts as a UI-driven REST call. The metric is no longer a measure of human-driven usage; it is contaminated by agent traffic, and the contamination has no provenance label distinguishing the two.
+Routing an ability through the delegation pattern re-uses the REST controller's full code path, including its telemetry emission. Every agent invocation now counts as a UI-driven REST call. The metric is no longer a measure of human-driven usage; it is contaminated by agent traffic, and the contamination has no provenance label distinguishing the two.
 
 The fix is the third row of the table above:
 
@@ -41,7 +63,7 @@ The fix is the third row of the table above:
 
 This way the dashboards stay clean and the ability still consumes the same business logic as the UI.
 
-If the existing REST endpoint emits no metrics, `delegate_to_rest_controller` is a fine shortcut.
+If the existing REST endpoint emits no metrics, the delegation pattern is a fine shortcut.
 
 ## MCP exposure rule
 
@@ -124,7 +146,7 @@ The ability and the REST endpoint now share business logic. Telemetry stays on t
 
 ## Rule of thumb
 
-- **Read with no telemetry, light logic** → route the ability through the existing REST handler (the `delegate_to_rest_controller` pattern). Cheapest. Drift risk is bounded because the REST controller is one short hop away.
+- **Read with no telemetry, light logic** → route the ability through the existing REST handler via the delegation pattern. Cheapest. Drift risk is bounded because the REST controller is one short hop away.
 - **Read with telemetry on the REST handler** → extract a service. Don't contaminate metrics.
 - **Write of any kind** → extract a service. Drift is most damaging on writes (lost validation, missing audit hooks).
 - **No existing REST endpoint** → start at the service. The first ability you ship is also the right time to add the structure that a future REST endpoint will consume.

--- a/skills/wp-abilities-api/references/shared-core-service.md
+++ b/skills/wp-abilities-api/references/shared-core-service.md
@@ -1,6 +1,8 @@
 # Shared core service — keeping abilities in lockstep with REST and UI
 
-When an ability mirrors something a human can already do through a supported UI or workflow, the ability MUST consume the same code path as that UI or workflow — same permissions, same validation, same business rules. Three call sites for the same operation (UI, REST, ability — possibly CLI too) drift apart over time unless they all delegate to a shared service. This reference covers when to delegate to an existing REST controller (the delegation pattern), when to extract a service class instead, and the side effects on the existing REST path that often force the second choice.
+When an ability mirrors something a human can already do through a supported UI or workflow, the ability MUST consume the same code path as that UI or workflow — same permissions, same validation, same business rules. Three call sites for the same operation (UI, REST, ability — possibly CLI too) drift apart over time unless they all delegate to a shared service.
+
+The default shape this reference recommends is a shared service that the ability, the REST controller, and the UI all consume. Routing the ability through the existing REST controller (the "delegation pattern" below) is a conditional shortcut — fine when the controller is a pure data-fetch and the ability runs predominantly inside REST contexts, but the wrong default for any ability with real growth surface. This reference covers when the shortcut is safe, when it isn't, and the side effects on the existing REST path that most often disqualify it.
 
 Read `domain-vs-projection.md` first — abilities are use-case contracts at the domain layer; UI/REST/CLI/MCP are projections. This reference is the implementation mechanism that keeps those projections honest.
 
@@ -22,10 +24,10 @@ The fix is to keep one source of business logic and treat ability/REST/UI/CLI as
 | Shape | Example | Verdict |
 |---|---|---|
 | **Re-implement** the logic in the execute callback. | The callback runs its own SQL, applies its own permission checks, builds its own response. | **Avoid.** Guaranteed drift the first time the original code path changes. |
-| **Delegate to the existing REST controller** via `WP_REST_Request`. | The ability builds a `WP_REST_Request` from its input, dispatches via `rest_do_request()`, and returns the response data. The dispatched request flows through the registered controller's permission check, validation, and handler. | **OK for low-stakes reads** — but read "Side effects on the existing REST path" below first. |
-| **Extract a service class** that ability + REST controller + UI handler all consume. | `My_Plugin::get_things_service()->list( $args )` called from the ability, the REST controller, and an admin-side handler. | **Recommended** for writes and for any read whose backing endpoint records usage metrics. |
+| **Delegate to the existing REST controller** via `WP_REST_Request`. | The ability builds a `WP_REST_Request` from its input, dispatches via `rest_do_request()`, and returns the response data. The dispatched request flows through the registered controller's permission check, validation, and handler. | **Conditional shortcut.** Acceptable only when *all three* hold: the backing handler is a pure data-fetch (read-only, no side effects), the operation is itself a read, and the ability runs predominantly inside REST contexts. Read "Side effects on the existing REST path" below before assuming the conditions hold. |
+| **Extract a service class** that ability + REST controller + UI handler all consume. | `My_Plugin::get_things_service()->list( $args )` called from the ability, the REST controller, and an admin-side handler. | **Default.** Choose this unless every delegation condition above holds. It is the only shape that removes drift entirely and the only shape that scales when an endpoint later grows a side effect, a write counterpart, or a non-REST caller. |
 
-The middle row is fine when the backing endpoint is light, read-only, and metric-neutral. The third row is what removes drift entirely; it is also more invasive because it usually means refactoring the existing REST controller to call the service rather than embed the logic.
+The third row is the default because it is the only one that decouples the ability (a domain-layer capability) from the REST transport. The middle row is a real shortcut — there is no point extracting a service class for `get_option('something')` — but its applicability is bounded enough that it should be reached for deliberately, not by default. Extracting a service is more invasive at first (it usually means refactoring the existing REST controller to call the service rather than embed the logic), but it is also the move that holds up under change.
 
 ## What the delegation pattern looks like
 
@@ -151,20 +153,15 @@ The ability and the REST endpoint now share business logic. Side effects (audit,
 
 ## Rule of thumb
 
-- **Read with no side effects on the REST path, light logic, predominantly invoked through REST** → route the ability through the existing REST handler via the delegation pattern. Cheapest. Drift risk is bounded because the REST controller is one short hop away.
+Start from the assumption that the ability extracts (or consumes an already-extracted) service. Walk back to delegation only when every condition for it holds.
+
+- **Write of any kind** → extract a service. Drift is most damaging on writes (lost validation, missing audit hooks). Non-negotiable.
+- **No existing REST endpoint** → start at the service. The first ability you ship is also the right time to add the structure that a future REST endpoint will consume.
 - **Read where the REST handler does more than data-fetch** (audit, hooks, notifications, telemetry) → extract a service. Don't fire UI-scoped side effects on agent invocations.
 - **Read predominantly invoked outside REST** (CLI, cron, agent, non-REST MCP transport) → prefer direct invocation of the service or the underlying request class. Delegation pays the first-call REST bootstrap cost on every cold path.
-- **Write of any kind** → extract a service. Drift is most damaging on writes (lost validation, missing audit hooks).
-- **No existing REST endpoint** → start at the service. The first ability you ship is also the right time to add the structure that a future REST endpoint will consume.
+- **Read with no side effects on the REST path, light logic, predominantly invoked through REST** → the delegation pattern is acceptable as a shortcut. Drift risk is bounded because the REST controller is one short hop away — but only as long as those three conditions hold.
 
-The side-effect, write, and non-REST-context rules **override** the
-lighter "if the backing takes a `WP_REST_Request`, just delegate"
-heuristic. The signature test is sufficient only when the REST handler
-is a pure data-fetch, the operation is a read, and the ability runs
-mostly inside REST contexts. If the handler emits side effects, the
-operation writes, or the ability runs predominantly through CLI / cron /
-agent paths, extract a service even when delegating would otherwise be
-the easy path.
+The bias is intentional. Service-extraction is the only shape that holds up when the REST handler later grows a side effect, when a write counterpart shows up, or when a non-REST caller appears (a new CLI command, a cron job, an agent invocation off a non-REST MCP transport). Delegation re-couples the domain layer to the REST transport; that re-coupling is fine when the conditions hold *and* unlikely to change, but the cost of unwinding it later is higher than starting at the service.
 
 ## Escape hatch — when re-implementation is OK
 
@@ -174,6 +171,12 @@ Two narrow cases:
 2. **The plugin is single-purpose and will not grow surfaces.** A 200-line plugin with one ability and no REST surface to drift against can keep logic in the execute callback. The drift risk only shows up at 2+ adapters.
 
 In both cases, leave a `// TODO: extract to service if a REST/UI surface gets added` comment so the next person sees the trigger condition.
+
+## Plugin-family override
+
+This reference describes the generic baseline. Specific plugin families can — and routinely do — tighten the rules further. A payments-family plugin might forbid the delegation pattern outright on the grounds that no payments endpoint is safe to treat as side-effect-free. A subscription plugin might require service extraction even for one-line option reads if the option is read in more than one transport. A plugin that ships its own MCP transport might rule out delegation for any ability exposed through it.
+
+When the plugin you are working in is one of those, the local rules win. Check the plugin's `AGENTS.md`, contributor guide, or ability-registration playbook before reaching for the delegation shortcut taught here.
 
 ## Related references
 


### PR DESCRIPTION
Adds three reference docs to the `wp-abilities-api` skill plus a six-line cross-link block in `SKILL.md`, and refreshes the existing `php-registration.md` reference against `class-wp-ability.php` trunk.

## What lands

| File | Purpose |
|---|---|
| `references/domain-vs-projection.md` | Three-layer model (domain capability / workflow / projection) and the use-case-contract test ("would a human intentionally do this through a supported UI or workflow?"). The projection-layer example anchors on the bundled `WordPress/mcp-adapter`'s `discover-abilities` / `execute-ability` / `get-ability-info` meta-abilities. |
| `references/shared-core-service.md` | When to delegate to a REST controller vs. extract a shared service. **Default: shared service.** Delegation is a conditional shortcut for low-stakes reads — three conditions enumerated. Six side-effect categories (telemetry, audit logs, custom hooks, notifications, cache writes, first-call REST bootstrap cost) that disqualify the shortcut. Plugin-family override section noting payments / subscriptions / own-MCP-transport plugins routinely tighten further. |
| `references/grouping-heuristic.md` | Granularity rules (semantic-intent vs REST-atomization vs action-bundle) with two generic worked examples. |
| `references/php-registration.md` | Refreshed: `permission_callback` is required (throws on missing); `meta.annotations` keys (`readonly`, `destructive`, `idempotent`) framed as Strongly Recommended; `meta.mcp.public` / `meta.mcp.type` taught for visibility through the bundled MCP adapter. |
| `wp-abilities-api/SKILL.md` | Six lines: layer-model intro at `## Procedure` + step-4 cross-links. |

## Verification at tip

- WP core symbols (`WP_REST_Request`, `WP_Error`, `rest_ensure_response`, `__()`, `rest_do_request`, `set_query_params`, `is_error`, `as_error`) verified against `WordPress/wordpress-develop` trunk.
- mcp-adapter abilities verified at `WordPress/mcp-adapter/includes/Abilities/{Discover,Execute,GetAbilityInfo}Ability.php`.
- PHP code blocks parse on PHP 7.2.
- `node eval/harness/run.mjs` passes.

## Status

Round 4 (current tip, ~417 added lines). Iteration:

- **Round 1** — original scope.
- **Round 2** — @nerrad's six inline comments addressed (registration-guide refresh, broadened inclusion test beyond admin-only, removed Jetpack Forms reference, prose-only delegate-helper framing, telemetry demoted to one of five side-effects).
- **Round 3** — three substantive deltas from pilot-ability learnings (`meta.mcp.public` / `mcp.type`; annotations escalated to Strongly Recommended; first-call REST bootstrap cost added as the sixth side-effect category).
- **Round 4** — @nerrad's two 2026-05-21 review items: mcp-adapter projection example anchored (`25530c6`); REST delegation reframed as a conditional shortcut, shared service named as default (`479c48c`).
