### PR TITLE
wp-abilities-api: add four mechanics-layer references (plugin-family-patterns, delegate-helper-pattern, error-code-vocabulary, input-schema-gotchas)

### DIFF
--- a/skills/wp-abilities-api/SKILL.md
+++ b/skills/wp-abilities-api/SKILL.md
@@ -53,6 +53,10 @@ For grouping decisions (how many abilities to register, and where to put filters
 
 To avoid drift between the ability and the existing UI / REST code path, see `references/shared-core-service.md` — abilities, REST handlers, CLI commands, and UI controllers should be thin adapters over a shared service. The reference also covers the metric trap (REST handlers that emit usage telemetry) and the `AGENTS.md` rule for keeping registrations in sync when underlying code paths change.
 
+For shared helper patterns when multiple execute callbacks delegate to existing REST controllers, see `references/plugin-family-patterns.md` (pick the shared-API-client vs zero-arg-controllers shape) and `references/delegate-helper-pattern.md` (the canonical helper and when not to use it).
+
+For standardized `WP_Error` codes that let agents reason about retry vs. escalation, see `references/error-code-vocabulary.md`.
+
 Implement the ability in PHP registration with:
 
 - stable `id` (namespaced),
@@ -92,6 +96,8 @@ Use the documented init hooks for Abilities API registration so they load at the
   - wrong REST base/namespace,
   - JS dependency not bundled,
   - caching (object/page caches) masking changes.
+- Execute callback returns unexpected errors or silently ignores input:
+  - `input_schema` defaults aren't being applied, pagination key drift between the ability and the backing, or `empty()`-based ID validation — see `references/input-schema-gotchas.md`.
 
 ## Escalation
 

--- a/skills/wp-abilities-api/SKILL.md
+++ b/skills/wp-abilities-api/SKILL.md
@@ -53,7 +53,7 @@ For grouping decisions (how many abilities to register, and where to put filters
 
 To avoid drift between the ability and the existing UI / REST code path, see `references/shared-core-service.md` — abilities, REST handlers, CLI commands, and UI controllers should be thin adapters over a shared service. The reference also covers the metric trap (REST handlers that emit usage telemetry) and the `AGENTS.md` rule for keeping registrations in sync when underlying code paths change.
 
-For shared helper patterns when multiple execute callbacks delegate to existing REST controllers, see `references/plugin-family-patterns.md` (pick the shared-API-client vs zero-arg-controllers shape) and `references/delegate-helper-pattern.md` (the canonical helper and when not to use it).
+For shared helper patterns when multiple execute callbacks delegate to existing REST controllers, see `references/plugin-family-patterns.md` (identify the shared-API-client vs zero-arg-controllers shape) and `references/delegate-helper-pattern.md` (one helper shape that works, and when not to use it).
 
 For standardized `WP_Error` codes that let agents reason about retry vs. escalation, see `references/error-code-vocabulary.md`.
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -1,0 +1,215 @@
+# Delegate helper pattern
+
+When an ability's execute callback needs to hand work to an existing REST controller instead of duplicating business logic, extract a `delegate_to_rest_controller` helper. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
+
+Read `plugin-family-patterns.md` first — the helper's exact shape depends on whether your plugin follows the shared-API-client pattern or the zero-arg-controllers pattern.
+
+## Why this helper exists
+
+List-style read abilities typically repeat the same four steps in every execute callback:
+
+1. Validate the plugin is initialized (class exists + dependencies resolved).
+2. Build a `WP_REST_Request` and copy the ability's `$input` onto it as params.
+3. Instantiate the backing controller and invoke the named method.
+4. Unwrap the response (controllers return either a raw array or a `WP_REST_Response`).
+
+Four abilities × this repetition = the boilerplate dominates the callback body. Extracting a helper keeps each execute callback a 3–4 line function that reads like pseudocode.
+
+## When to extract
+
+After the **second** list-style ability lands. Before the third ability gets added, refactor the duplicated code out of the first two execute callbacks into a private static helper. Convert subsequent abilities to call the helper as you add them.
+
+If the plugin only ever ships one or two abilities, inline the code. The helper's payoff is at 3+ callers.
+
+## Canonical signature (Pattern A — shared-API-client)
+
+```php
+/**
+ * Delegate an ability's execute callback to a REST controller.
+ *
+ * Builds a WP_REST_Request from the ability's input, instantiates the
+ * backing controller with the plugin's shared API client, invokes the
+ * named method, and normalizes the return so callers always see
+ * array|\WP_Error. Controllers in this plugin return either a
+ * WP_REST_Response or a raw array; the helper unwraps both shapes.
+ *
+ * Not used by zero-arg abilities — those call their controller directly
+ * so we don't synthesize a WP_REST_Request just to discard it.
+ *
+ * @param string     $controller_class Fully-qualified controller class (no leading backslash).
+ * @param string     $method           Controller method to invoke on the built request.
+ * @param string     $route            REST route string used when constructing WP_REST_Request.
+ * @param array|null $input            Ability input; each key/value becomes a request param.
+ * @param string     $http_method      HTTP method for WP_REST_Request. Defaults to 'GET'; writes pass 'POST'.
+ * @return array|\WP_Error             Response payload as an array, or WP_Error on failure.
+ */
+private static function delegate_to_rest_controller(
+    string $controller_class,
+    string $method,
+    string $route,
+    ?array $input,
+    string $http_method = 'GET'
+) {
+    $fqcn = '\\' . $controller_class;
+
+    // Guard 1: controller class is loaded.
+    if ( ! class_exists( $fqcn ) ) {
+        return new \WP_Error(
+            '<plugin>_not_initialized',
+            __( '<Plugin> is not initialized.', '<text-domain>' )
+        );
+    }
+
+    // Guard 2: shared API client is available.
+    $api_client = null;
+    if ( class_exists( '\<Plugin_Main_Class>' ) && method_exists( '\<Plugin_Main_Class>', 'get_<client_accessor>' ) ) {
+        $api_client = \<Plugin_Main_Class>::get_<client_accessor>();
+    }
+    if ( null === $api_client ) {
+        return new \WP_Error(
+            '<plugin>_not_initialized',
+            __( '<Plugin> is not initialized.', '<text-domain>' )
+        );
+    }
+
+    // Build the request.
+    $request = new \WP_REST_Request( $http_method, $route );
+    if ( null !== $input ) {
+        foreach ( $input as $param => $value ) {
+            $request->set_param( $param, $value );
+        }
+    }
+
+    // Invoke + guard 3: WP_Error short-circuit + dual-shape unwrap.
+    $controller = new $fqcn( $api_client );
+    $response   = $controller->{$method}( $request );
+
+    if ( is_wp_error( $response ) ) {
+        return $response;
+    }
+    if ( $response instanceof \WP_REST_Response ) {
+        $data = $response->get_data();
+        return is_array( $data ) ? $data : [];
+    }
+    return is_array( $response ) ? $response : [];
+}
+```
+
+Positional (not named) arguments on purpose — the helper is called from every list ability and keyword-args for PHP 8 would add visual noise. Order is intentional: controller, method, route, input, http_method (the defaultable tail).
+
+## The three guards
+
+### 1. `class_exists` on the controller
+
+Execute callbacks can be reached on sites where the plugin's classes haven't loaded (tests, WP-CLI with limited bootstrap, admin pages with conditional autoloading). Check is cheap; without it a missing class produces a fatal.
+
+Note `'\\' . $controller_class` — accept controller class names without a leading backslash (readable in config arrays) and re-add it so `class_exists` and `new $fqcn(...)` both root-resolve.
+
+### 2. Required dependency (API client) null-check
+
+For Pattern A plugins the accessor is a `public static` method on the main plugin class. Both `class_exists` on the plugin class AND `method_exists` on the accessor are guarded because either could be absent during partial bootstraps. A null return from the accessor is also treated as "not initialized".
+
+Missing this argument produces `ArgumentCountError: Too few arguments to function <Controller>::__construct(), 0 passed` — a PHP fatal. The standardized `<plugin>_not_initialized` error code is documented in `error-code-vocabulary.md`.
+
+For Pattern B plugins, this guard is either skipped entirely (zero-arg constructor) or replaced with construction-time scalar args passed in via an optional `constructor_args` parameter.
+
+### 3. `is_wp_error` short-circuit
+
+Before trying to unwrap the response, check if it's already a `WP_Error`. Several controllers return `WP_Error` for both validation failures and upstream failures; that error needs to bubble up intact so the agent can see the upstream code.
+
+## Dual response-shape unwrap
+
+```php
+if ( $response instanceof \WP_REST_Response ) {
+    $data = $response->get_data();
+    return is_array( $data ) ? $data : [];
+}
+return is_array( $response ) ? $response : [];
+```
+
+Real WordPress REST controllers return either:
+- A `WP_REST_Response` (the output of `rest_ensure_response( ... )` or `new WP_REST_Response( ... )`), or
+- A raw array (typical when a controller delegates to an internal request-handler class that returns the decoded transport payload directly).
+
+Both happen. The helper unwraps `WP_REST_Response` via `get_data()` and passes raw arrays through. The `is_array(...) ? ... : []` coalesce defends against a non-array return type that the ability's `output_schema` would have rejected downstream anyway — returning `[]` fails safely rather than leaking a surprising type.
+
+## When NOT to use the helper
+
+Two categories of abilities bypass the helper and call the backing directly:
+
+### Zero-arg backing methods
+
+If the backing method takes no `WP_REST_Request` parameter, don't synthesize a request just to discard it. Call the method directly:
+
+```php
+public static function execute_get_overview( $input = null ) {
+    if ( ! class_exists( '\My_Plugin_REST_Overview_Controller' ) ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+
+    $api_client = /* ... same accessor check ... */;
+    if ( null === $api_client ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+
+    $controller = new \My_Plugin_REST_Overview_Controller( $api_client );
+    $response   = $controller->get_overview(); // No $request argument.
+
+    if ( is_wp_error( $response ) ) {
+        return $response;
+    }
+    return is_array( $response ) ? $response : [];
+}
+```
+
+### Abilities that use a non-REST service
+
+If the execute callback reaches a service directly (e.g. `My_Plugin::get_account_service()->get_cached_account_data()`) rather than a REST controller, stay on the direct path. The ability is not REST-backed and the helper would add a construction step for no gain.
+
+## Rule of thumb
+
+**If the backing method's signature includes `WP_REST_Request`, use the helper. Otherwise direct-path.**
+
+## Conversion pattern — before and after
+
+Before extraction (inline in the execute callback):
+
+```php
+public static function execute_get_things( $input = null ) {
+    if ( ! class_exists( '\My_Plugin_REST_Things_Controller' ) ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+    $api_client = \My_Plugin::get_api_client();
+    if ( ! $api_client ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+    $request = new \WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+    foreach ( (array) $input as $param => $value ) {
+        $request->set_param( $param, $value );
+    }
+    $controller = new \My_Plugin_REST_Things_Controller( $api_client );
+    $response   = $controller->get_things( $request );
+    // ... unwrap ...
+}
+```
+
+After extraction:
+
+```php
+public static function execute_get_things( $input = null ) {
+    return self::delegate_to_rest_controller(
+        'My_Plugin_REST_Things_Controller',
+        'get_things',
+        '/my-plugin/v1/things',
+        is_array( $input ) ? $input : null
+    );
+}
+```
+
+Note the `is_array( $input ) ? $input : null` — the helper signature is `?array`, and passing `null` tells it to build the request with no params at all. This matters because the Abilities API sometimes invokes a callback with no input object.
+
+## Related references
+
+- `plugin-family-patterns.md` — choosing the helper's constructor shape.
+- `error-code-vocabulary.md` — the `<plugin>_not_initialized` code and its siblings.
+- `input-schema-gotchas.md` — callbacks for list abilities often need `per_page` pagination translation BEFORE calling the helper.

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -1,8 +1,8 @@
 # Delegate helper pattern
 
-Once you've decided delegation is the right shape for an ability — that is, the backing REST controller is a pure data-fetch, the operation is a read, and the ability runs predominantly inside REST contexts (see `shared-core-service.md` for when the answer is "no, extract a shared service" instead) — extract a `delegate_to_rest_controller` helper rather than open-coding the request-build/dispatch/unwrap pipeline in each execute callback. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
+Once you've decided delegation is the right shape for an ability — that is, the backing REST controller is a pure data-fetch, the operation is a read, and the ability runs predominantly inside REST contexts (see `shared-core-service.md` for when the answer is "no, extract a shared service" instead) — extract a `delegate_to_rest_controller` helper rather than open-coding the request-build/dispatch/unwrap pipeline in each execute callback. This reference documents one helper shape that works, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all. Adapt the exact signature to the plugin you're working in — the guards and unwrap matter more than the parameter list.
 
-Read `plugin-family-patterns.md` first — the helper's exact shape depends on whether your plugin follows the shared-API-client pattern or the zero-arg-controllers pattern.
+Read `plugin-family-patterns.md` first — the helper's exact shape depends on how the backing controller is constructed (shared API client vs. zero-arg).
 
 ## Why this helper exists
 
@@ -21,7 +21,7 @@ After the **second** list-style ability lands. Before the third ability gets add
 
 If the plugin only ever ships one or two abilities, inline the code. The helper's payoff is at 3+ callers.
 
-## Canonical signature (Pattern A — shared-API-client)
+## Helper shape
 
 ```php
 /**
@@ -107,11 +107,11 @@ Note `'\\' . $controller_class` — accept controller class names without a lead
 
 ### 2. Required dependency (API client) null-check
 
-For Pattern A plugins the accessor is a `public static` method on the main plugin class. Both `class_exists` on the plugin class AND `method_exists` on the accessor are guarded because either could be absent during partial bootstraps. A null return from the accessor is also treated as "not initialized".
+When the controller takes a shared API client as a constructor argument, the accessor is typically a `public static` method on the main plugin class. Guard both `class_exists` on the plugin class AND `method_exists` on the accessor because either could be absent during partial bootstraps. Treat a null return from the accessor as "not initialized".
 
 Missing this argument produces `ArgumentCountError: Too few arguments to function <Controller>::__construct(), 0 passed` — a PHP fatal. The standardized `<plugin>_not_initialized` error code is documented in `error-code-vocabulary.md`.
 
-For Pattern B plugins, this guard is either skipped entirely (zero-arg constructor) or replaced with construction-time scalar args passed in via an optional `constructor_args` parameter.
+When the controller takes no constructor args, skip this guard entirely. When it takes only simple scalars (e.g. a post-type string), pass them in via an optional `constructor_args` parameter on the helper.
 
 ### 3. `is_wp_error` short-circuit
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -1,6 +1,6 @@
 # Delegate helper pattern
 
-When an ability's execute callback needs to hand work to an existing REST controller instead of duplicating business logic, extract a `delegate_to_rest_controller` helper. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
+Once you've decided delegation is the right shape for an ability — that is, the backing REST controller is a pure data-fetch, the operation is a read, and the ability runs predominantly inside REST contexts (see `shared-core-service.md` for when the answer is "no, extract a shared service" instead) — extract a `delegate_to_rest_controller` helper rather than open-coding the request-build/dispatch/unwrap pipeline in each execute callback. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
 
 Read `plugin-family-patterns.md` first — the helper's exact shape depends on whether your plugin follows the shared-API-client pattern or the zero-arg-controllers pattern.
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -135,7 +135,33 @@ Both happen. The helper unwraps `WP_REST_Response` via `get_data()` and passes r
 
 ## When NOT to use the helper
 
-Two categories of abilities bypass the helper and call the backing directly:
+Three categories of abilities bypass the helper and call the backing directly:
+
+### Backing request class can be invoked without the controller
+
+If the REST controller's only role is to translate `WP_REST_Request` into a call to an underlying request class (e.g., `Things_Request::from_rest_request( $request )->execute()`) and adds no validation, permission logic, or orchestration on top, bypass the controller and call the request class directly:
+
+```php
+public static function execute_get_things( $input = null ) {
+    if ( ! class_exists( '\My_Plugin\Things_Request' ) ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+
+    $request = new \WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+    foreach ( (array) $input as $param => $value ) {
+        $request->set_param( $param, $value );
+    }
+
+    $things_request = \My_Plugin\Things_Request::from_rest_request( $request );
+    $rows           = $things_request->execute();
+
+    return is_array( $rows ) ? $rows : [];
+}
+```
+
+The `WP_REST_Request` object exists only to satisfy `from_rest_request()`'s parameter contract — nothing dispatches it. This is the shortest path through the layers: no controller construction, no controller-emitted side effects, and (when the request class is hit before any REST traffic in the lifecycle) no `rest_api_init` cost. See `shared-core-service.md` for the broader discussion of REST-path side effects and the first-call bootstrap cost on cold paths.
+
+The tradeoff is real: bypassing the controller bypasses anything the controller does. If the controller runs validation that the request class doesn't, or emits an audit hook the request class doesn't, that work is lost on the ability path. Use this shape when the controller is genuinely a thin wrapper, not when it's doing work you'd want to keep.
 
 ### Zero-arg backing methods
 
@@ -168,7 +194,7 @@ If the execute callback reaches a service directly (e.g. `My_Plugin::get_account
 
 ## Rule of thumb
 
-**If the backing method's signature includes `WP_REST_Request`, use the helper. Otherwise direct-path.**
+**If the backing method takes `WP_REST_Request` and the controller adds something beyond delegating to an underlying request class (validation, permissions, orchestration, side effects you want to keep), use the helper. If the controller is a thin wrapper over a request class, call the request class directly. Otherwise direct-path.**
 
 ## Conversion pattern — before and after
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -44,11 +44,11 @@ If the plugin only ever ships one or two abilities, inline the code. The helper'
  * @return array|\WP_Error             Response payload as an array, or WP_Error on failure.
  */
 private static function delegate_to_rest_controller(
-    string $controller_class,
-    string $method,
-    string $route,
-    ?array $input,
-    string $http_method = 'GET'
+    $controller_class,
+    $method,
+    $route,
+    $input,
+    $http_method = 'GET'
 ) {
     $fqcn = '\\' . $controller_class;
 

--- a/skills/wp-abilities-api/references/error-code-vocabulary.md
+++ b/skills/wp-abilities-api/references/error-code-vocabulary.md
@@ -1,0 +1,123 @@
+# Error code vocabulary
+
+Every `WP_Error` returned from an ability's execute callback should use a code drawn from this small vocabulary. A consistent vocabulary lets the agent (or the caller in your automation) build retry and recovery logic that matches on codes instead of parsing error messages.
+
+## Why standardized codes matter
+
+Agents that orchestrate multiple abilities need to know: "did this fail because of my input, or because something downstream is unreachable?" The answer drives retry strategy:
+
+- Bootstrap failures → surface to the human, don't retry.
+- Input shape errors → fix the input and retry the same call.
+- Transient backend errors → retry with backoff; may succeed on its own.
+- Upstream third-party errors → may need a different strategy entirely.
+
+Without a convention, every plugin invents its own codes and agents can't reason uniformly across them. The categories below cover 95% of real-world ability errors; sticking to them means an agent that learned the retry logic for one plugin can reuse it for the next.
+
+## Vocabulary
+
+Substitute `<plugin>` with the plugin's slug in lowercase, underscores only (e.g. `woopayments`, `jetpack_forms`). This matches WordPress error-code conventions. If the plugin already has a house style for error codes (WooPayments uses `woopayments`, not `woo_payments`), mirror that — consistency within a plugin trumps consistency across the vocabulary.
+
+| Code | When to use | Agent behavior |
+|---|---|---|
+| `<plugin>_not_initialized` | Plugin class missing, shared service accessor returns null, required dependency isn't resolvable. | Not retriable from the agent side. Usually a config or bootstrap-ordering problem. Escalate. |
+| `<plugin>_missing_<field>` | A required input field is missing or empty (your execute callback's own check, not the schema-validator's). | Agent should add the field and retry. |
+| `<plugin>_invalid_<field>` | Field is present but semantically wrong (bad enum value, malformed date, wrong type). | Agent should correct the value and retry. |
+| `<plugin>_<resource>_data_unavailable` | Backing service returned a transient error (cache miss + remote failure, upstream 5xx, stale-while-revalidate failed). | Agent can retry, probably with backoff. |
+| `ability_invalid_input` | The Abilities API's own schema-validator rejected the input before the execute callback ran. | Equivalent to `<plugin>_missing_<field>` or `<plugin>_invalid_<field>`, just thrown earlier in the pipeline. Agent should fix input. |
+
+### `ability_invalid_input` — the earlier path
+
+When an ability is invoked via the Abilities API REST bridge, the registered `input_schema` runs first. Missing required fields or type mismatches produce `WP_Error( 'ability_invalid_input' )` BEFORE the execute callback fires. Direct invocation (unit tests, non-REST wrappers) bypasses schema validation and hits your execute callback's own checks instead, producing `<plugin>_missing_<field>` / `<plugin>_invalid_<field>`.
+
+Both paths are acceptable — end-agent-facing behavior is equivalent (deterministic validation error, no side effects). Document the observation in the ability's PR description or "notes for reviewers" so reviewers know both codes are expected in different harness runs.
+
+## Worked examples
+
+```php
+// Bootstrap incomplete — plugin class missing or accessor returned null.
+return new \WP_Error(
+    '<plugin>_not_initialized',
+    __( '<Plugin> is not initialized.', '<text-domain>' )
+);
+
+// Required field missing (execute-callback check, schema was bypassed).
+return new \WP_Error(
+    '<plugin>_missing_<field>',
+    __( 'A <field> is required to <do the thing>.', '<text-domain>' )
+);
+
+// Field present but malformed.
+return new \WP_Error(
+    '<plugin>_invalid_<field>',
+    sprintf(
+        /* translators: %s: input parameter name. */
+        __( 'The "%s" parameter must be an ISO 8601 date-time string.', '<text-domain>' ),
+        $key
+    )
+);
+
+// Transient backend error.
+return new \WP_Error(
+    '<plugin>_<resource>_data_unavailable',
+    __( 'Unable to retrieve <resource> data. The cache may be stale or the remote service returned an error.', '<text-domain>' )
+);
+```
+
+## Upstream codes can bubble through — and usually should
+
+If the backing controller talks to a third-party API (Stripe, WPCOM, another SaaS), its own error codes may surface verbatim in `WP_Error::get_error_code()` the ability returns. Typical examples:
+
+- `resource_missing` — Stripe's "object ID not found" code. Tells an agent the specific ID was wrong.
+- `rate_limited` — upstream throttling. Tells an agent to slow down.
+
+**Let these through rather than re-wrapping.** A re-wrapped `<plugin>_<resource>_not_found` loses the information that would help the agent act. Document the upstream codes you've observed in the ability's `description` or PR notes so reviewers know they're expected.
+
+## Code naming rules
+
+1. **Lowercase, underscores only.** `<plugin>_missing_order_id`, not `<plugin>-missingOrderId` or `<Plugin>-MissingOrderId`.
+2. **Plugin prefix first.** Multi-word slugs should normalize to a single-word prefix where the plugin already does (e.g. `woopayments` rather than `woo_payments`).
+3. **Action second.** Use one of `missing`, `invalid`, `not_initialized`, `<resource>_data_unavailable`.
+4. **Field or resource name last.** `<plugin>_missing_dispute_id`, not `<plugin>_dispute_id_missing`. This matches English phrasing ("a dispute_id is required") and is faster to skim in error logs.
+
+## Internationalization
+
+Error MESSAGES are translatable via `__()` or `sprintf(__())`. Error CODES are not — they're stable machine identifiers.
+
+```php
+// WRONG — don't translate the code.
+return new \WP_Error( __( '<plugin>_missing_order_id', '<text-domain>' ), ... );
+
+// RIGHT — code is a literal, message is translatable.
+return new \WP_Error(
+    '<plugin>_missing_order_id',
+    __( 'An order_id is required.', '<text-domain>' )
+);
+```
+
+When a message interpolates a parameter name or value, include a translator comment:
+
+```php
+return new \WP_Error(
+    '<plugin>_invalid_date',
+    sprintf(
+        /* translators: %s: input parameter name. */
+        __( 'The "%s" parameter must be an ISO 8601 date-time string.', '<text-domain>' ),
+        $key
+    )
+);
+```
+
+## Don't over-specify
+
+The goal is consistent codes across all of a plugin's abilities, not ultra-fine granularity. `<plugin>_missing_dispute_id` is the right level. `<plugin>_missing_dispute_id_in_submit_evidence_context` is not — the ability name belongs in `WP_Error::get_error_data()` or in the agent's calling context, not in the code.
+
+## Summary — the four questions
+
+When writing an execute callback, ask in order:
+
+1. Can the plugin even service this call? → `<plugin>_not_initialized`.
+2. Is the required input present? → `<plugin>_missing_<field>`.
+3. Is the required input the right shape? → `<plugin>_invalid_<field>`.
+4. Did the backing service choke? → `<plugin>_<resource>_data_unavailable`, or let the upstream code bubble through.
+
+Four categories, one consistent code vocabulary per plugin. That's enough for agents to build reliable retry logic on top.

--- a/skills/wp-abilities-api/references/error-code-vocabulary.md
+++ b/skills/wp-abilities-api/references/error-code-vocabulary.md
@@ -15,7 +15,7 @@ Without a convention, every plugin invents its own codes and agents can't reason
 
 ## Vocabulary
 
-Substitute `<plugin>` with the plugin's slug in lowercase, underscores only (e.g. `woopayments`, `jetpack_forms`). This matches WordPress error-code conventions. If the plugin already has a house style for error codes (WooPayments uses `woopayments`, not `woo_payments`), mirror that — consistency within a plugin trumps consistency across the vocabulary.
+Substitute `<plugin>` with the plugin's slug in lowercase, underscores only. This matches WordPress error-code conventions. If the plugin already has a house style — for example, a single-word slug that deliberately omits underscores between elided words — mirror that. Consistency within a plugin trumps consistency across the vocabulary.
 
 | Code | When to use | Agent behavior |
 |---|---|---|

--- a/skills/wp-abilities-api/references/input-schema-gotchas.md
+++ b/skills/wp-abilities-api/references/input-schema-gotchas.md
@@ -1,0 +1,221 @@
+# Input schema gotchas
+
+Three surprises the Abilities API's `input_schema` will ship with if you rely on schema declarations alone. All three have been caught in real plugin work after the schema looked correct and tests passed; each has a defensive pattern that makes the execute callback robust regardless.
+
+## 1. Schema `default` values are NOT injected into execute callback input
+
+### Problem
+
+`wp_register_ability()` lets you declare per-property defaults in `input_schema`:
+
+```php
+'input_schema' => [
+    'type'       => 'object',
+    'properties' => [
+        'submit' => [
+            'type'        => 'boolean',
+            'default'     => false,
+            'description' => __( 'Whether to submit evidence for review.', '<text-domain>' ),
+        ],
+    ],
+],
+```
+
+The Abilities API's validate path enforces `type` and `required`, but it does NOT populate missing properties with their declared `default`. If an agent invokes the ability with `{ dispute_id: "dp_..." }` and omits `submit`, the execute callback receives `$input` **without** a `submit` key — it does not get `$input['submit'] = false`.
+
+### Symptoms
+
+- Boolean defaults silently become "undefined" in the callback and any `if ( $input['submit'] )` check compares against `null`, which works by accident but fails `isset` checks and strict-type branches.
+- Integer pagination defaults like `'page' => [ 'default' => 1 ]` never reach the backing controller, so pagination falls back to the controller's internal default rather than the one declared in the schema.
+- Object defaults (`'metadata' => [ 'default' => [] ]`) become `null` rather than `[]` and any `foreach ( $input['metadata'] as ... )` hits a type error.
+
+### Fix — normalize defaults explicitly in the execute callback
+
+```php
+public static function execute_submit_evidence( $input = null ) {
+    if ( ! is_array( $input ) ) {
+        $input = [];
+    }
+
+    // Apply schema defaults the Abilities API does not inject.
+    if ( ! array_key_exists( 'submit', $input ) || null === $input['submit'] ) {
+        $input['submit'] = false;
+    }
+    $input['submit'] = (bool) $input['submit'];
+
+    if ( ! array_key_exists( 'metadata', $input ) || null === $input['metadata'] ) {
+        $input['metadata'] = [];
+    }
+
+    // ... rest of callback
+}
+```
+
+The `array_key_exists` + null-check pattern catches both "missing key" and "explicit null" (some serializers produce nulls for optional fields).
+
+Keep the declared `default` in `input_schema` anyway — it documents the expected behavior for anyone reading the registration and is visible to agents in the schema introspection endpoints. Just don't rely on it for runtime population.
+
+## 2. Pagination parameter-name drift
+
+### Problem
+
+The `input_schema` convention across most WordPress REST endpoints is `per_page` (matching WP core REST list endpoints and `WP_REST_Controller`'s `get_collection_params()`). Some plugin REST controllers, however, delegate to an internal request-builder class that reads a different key (e.g. `pagesize` or `page_size`), typically for historical reasons.
+
+If the ability's `input_schema` exposes `per_page` and the backing controller reads `pagesize`, the agent's `per_page: 50` silently never reaches pagination — the value is accepted, forwarded verbatim to the backing, and then ignored. Agents keep getting the default page size and suspect their filter is broken.
+
+### Symptoms
+
+- List abilities return the backing controller's default page size regardless of the agent's `per_page` input.
+- Integration tests that only check "a list came back" pass; only a test asserting `count( $response['data'] )` catches it.
+- Harness runs show the raw response count matching the default (25, 10, etc.) for every call.
+
+### Detection heuristic
+
+Before shipping a paginated ability, grep the backing controller's call chain:
+
+```bash
+# Check the backing controller and anything it delegates to.
+grep -rn "pagesize\|page_size" <path/to/backing-controller.php> <path/to/request-helpers/>
+```
+
+If `pagesize` (or any non-`per_page` key) appears in the chain and the ability's schema exposes `per_page`, the execute callback MUST translate.
+
+### Fix — translate before delegating
+
+```php
+/**
+ * Translate pagination keys for abilities whose backing reads a non-standard key.
+ *
+ * Abilities expose `per_page` uniformly for agent-facing consistency; this
+ * helper rewrites it to whatever key the backing actually reads.
+ *
+ * @param array|null $input Ability input (or null).
+ * @return array|null       Input with `per_page` rewritten to `<backing_key>` when present.
+ */
+private static function translate_pagination_keys( $input ) {
+    if ( ! is_array( $input ) ) {
+        return $input;
+    }
+    if ( isset( $input['per_page'] ) ) {
+        $input['<backing_key>'] = $input['per_page'];
+        unset( $input['per_page'] );
+    }
+    return $input;
+}
+
+public static function execute_get_things( $input = null ) {
+    $input = self::translate_pagination_keys( is_array( $input ) ? $input : null );
+
+    return self::delegate_to_rest_controller(
+        '<Backing_Controller_Class>',
+        'get_things',
+        '/my-plugin/v1/things',
+        $input
+    );
+}
+```
+
+Place the translation BEFORE the delegate call so `per_page` never reaches the backing.
+
+### When NOT to apply this
+
+Do not apply blindly. If the backing reads `per_page` directly (most modern WP REST controllers do), adding this translation would silently break pagination by renaming the key to something the backing doesn't understand.
+
+**Always grep the backing first.** The translation is only correct for a specific backing chain; it's not a general safety net.
+
+## 3. ID validation must not use `empty()`
+
+### Problem
+
+PHP's `empty()` is permissive in ways that bite ID validation:
+
+```php
+empty( '0' )   // true  — but "0" is a legal string ID (order ID, row ID, post ID in some code paths)
+empty( 0 )     // true  — same for integer zero
+empty( [] )    // true  — expected, but same keyword used for different cases
+```
+
+An execute callback that guards required IDs with `empty( $input['order_id'] )` will false-reject a legitimate `"0"` and return a "missing" error for input that's actually present. The agent retries with the same input, gets the same error, and the call is stuck.
+
+### Symptoms
+
+- Abilities reject specific IDs ending in zero or consisting of zero.
+- Unit tests written with non-zero IDs pass; a regression lands the day an agent tries a real zero-ID.
+- `WP_Error( '<plugin>_missing_<field>' )` fires for input the schema validator would have accepted.
+
+### Fix — three explicit checks
+
+```php
+if ( ! isset( $input['order_id'] )
+    || ! is_string( $input['order_id'] )
+    || '' === $input['order_id']
+) {
+    return new \WP_Error(
+        '<plugin>_missing_order_id',
+        __( 'An order_id is required to fetch order detail.', '<text-domain>' )
+    );
+}
+```
+
+Three separate checks, each non-redundant:
+
+1. `! isset( ... )` — the key is present on the array.
+2. `! is_string( ... )` — type is right. (For integer IDs, use `is_int` + non-negative check instead.) Without this, a caller that passes `123` (integer) where the schema documents a string would fall through to a later step that does `rawurlencode( $input['order_id'] )` and produces a cryptic coercion error rather than a clean missing-field response.
+3. `'' === $input[ ... ]` — non-empty in the strict sense. Rejects empty string only; accepts `"0"` as a legal value.
+
+Use the standardized `<plugin>_missing_<field>` error code (see `error-code-vocabulary.md`) for this case.
+
+### Add a regression-guard unit test
+
+The guard is load-bearing enough that it deserves an explicit test — otherwise someone will simplify it back to `empty()` in a future refactor:
+
+```php
+public function test_execute_returns_wp_error_when_id_not_a_string(): void {
+    $result = My_Plugin_Abilities::execute_get_thing( [ 'order_id' => 123 ] );
+    $this->assertInstanceOf( \WP_Error::class, $result );
+    $this->assertSame( '<plugin>_missing_order_id', $result->get_error_code() );
+}
+```
+
+The integer `123` is a fine canary — it's non-empty, it `isset`s, but it's not a string. A callback that only uses `isset` + `empty` would false-pass this input and fall through to the URL construction with an integer argument.
+
+## Putting the three together
+
+A hardened execute callback for a list-style ability with a required ID, schema defaults, and backing pagination drift:
+
+```php
+public static function execute_get_thing_details( $input = null ) {
+    if ( ! is_array( $input ) ) {
+        $input = [];
+    }
+
+    // Gotcha 3: required-ID validation (not empty()).
+    if ( ! isset( $input['thing_id'] )
+        || ! is_string( $input['thing_id'] )
+        || '' === $input['thing_id']
+    ) {
+        return new \WP_Error(
+            '<plugin>_missing_thing_id',
+            __( 'A thing_id is required.', '<text-domain>' )
+        );
+    }
+
+    // Gotcha 1: apply defaults the Abilities API doesn't inject.
+    if ( ! array_key_exists( 'include_history', $input ) || null === $input['include_history'] ) {
+        $input['include_history'] = false;
+    }
+    $input['include_history'] = (bool) $input['include_history'];
+
+    // Gotcha 2: translate pagination before delegating (only if backing reads a non-standard key).
+    $input = self::translate_pagination_keys( $input );
+
+    return self::delegate_to_rest_controller(
+        '<Backing_Controller_Class>',
+        'get_thing',
+        '/my-plugin/v1/things/' . rawurlencode( $input['thing_id'] ),
+        $input
+    );
+}
+```
+
+Each of the three lines the callback adds on top of the "just delegate" pattern has a paid-for bug behind it. Keep them.

--- a/skills/wp-abilities-api/references/input-schema-gotchas.md
+++ b/skills/wp-abilities-api/references/input-schema-gotchas.md
@@ -179,7 +179,51 @@ public function test_execute_returns_wp_error_when_id_not_a_string(): void {
 
 The integer `123` is a fine canary — it's non-empty, it `isset`s, but it's not a string. A callback that only uses `isset` + `empty` would false-pass this input and fall through to the URL construction with an integer argument.
 
-## Putting the three together
+## 4. Direct vs indirect invocation differ in strictness
+
+### Problem
+
+Two ways exist to invoke an ability's `execute_callback`:
+
+- **Direct.** A caller imports the registrar and calls the static method (`Abilities_Registrar::execute_get_things( $input )`). PHP signature defaults apply; no schema validation runs.
+- **Indirect.** A caller resolves the ability through `wp_get_ability( '<id>' )->execute( $input )`. WordPress runs `WP_Ability::normalize_input()` then `validate_input()` (then `check_permissions()`) before the callback is invoked.
+
+The two paths differ in three ways agents trip over:
+
+1. **Validation against `input_schema` runs only on the indirect path.** If the ability declares an object-typed schema with properties and the indirect caller passes `null` (or omits the argument entirely, as `$ability->execute()` does), `validate_input()` rejects with an `ability_invalid_input` error before the callback runs. The PHP-level `$input = null` default in the callback signature is dead code on this path.
+
+2. **Schema's top-level `default` IS applied — but only on the indirect path.** `normalize_input()` substitutes the schema's top-level `default` when the caller passes `null`. Direct callers don't run through this method; they get whatever PHP default the callback signature declares. Declaring `default => (object) array()` at the schema root makes `$ability->execute()` work without arguments — but the same callback called directly still receives PHP `null`.
+
+3. **The callback's first argument arrives only when `input_schema` is non-empty.** WordPress only forwards `$input` to the callback when the schema is declared. Without an input schema, the callback is invoked with zero arguments — PHP-level signature defaults compensate for this if you wrote them; without them, the indirect path produces an `ArgumentCountError`.
+
+### Symptoms
+
+- An ability looks fine when unit-tested by directly invoking the static method, then fails the moment it's exercised through `wp_get_ability(...)->execute()` from MCP / Command Palette / agent harnesses.
+- "Works in the test, breaks in MCP" — typical pattern when a test calls `Abilities_Registrar::execute_get_things( [] )` (passing an empty array) but the agent invocation goes through the indirect pipeline.
+- A schema with all-optional properties still rejects zero-arg indirect calls because `null` is not an object.
+
+### Fix — declare a top-level schema `default` for any zero-arg-allowed ability
+
+```php
+'input_schema' => [
+    'type'       => 'object',
+    'default'    => (object) array(),  // applied by normalize_input() on null inputs
+    'properties' => [
+        'per_page' => [ 'type' => 'integer', 'default' => 10 ],
+        // ...
+    ],
+],
+```
+
+`(object) array()` is preferred over `[]` because it json-encodes to `{}` rather than the array literal `[]`, avoiding PHP's array/object ambiguity at the validator boundary.
+
+### Distinguish from Gotcha 1
+
+Top-level schema `default` is honored by `normalize_input()` and reaches the callback. Property-level `default` (Gotcha 1) is NOT — those values are dropped by the validator, and the callback has to defensively reapply them. Different layers, different fates.
+
+If you've declared the top-level `default` in the schema, the PHP-level signature default exists only for direct callers. Don't add a third layer of fallback inside the callback that re-checks `if ( $input === null )` — three compensating defaults stacked on each other diffuses the meaning of "no input."
+
+## Putting gotchas 1-3 together
 
 A hardened execute callback for a list-style ability with a required ID, schema defaults, and backing pagination drift:
 

--- a/skills/wp-abilities-api/references/input-schema-gotchas.md
+++ b/skills/wp-abilities-api/references/input-schema-gotchas.md
@@ -170,7 +170,7 @@ Use the standardized `<plugin>_missing_<field>` error code (see `error-code-voca
 The guard is load-bearing enough that it deserves an explicit test — otherwise someone will simplify it back to `empty()` in a future refactor:
 
 ```php
-public function test_execute_returns_wp_error_when_id_not_a_string(): void {
+public function test_execute_returns_wp_error_when_id_not_a_string() {
     $result = My_Plugin_Abilities::execute_get_thing( [ 'order_id' => 123 ] );
     $this->assertInstanceOf( \WP_Error::class, $result );
     $this->assertSame( '<plugin>_missing_order_id', $result->get_error_code() );

--- a/skills/wp-abilities-api/references/plugin-family-patterns.md
+++ b/skills/wp-abilities-api/references/plugin-family-patterns.md
@@ -1,12 +1,12 @@
 # Plugin-family patterns
 
-This reference covers shared implementation *mechanics* — the call-shape pattern your execute callbacks follow when handing work to existing business logic. Two patterns cover most real-world WordPress plugins; pick one up front, because the choice ripples through your delegate helper, your tests, and your error codes.
+This reference covers shared implementation *mechanics* — the call shape your execute callbacks follow when handing work to existing business logic. Two shapes are common enough across real-world WordPress plugins to be worth naming; which one fits is determined by how the backing controller is constructed, not by a choice you make up front. The choice still ripples through your delegate helper, your tests, and your error codes, so it's worth confirming early.
 
 Family-specific *registration* conventions — loader path, ability category, MCP exposure defaults, error-code prefix house style — live in separate plugin-family overlays (for example, a WooCommerce-extension overlay), not in this reference. Apply any relevant overlay before scaffolding registration. The patterns below should stay portable: they describe how the execute callback talks to backing code, not what the registration metadata should look like for your plugin family.
 
-There is also a third option that sits *outside* this dichotomy. If the operation does not yet have a shared service class — or if you can refactor toward one — extracting a service that the ability, the REST controller, and the UI all consume is the default per `shared-core-service.md`. Delegation through an existing REST controller (Patterns A and B below) is a conditional shortcut for low-stakes reads, not the starting point. Confirm the shape is right before you reach for either pattern.
+There is also a third option that sits *outside* this dichotomy. If the operation does not yet have a shared service class — or if you can refactor toward one — extracting a service that the ability, the REST controller, and the UI all consume is the default per `shared-core-service.md`. Delegation through an existing REST controller (either shape below) is a conditional shortcut for low-stakes reads, not the starting point. Confirm the shape is right before you reach for either.
 
-## Pattern A — Shared API client
+## Shape: shared API client
 
 Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an upstream API). The plugin bootstraps a single API client, exposes it via a static accessor on a main plugin class, and every REST controller takes that client as a constructor argument.
 
@@ -17,7 +17,7 @@ Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an 
 grep -n "public function __construct" <path/to/rest-controller.php>
 ```
 
-If the constructor takes a required typed argument (e.g. `My_Plugin_API_Client $api_client`), you're in Pattern A. Confirm the plugin has a central accessor:
+If the constructor takes a required typed argument (e.g. `My_Plugin_API_Client $api_client`), you're in the shared-API-client shape. Confirm the plugin has a central accessor:
 
 ```bash
 grep -rn "get_api_client\|get_.*_api_client\|get_service" <path/to/plugin/main-class.php>
@@ -73,7 +73,7 @@ class Abilities_Registrar {
             return new \WP_Error( 'my_plugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
         }
 
-        // Pattern A specifics: fetch the shared API client and null-check.
+        // Shape specifics: fetch the shared API client and null-check.
         $api_client = null;
         if ( class_exists( '\My_Plugin' ) && method_exists( '\My_Plugin', 'get_api_client' ) ) {
             $api_client = \My_Plugin::get_api_client();
@@ -112,7 +112,7 @@ class Abilities_Registrar {
 
 Worked example: a plugin that talks to an external SaaS or upstream HTTP service typically follows this pattern. The plugin's main class exposes the API client via a static accessor (e.g. `Plugin_Main::get_api_client()`); REST controllers extend a base class whose constructor takes that client as a typed argument; the abilities registrar pulls the client through the same accessor before constructing controllers.
 
-## Pattern B — Zero-arg controllers
+## Shape: zero-arg controllers
 
 Common in plugins/packages that delegate primarily to WordPress core mechanisms (custom post types, options, meta) and don't maintain a single shared API client. Controllers instantiate cleanly without a dependency graph.
 
@@ -122,9 +122,9 @@ Common in plugins/packages that delegate primarily to WordPress core mechanisms 
 grep -n "public function __construct" <path/to/rest-controller.php>
 ```
 
-If the constructor takes no required arguments, or takes only simple scalars you can hardcode at the ability call site (e.g. a post-type string), you're in Pattern B.
+If the constructor takes no required arguments, or takes only simple scalars you can hardcode at the ability call site (e.g. a post-type string), you're in the zero-arg shape.
 
-Also grep the plugin's main bootstrap class for the absence of a singleton API accessor — if there isn't one, Pattern B is the honest choice.
+Also grep the plugin's main bootstrap class for the absence of a singleton API accessor — if there isn't one, the zero-arg shape is the honest choice.
 
 ### Minimal skeleton
 
@@ -203,7 +203,7 @@ See `delegate-helper-pattern.md` for the full helper signature and guards.
 ### Testing implications
 
 - **No API-client mock needed.** Unit tests instantiate the ability registrar directly and call `execute_*` with input arrays.
-- **Test at the `wp_get_ability()` level when possible.** In Pattern B the backing controller often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
+- **Test at the `wp_get_ability()` level when possible.** With zero-arg controllers the backing often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
 - **The `<plugin>_not_initialized` failure mode is less common.** It still exists — if a package isn't loaded, `class_exists` on the backing controller still fails — but the surface area is smaller.
 
 Worked example: a plugin whose REST controllers wrap a custom post type, taxonomy, option, or meta typically follows this pattern. Each execute callback constructs its controller inline (e.g. `new My_CPT_Endpoint( 'my_cpt' )`), passing whatever scalar (post-type slug, taxonomy name) the controller needs. No shared helper in the registrar; the construction step is small enough to inline.
@@ -212,14 +212,14 @@ Worked example: a plugin whose REST controllers wrap a custom post type, taxonom
 
 A single plugin can legitimately use both patterns across different abilities:
 
-- A Pattern A ability for backing controllers that talk to the upstream service.
-- A Pattern B ability for backing controllers that only touch WP core (e.g. a CPT-based settings endpoint in the same plugin).
+- A shared-API-client ability for backing controllers that talk to the upstream service.
+- A zero-arg ability for backing controllers that only touch WP core (e.g. a CPT-based settings endpoint in the same plugin).
 
-If this happens, the helper in `delegate-helper-pattern.md` can support both via optional `constructor_args` — but resist the temptation to over-engineer until you have at least two Pattern B abilities that would share the helper.
+If this happens, the helper in `delegate-helper-pattern.md` can support both via optional `constructor_args` — but resist the temptation to over-engineer until you have at least two zero-arg abilities that would share the helper.
 
 ## Anti-pattern — inventing an API client where there isn't one
 
-Don't introduce a fake shared API client to fit Pattern A's helper shape. If the plugin is genuinely stateless / CPT-driven, Pattern B's inline construction is the honest answer. The helper is scaffolding that pays back when you have 4+ abilities sharing the build-request → instantiate → unwrap flow; before that, inline code is faster to read and review.
+Don't introduce a fake shared API client to fit the shared-client helper shape. If the plugin is genuinely stateless / CPT-driven, inline construction is the honest answer. The helper is scaffolding that pays back when you have 4+ abilities sharing the build-request → instantiate → unwrap flow; before that, inline code is faster to read and review.
 
 ## Picking quickly
 

--- a/skills/wp-abilities-api/references/plugin-family-patterns.md
+++ b/skills/wp-abilities-api/references/plugin-family-patterns.md
@@ -1,0 +1,229 @@
+# Plugin-family patterns
+
+When you adopt the Abilities API inside an existing plugin, the plugin's architecture dictates HOW your execute callbacks call the existing business logic. Two patterns cover most real-world WordPress plugins. Pick one up front — the choice ripples through your delegate helper, your tests, and your error codes.
+
+## Pattern A — Shared-API-client ("Woo-family")
+
+Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an upstream API). The plugin bootstraps a single API client, exposes it via a static accessor on a main plugin class, and every REST controller takes that client as a constructor argument.
+
+### Detection
+
+```bash
+# Inspect the backing REST controller's __construct signature.
+grep -n "public function __construct" <path/to/rest-controller.php>
+```
+
+If the constructor takes a required typed argument (e.g. `My_Plugin_API_Client $api_client`), you're in Pattern A. Confirm the plugin has a central accessor:
+
+```bash
+grep -rn "get_api_client\|get_.*_api_client\|get_service" <path/to/plugin/main-class.php>
+```
+
+You're looking for a `public static function get_<something>()` that returns the shared client.
+
+### Minimal skeleton
+
+```php
+<?php
+namespace My_Plugin\Abilities;
+
+class Abilities_Registrar {
+
+    const CATEGORY_SLUG = 'my-plugin';
+
+    public static function init() {
+        add_action( 'wp_abilities_api_categories_init', [ __CLASS__, 'register_category' ] );
+        add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+    }
+
+    public static function register_abilities() {
+        wp_register_ability(
+            'my-plugin/get-things',
+            [
+                'label'               => __( 'Get things', 'my-plugin' ),
+                'description'         => __( 'List things with filters.', 'my-plugin' ),
+                'category'            => self::CATEGORY_SLUG,
+                'input_schema'        => [ /* ... */ ],
+                'execute_callback'    => [ __CLASS__, 'execute_get_things' ],
+                'permission_callback' => [ __CLASS__, 'current_user_has_capability' ],
+                'meta'                => [
+                    'annotations'  => [ 'readonly' => true, 'destructive' => false, 'idempotent' => true ],
+                    'show_in_rest' => true,
+                ],
+            ]
+        );
+    }
+
+    public static function execute_get_things( $input = null ) {
+        return self::delegate_to_rest_controller(
+            'My_Plugin_REST_Things_Controller',
+            'get_things',
+            '/my-plugin/v1/things',
+            is_array( $input ) ? $input : null
+        );
+    }
+
+    private static function delegate_to_rest_controller( $controller_class, $method, $route, $input, $http_method = 'GET' ) {
+        $fqcn = '\\' . $controller_class;
+        if ( ! class_exists( $fqcn ) ) {
+            return new \WP_Error( 'my_plugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
+        }
+
+        // Pattern A specifics: fetch the shared API client and null-check.
+        $api_client = null;
+        if ( class_exists( '\My_Plugin' ) && method_exists( '\My_Plugin', 'get_api_client' ) ) {
+            $api_client = \My_Plugin::get_api_client();
+        }
+        if ( null === $api_client ) {
+            return new \WP_Error( 'my_plugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
+        }
+
+        $request = new \WP_REST_Request( $http_method, $route );
+        if ( is_array( $input ) ) {
+            foreach ( $input as $param => $value ) {
+                $request->set_param( $param, $value );
+            }
+        }
+
+        $controller = new $fqcn( $api_client );
+        $response   = $controller->{$method}( $request );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+        if ( $response instanceof \WP_REST_Response ) {
+            $data = $response->get_data();
+            return is_array( $data ) ? $data : [];
+        }
+        return is_array( $response ) ? $response : [];
+    }
+}
+```
+
+### Testing implications
+
+- **Bootstrap test doubles need the API client.** Unit tests that instantiate controllers must provide a mocked or stubbed client; otherwise the constructor fails with `ArgumentCountError: Too few arguments`.
+- **The "not initialized" error path is reachable and must be covered.** One unit test should stub the accessor to return null and assert the ability returns `<plugin>_not_initialized`. This is a common failure during partial bootstraps (WP-CLI with restricted loading, test harnesses, admin pages with conditional autoloading).
+- **Integration tests need real or faked HTTP.** The backing controller will hit the upstream unless the API client is mocked, so integration harnesses typically route through a fake transport.
+
+Worked example: WooPayments' `Abilities_Registrar` uses this pattern. Controllers extend `WC_Payments_REST_Controller`, whose constructor takes a `WC_Payments_API_Client`; the shared client comes from `WC_Payments::get_payments_api_client()`.
+
+## Pattern B — Zero-arg controllers ("Jetpack-family")
+
+Common in plugins/packages that delegate primarily to WordPress core mechanisms (custom post types, options, meta) and don't maintain a single shared API client. Controllers instantiate cleanly without a dependency graph.
+
+### Detection
+
+```bash
+grep -n "public function __construct" <path/to/rest-controller.php>
+```
+
+If the constructor takes no required arguments, or takes only simple scalars you can hardcode at the ability call site (e.g. a post-type string), you're in Pattern B.
+
+Also grep the plugin's main bootstrap class for the absence of a singleton API accessor — if there isn't one, Pattern B is the honest choice.
+
+### Minimal skeleton
+
+```php
+<?php
+namespace My_Plugin\Abilities;
+
+class Abilities_Registrar {
+
+    const CATEGORY_SLUG = 'my-plugin';
+
+    public static function init() {
+        add_action( 'wp_abilities_api_categories_init', [ __CLASS__, 'register_category' ] );
+        add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+    }
+
+    public static function register_abilities() {
+        wp_register_ability(
+            'my-plugin/get-things',
+            [
+                /* ... */
+                'execute_callback' => [ __CLASS__, 'execute_get_things' ],
+                /* ... */
+            ]
+        );
+    }
+
+    public static function execute_get_things( $input = null ) {
+        $input    = is_array( $input ) ? $input : [];
+        $endpoint = new \My_Plugin_Things_Endpoint();
+        $request  = new \WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+
+        foreach ( [ 'page', 'per_page', 'status', 'search' ] as $key ) {
+            if ( isset( $input[ $key ] ) ) {
+                $request->set_param( $key, $input[ $key ] );
+            }
+        }
+
+        $response = $endpoint->get_items( $request );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+        return $response instanceof \WP_REST_Response ? $response->get_data() : $response;
+    }
+}
+```
+
+No helper is required — the construction step is a single line and inlining per callback stays readable. If you do extract a helper, it takes a `constructor_args` parameter because the controller class isn't constant across abilities:
+
+```php
+/**
+ * @param string     $controller_class Fully-qualified controller class.
+ * @param string     $method           Method to invoke on the request.
+ * @param string     $route            REST route used when constructing WP_REST_Request.
+ * @param array|null $input            Ability input (or null).
+ * @param string     $http_method      HTTP method. Defaults to 'GET'.
+ * @param array      $constructor_args Optional scalar args for the controller's constructor.
+ * @return array|\WP_Error
+ */
+private static function delegate_to_rest_controller(
+    $controller_class,
+    $method,
+    $route,
+    $input,
+    $http_method = 'GET',
+    $constructor_args = array()
+) {
+    /* ... */
+}
+```
+
+The phpDoc carries the `array|\WP_Error` return shape; the function signature itself stays untyped on the return so this snippet parses on PHP 7.2+.
+
+See `delegate-helper-pattern.md` for the full helper signature and guards.
+
+### Testing implications
+
+- **No API-client mock needed.** Unit tests instantiate the ability registrar directly and call `execute_*` with input arrays.
+- **Test at the `wp_get_ability()` level when possible.** In Pattern B the backing controller often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
+- **The `<plugin>_not_initialized` failure mode is less common.** It still exists — if a package isn't loaded, `class_exists` on the backing controller still fails — but the surface area is smaller.
+
+Worked example: Jetpack Forms' `Forms_Abilities` class instantiates `Contact_Form_Endpoint( 'feedback' )` per execute callback. No shared helper in the registrar; the construction step is inline. Canonical file: [`Automattic/jetpack/projects/packages/forms/src/abilities/class-forms-abilities.php`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/abilities/class-forms-abilities.php).
+
+## Hybrid cases
+
+A single plugin can legitimately use both patterns across different abilities:
+
+- A Pattern A ability for backing controllers that talk to the upstream service.
+- A Pattern B ability for backing controllers that only touch WP core (e.g. a CPT-based settings endpoint in the same plugin).
+
+If this happens, the helper in `delegate-helper-pattern.md` can support both via optional `constructor_args` — but resist the temptation to over-engineer until you have at least two Pattern B abilities that would share the helper.
+
+## Anti-pattern — inventing an API client where there isn't one
+
+Don't introduce a fake shared API client to fit Pattern A's helper shape. If the plugin is genuinely stateless / CPT-driven, Pattern B's inline construction is the honest answer. The helper is scaffolding that pays back when you have 4+ abilities sharing the build-request → instantiate → unwrap flow; before that, inline code is faster to read and review.
+
+## Picking quickly
+
+| Signal | Likely pattern |
+|---|---|
+| Backing controller's `__construct` takes an API-client-like object | A |
+| Plugin has a `Plugin::get_*_client()` static accessor | A |
+| Plugin talks to an external SaaS / upstream HTTP service | A |
+| Backing controller `__construct` is zero-arg or only takes scalars | B |
+| Backing is a CPT / options / meta wrapper | B |
+| Plugin is a Jetpack-style first-party WordPress package | B |

--- a/skills/wp-abilities-api/references/plugin-family-patterns.md
+++ b/skills/wp-abilities-api/references/plugin-family-patterns.md
@@ -1,8 +1,12 @@
 # Plugin-family patterns
 
-When you adopt the Abilities API inside an existing plugin, the plugin's architecture dictates HOW your execute callbacks call the existing business logic. Two patterns cover most real-world WordPress plugins. Pick one up front — the choice ripples through your delegate helper, your tests, and your error codes.
+This reference covers shared implementation *mechanics* — the call-shape pattern your execute callbacks follow when handing work to existing business logic. Two patterns cover most real-world WordPress plugins; pick one up front, because the choice ripples through your delegate helper, your tests, and your error codes.
 
-## Pattern A — Shared-API-client ("Woo-family")
+Family-specific *registration* conventions — loader path, ability category, MCP exposure defaults, error-code prefix house style — live in separate plugin-family overlays (for example, a WooCommerce-extension overlay), not in this reference. Apply any relevant overlay before scaffolding registration. The patterns below should stay portable: they describe how the execute callback talks to backing code, not what the registration metadata should look like for your plugin family.
+
+There is also a third option that sits *outside* this dichotomy. If the operation does not yet have a shared service class — or if you can refactor toward one — extracting a service that the ability, the REST controller, and the UI all consume is the default per `shared-core-service.md`. Delegation through an existing REST controller (Patterns A and B below) is a conditional shortcut for low-stakes reads, not the starting point. Confirm the shape is right before you reach for either pattern.
+
+## Pattern A — Shared API client
 
 Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an upstream API). The plugin bootstraps a single API client, exposes it via a static accessor on a main plugin class, and every REST controller takes that client as a constructor argument.
 
@@ -106,9 +110,9 @@ class Abilities_Registrar {
 - **The "not initialized" error path is reachable and must be covered.** One unit test should stub the accessor to return null and assert the ability returns `<plugin>_not_initialized`. This is a common failure during partial bootstraps (WP-CLI with restricted loading, test harnesses, admin pages with conditional autoloading).
 - **Integration tests need real or faked HTTP.** The backing controller will hit the upstream unless the API client is mocked, so integration harnesses typically route through a fake transport.
 
-Worked example: WooPayments' `Abilities_Registrar` uses this pattern. Controllers extend `WC_Payments_REST_Controller`, whose constructor takes a `WC_Payments_API_Client`; the shared client comes from `WC_Payments::get_payments_api_client()`.
+Worked example: a plugin that talks to an external SaaS or upstream HTTP service typically follows this pattern. The plugin's main class exposes the API client via a static accessor (e.g. `Plugin_Main::get_api_client()`); REST controllers extend a base class whose constructor takes that client as a typed argument; the abilities registrar pulls the client through the same accessor before constructing controllers.
 
-## Pattern B — Zero-arg controllers ("Jetpack-family")
+## Pattern B — Zero-arg controllers
 
 Common in plugins/packages that delegate primarily to WordPress core mechanisms (custom post types, options, meta) and don't maintain a single shared API client. Controllers instantiate cleanly without a dependency graph.
 
@@ -202,7 +206,7 @@ See `delegate-helper-pattern.md` for the full helper signature and guards.
 - **Test at the `wp_get_ability()` level when possible.** In Pattern B the backing controller often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
 - **The `<plugin>_not_initialized` failure mode is less common.** It still exists — if a package isn't loaded, `class_exists` on the backing controller still fails — but the surface area is smaller.
 
-Worked example: Jetpack Forms' `Forms_Abilities` class instantiates `Contact_Form_Endpoint( 'feedback' )` per execute callback. No shared helper in the registrar; the construction step is inline. Canonical file: [`Automattic/jetpack/projects/packages/forms/src/abilities/class-forms-abilities.php`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/abilities/class-forms-abilities.php).
+Worked example: a plugin whose REST controllers wrap a custom post type, taxonomy, option, or meta typically follows this pattern. Each execute callback constructs its controller inline (e.g. `new My_CPT_Endpoint( 'my_cpt' )`), passing whatever scalar (post-type slug, taxonomy name) the controller needs. No shared helper in the registrar; the construction step is small enough to inline.
 
 ## Hybrid cases
 
@@ -226,4 +230,4 @@ Don't introduce a fake shared API client to fit Pattern A's helper shape. If the
 | Plugin talks to an external SaaS / upstream HTTP service | A |
 | Backing controller `__construct` is zero-arg or only takes scalars | B |
 | Backing is a CPT / options / meta wrapper | B |
-| Plugin is a Jetpack-style first-party WordPress package | B |
+| Plugin's REST surface wraps WP-core post types, taxonomies, options, or meta | B |


### PR DESCRIPTION
Adds four mechanics-layer reference docs to `wp-abilities-api/` plus a six-line cross-link block in `SKILL.md`. Stacks on merged #44 (now in `trunk` as `26aa4e8`).

## What lands

| File | Purpose |
|---|---|
| `references/plugin-family-patterns.md` | Two call-shape patterns (shared API client vs zero-arg controllers) — implementation *mechanics* only. Family-specific *registration* conventions (loader, category, MCP defaults, error-code prefix) explicitly belong in plugin-family overlays. Service-extraction is named as the third option outside the A/B dichotomy, coherent with #44 round 4. |
| `references/delegate-helper-pattern.md` | Canonical `delegate_to_rest_controller` helper. Opens by gating entry on the three delegation preconditions (read-only handler, read op, predominantly inside REST contexts); for everything else, points back at `shared-core-service.md`. Three guards, dual response-shape unwrap, when NOT to use. |
| `references/error-code-vocabulary.md` | Standardized `WP_Error` codes (`<plugin>_not_initialized`, `<plugin>_missing_<field>`, `<plugin>_invalid_<field>`, `<plugin>_<resource>_data_unavailable`, `ability_invalid_input`) so agents can build retry logic against codes, not message strings. |
| `references/input-schema-gotchas.md` | Four runtime surprises: schema-default non-injection, pagination key drift between abilities exposing `per_page` and backings reading `pagesize`, PHP `empty()` false-rejecting `"0"` and `0` as legitimate IDs, and direct-vs-indirect invocation strictness. |
| `wp-abilities-api/SKILL.md` | Six lines: step-4 cross-links + a failure-mode pointer. |

## Verification at tip

- WP core symbols verified against `WordPress/wordpress-develop` trunk.
- PHP code blocks parse on PHP 7.2.
- `node eval/harness/run.mjs` passes.
- No plugin-family-specific names in worked examples after round 2.

## Status

Round 2 (current tip). Round 2 addressed @nerrad's 2026-05-21 inline comment at `#discussion_r3277876461` asking for an overlay-vs-portable framing in `plugin-family-patterns.md:3`, plus the related portability cleanup across the other refs:

- `acfea3c` — rewrites `plugin-family-patterns.md`'s intro on the overlay axis; drops `("Woo-family")` / `("Jetpack-family")` parentheticals on Pattern A/B; genericizes both worked examples (WooPayments class chain → generic SaaS client; Jetpack Forms file link → generic CPT pattern) and the family-named "Picking quickly" row.
- `5eb7f72` — same posture applied to `error-code-vocabulary.md` (drops `woopayments` / `jetpack_forms` and the WooPayments house-style callout).
- `e16d580` — re-anchors `delegate-helper-pattern.md`'s opening to the conditional-shortcut framing from #44 round 4.

This reference is now portable mechanics only; family-specific registration conventions belong in the WooCommerce-extension overlay (`Automattic/payments-ai-tools` PR #21).

Rebased onto `trunk` after #44 merged on 2026-05-26 (squash commit `26aa4e8`); the diff now shows only this PR's 12 mechanics-layer commits.

