### PR TITLE
wp-abilities-audit: add new skill for surveying a plugin's REST surface and producing a structured audit doc

### DIFF
--- a/eval/scenarios/wp-abilities-audit.json
+++ b/eval/scenarios/wp-abilities-audit.json
@@ -10,7 +10,8 @@
     "Step 5: Apply semantic-intent grouping per wp-abilities-api/references/grouping-heuristic.md; do NOT atomize one ability per HTTP method",
     "Step 6: Mark inherited routes with backing.inherited_from and null line numbers per audit-schema.md",
     "Step 7: Write the audit doc to the user-provided output path, NOT into the plugin worktree",
-    "Step 8: Include at least one entry in surfaced_gaps for a high-leverage zero-arg candidate or a backing: null gap"
+    "Step 8: Include at least one entry in surfaced_gaps for a high-leverage zero-arg candidate or a backing: null gap",
+    "Step 9: For each proposed ability, record the implementation-readiness fields per audit-schema.md: use_case_fit (one-sentence workflow), side_effects (array; empty list is a load-bearing fact, not a missing value), seed_data_needs (representative-data shape or null)"
   ],
   "success_criteria": [
     "Routes to wp-abilities-audit skill",
@@ -19,6 +20,7 @@
     "proposed_abilities has at least 3 entries with at least one read and one write",
     "surfaced_gaps array has at least one entry",
     "Controller Inventory table lists every controller grep enumerated",
-    "Notes and Surprises section captures at least one judgment call"
+    "Notes and Surprises section captures at least one judgment call",
+    "Every entry in proposed_abilities populates use_case_fit, side_effects, and seed_data_needs (the implementation-readiness fields)"
   ]
 }

--- a/eval/scenarios/wp-abilities-audit.json
+++ b/eval/scenarios/wp-abilities-audit.json
@@ -1,0 +1,24 @@
+{
+  "name": "Produce an Abilities API audit doc for a plugin with a non-standard REST layout",
+  "skills": ["wordpress-router", "wp-project-triage", "wp-abilities-audit", "wp-abilities-api"],
+  "query": "I'm working on a plugin checkout that currently registers zero abilities. Its REST controllers live under `includes/api/` (not the standard `includes/admin/` layout) and extend a post-type-backed base controller for a custom post type with distinct read and write capabilities. Produce a Phase-1 Abilities API audit doc at `~/notes/2026-04-20-abilities-audit-<plugin>.md` so we can hand it to engineering for implementation.",
+  "expected_behavior": [
+    "Step 1: Run wordpress-router to classify the repo, then route to wp-abilities-audit",
+    "Step 2: Run wp-project-triage to populate version signals",
+    "Step 3: Use glob-first/grep-fallback enumeration; fall through to grep because includes/admin glob returns zero hits",
+    "Step 4: Trace post-type-backed capabilities and produce a {read, write} structured capability_gate",
+    "Step 5: Apply semantic-intent grouping per wp-abilities-api/references/grouping-heuristic.md; do NOT atomize one ability per HTTP method",
+    "Step 6: Mark inherited routes with backing.inherited_from and null line numbers per audit-schema.md",
+    "Step 7: Write the audit doc to the user-provided output path, NOT into the plugin worktree",
+    "Step 8: Include at least one entry in surfaced_gaps for a high-leverage zero-arg candidate or a backing: null gap"
+  ],
+  "success_criteria": [
+    "Routes to wp-abilities-audit skill",
+    "Output is a markdown file at the user-specified path with Last updated header, YAML block, and prose sections",
+    "capability_gate uses the structured {read, write} object form",
+    "proposed_abilities has at least 3 entries with at least one read and one write",
+    "surfaced_gaps array has at least one entry",
+    "Controller Inventory table lists every controller grep enumerated",
+    "Notes and Surprises section captures at least one judgment call"
+  ]
+}

--- a/skills/wp-abilities-api/SKILL.md
+++ b/skills/wp-abilities-api/SKILL.md
@@ -53,6 +53,10 @@ For grouping decisions (how many abilities to register, and where to put filters
 
 To avoid drift between the ability and the existing UI / REST code path, see `references/shared-core-service.md` — abilities, REST handlers, CLI commands, and UI controllers should be thin adapters over a shared service. The reference also covers the metric trap (REST handlers that emit usage telemetry) and the `AGENTS.md` rule for keeping registrations in sync when underlying code paths change.
 
+For shared helper patterns when multiple execute callbacks delegate to existing REST controllers, see `references/plugin-family-patterns.md` (pick the shared-API-client vs zero-arg-controllers shape) and `references/delegate-helper-pattern.md` (the canonical helper and when not to use it).
+
+For standardized `WP_Error` codes that let agents reason about retry vs. escalation, see `references/error-code-vocabulary.md`.
+
 Implement the ability in PHP registration with:
 
 - stable `id` (namespaced),
@@ -92,6 +96,8 @@ Use the documented init hooks for Abilities API registration so they load at the
   - wrong REST base/namespace,
   - JS dependency not bundled,
   - caching (object/page caches) masking changes.
+- Execute callback returns unexpected errors or silently ignores input:
+  - `input_schema` defaults aren't being applied, pagination key drift between the ability and the backing, or `empty()`-based ID validation — see `references/input-schema-gotchas.md`.
 
 ## Escalation
 

--- a/skills/wp-abilities-api/SKILL.md
+++ b/skills/wp-abilities-api/SKILL.md
@@ -53,7 +53,7 @@ For grouping decisions (how many abilities to register, and where to put filters
 
 To avoid drift between the ability and the existing UI / REST code path, see `references/shared-core-service.md` — abilities, REST handlers, CLI commands, and UI controllers should be thin adapters over a shared service. The reference also covers the metric trap (REST handlers that emit usage telemetry) and the `AGENTS.md` rule for keeping registrations in sync when underlying code paths change.
 
-For shared helper patterns when multiple execute callbacks delegate to existing REST controllers, see `references/plugin-family-patterns.md` (pick the shared-API-client vs zero-arg-controllers shape) and `references/delegate-helper-pattern.md` (the canonical helper and when not to use it).
+For shared helper patterns when multiple execute callbacks delegate to existing REST controllers, see `references/plugin-family-patterns.md` (identify the shared-API-client vs zero-arg-controllers shape) and `references/delegate-helper-pattern.md` (one helper shape that works, and when not to use it).
 
 For standardized `WP_Error` codes that let agents reason about retry vs. escalation, see `references/error-code-vocabulary.md`.
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -1,0 +1,215 @@
+# Delegate helper pattern
+
+When an ability's execute callback needs to hand work to an existing REST controller instead of duplicating business logic, extract a `delegate_to_rest_controller` helper. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
+
+Read `plugin-family-patterns.md` first — the helper's exact shape depends on whether your plugin follows the shared-API-client pattern or the zero-arg-controllers pattern.
+
+## Why this helper exists
+
+List-style read abilities typically repeat the same four steps in every execute callback:
+
+1. Validate the plugin is initialized (class exists + dependencies resolved).
+2. Build a `WP_REST_Request` and copy the ability's `$input` onto it as params.
+3. Instantiate the backing controller and invoke the named method.
+4. Unwrap the response (controllers return either a raw array or a `WP_REST_Response`).
+
+Four abilities × this repetition = the boilerplate dominates the callback body. Extracting a helper keeps each execute callback a 3–4 line function that reads like pseudocode.
+
+## When to extract
+
+After the **second** list-style ability lands. Before the third ability gets added, refactor the duplicated code out of the first two execute callbacks into a private static helper. Convert subsequent abilities to call the helper as you add them.
+
+If the plugin only ever ships one or two abilities, inline the code. The helper's payoff is at 3+ callers.
+
+## Canonical signature (Pattern A — shared-API-client)
+
+```php
+/**
+ * Delegate an ability's execute callback to a REST controller.
+ *
+ * Builds a WP_REST_Request from the ability's input, instantiates the
+ * backing controller with the plugin's shared API client, invokes the
+ * named method, and normalizes the return so callers always see
+ * array|\WP_Error. Controllers in this plugin return either a
+ * WP_REST_Response or a raw array; the helper unwraps both shapes.
+ *
+ * Not used by zero-arg abilities — those call their controller directly
+ * so we don't synthesize a WP_REST_Request just to discard it.
+ *
+ * @param string     $controller_class Fully-qualified controller class (no leading backslash).
+ * @param string     $method           Controller method to invoke on the built request.
+ * @param string     $route            REST route string used when constructing WP_REST_Request.
+ * @param array|null $input            Ability input; each key/value becomes a request param.
+ * @param string     $http_method      HTTP method for WP_REST_Request. Defaults to 'GET'; writes pass 'POST'.
+ * @return array|\WP_Error             Response payload as an array, or WP_Error on failure.
+ */
+private static function delegate_to_rest_controller(
+    string $controller_class,
+    string $method,
+    string $route,
+    ?array $input,
+    string $http_method = 'GET'
+) {
+    $fqcn = '\\' . $controller_class;
+
+    // Guard 1: controller class is loaded.
+    if ( ! class_exists( $fqcn ) ) {
+        return new \WP_Error(
+            '<plugin>_not_initialized',
+            __( '<Plugin> is not initialized.', '<text-domain>' )
+        );
+    }
+
+    // Guard 2: shared API client is available.
+    $api_client = null;
+    if ( class_exists( '\<Plugin_Main_Class>' ) && method_exists( '\<Plugin_Main_Class>', 'get_<client_accessor>' ) ) {
+        $api_client = \<Plugin_Main_Class>::get_<client_accessor>();
+    }
+    if ( null === $api_client ) {
+        return new \WP_Error(
+            '<plugin>_not_initialized',
+            __( '<Plugin> is not initialized.', '<text-domain>' )
+        );
+    }
+
+    // Build the request.
+    $request = new \WP_REST_Request( $http_method, $route );
+    if ( null !== $input ) {
+        foreach ( $input as $param => $value ) {
+            $request->set_param( $param, $value );
+        }
+    }
+
+    // Invoke + guard 3: WP_Error short-circuit + dual-shape unwrap.
+    $controller = new $fqcn( $api_client );
+    $response   = $controller->{$method}( $request );
+
+    if ( is_wp_error( $response ) ) {
+        return $response;
+    }
+    if ( $response instanceof \WP_REST_Response ) {
+        $data = $response->get_data();
+        return is_array( $data ) ? $data : [];
+    }
+    return is_array( $response ) ? $response : [];
+}
+```
+
+Positional (not named) arguments on purpose — the helper is called from every list ability and keyword-args for PHP 8 would add visual noise. Order is intentional: controller, method, route, input, http_method (the defaultable tail).
+
+## The three guards
+
+### 1. `class_exists` on the controller
+
+Execute callbacks can be reached on sites where the plugin's classes haven't loaded (tests, WP-CLI with limited bootstrap, admin pages with conditional autoloading). Check is cheap; without it a missing class produces a fatal.
+
+Note `'\\' . $controller_class` — accept controller class names without a leading backslash (readable in config arrays) and re-add it so `class_exists` and `new $fqcn(...)` both root-resolve.
+
+### 2. Required dependency (API client) null-check
+
+For Pattern A plugins the accessor is a `public static` method on the main plugin class. Both `class_exists` on the plugin class AND `method_exists` on the accessor are guarded because either could be absent during partial bootstraps. A null return from the accessor is also treated as "not initialized".
+
+Missing this argument produces `ArgumentCountError: Too few arguments to function <Controller>::__construct(), 0 passed` — a PHP fatal. The standardized `<plugin>_not_initialized` error code is documented in `error-code-vocabulary.md`.
+
+For Pattern B plugins, this guard is either skipped entirely (zero-arg constructor) or replaced with construction-time scalar args passed in via an optional `constructor_args` parameter.
+
+### 3. `is_wp_error` short-circuit
+
+Before trying to unwrap the response, check if it's already a `WP_Error`. Several controllers return `WP_Error` for both validation failures and upstream failures; that error needs to bubble up intact so the agent can see the upstream code.
+
+## Dual response-shape unwrap
+
+```php
+if ( $response instanceof \WP_REST_Response ) {
+    $data = $response->get_data();
+    return is_array( $data ) ? $data : [];
+}
+return is_array( $response ) ? $response : [];
+```
+
+Real WordPress REST controllers return either:
+- A `WP_REST_Response` (the output of `rest_ensure_response( ... )` or `new WP_REST_Response( ... )`), or
+- A raw array (typical when a controller delegates to an internal request-handler class that returns the decoded transport payload directly).
+
+Both happen. The helper unwraps `WP_REST_Response` via `get_data()` and passes raw arrays through. The `is_array(...) ? ... : []` coalesce defends against a non-array return type that the ability's `output_schema` would have rejected downstream anyway — returning `[]` fails safely rather than leaking a surprising type.
+
+## When NOT to use the helper
+
+Two categories of abilities bypass the helper and call the backing directly:
+
+### Zero-arg backing methods
+
+If the backing method takes no `WP_REST_Request` parameter, don't synthesize a request just to discard it. Call the method directly:
+
+```php
+public static function execute_get_overview( $input = null ) {
+    if ( ! class_exists( '\My_Plugin_REST_Overview_Controller' ) ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+
+    $api_client = /* ... same accessor check ... */;
+    if ( null === $api_client ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+
+    $controller = new \My_Plugin_REST_Overview_Controller( $api_client );
+    $response   = $controller->get_overview(); // No $request argument.
+
+    if ( is_wp_error( $response ) ) {
+        return $response;
+    }
+    return is_array( $response ) ? $response : [];
+}
+```
+
+### Abilities that use a non-REST service
+
+If the execute callback reaches a service directly (e.g. `My_Plugin::get_account_service()->get_cached_account_data()`) rather than a REST controller, stay on the direct path. The ability is not REST-backed and the helper would add a construction step for no gain.
+
+## Rule of thumb
+
+**If the backing method's signature includes `WP_REST_Request`, use the helper. Otherwise direct-path.**
+
+## Conversion pattern — before and after
+
+Before extraction (inline in the execute callback):
+
+```php
+public static function execute_get_things( $input = null ) {
+    if ( ! class_exists( '\My_Plugin_REST_Things_Controller' ) ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+    $api_client = \My_Plugin::get_api_client();
+    if ( ! $api_client ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+    $request = new \WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+    foreach ( (array) $input as $param => $value ) {
+        $request->set_param( $param, $value );
+    }
+    $controller = new \My_Plugin_REST_Things_Controller( $api_client );
+    $response   = $controller->get_things( $request );
+    // ... unwrap ...
+}
+```
+
+After extraction:
+
+```php
+public static function execute_get_things( $input = null ) {
+    return self::delegate_to_rest_controller(
+        'My_Plugin_REST_Things_Controller',
+        'get_things',
+        '/my-plugin/v1/things',
+        is_array( $input ) ? $input : null
+    );
+}
+```
+
+Note the `is_array( $input ) ? $input : null` — the helper signature is `?array`, and passing `null` tells it to build the request with no params at all. This matters because the Abilities API sometimes invokes a callback with no input object.
+
+## Related references
+
+- `plugin-family-patterns.md` — choosing the helper's constructor shape.
+- `error-code-vocabulary.md` — the `<plugin>_not_initialized` code and its siblings.
+- `input-schema-gotchas.md` — callbacks for list abilities often need `per_page` pagination translation BEFORE calling the helper.

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -1,8 +1,8 @@
 # Delegate helper pattern
 
-Once you've decided delegation is the right shape for an ability — that is, the backing REST controller is a pure data-fetch, the operation is a read, and the ability runs predominantly inside REST contexts (see `shared-core-service.md` for when the answer is "no, extract a shared service" instead) — extract a `delegate_to_rest_controller` helper rather than open-coding the request-build/dispatch/unwrap pipeline in each execute callback. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
+Once you've decided delegation is the right shape for an ability — that is, the backing REST controller is a pure data-fetch, the operation is a read, and the ability runs predominantly inside REST contexts (see `shared-core-service.md` for when the answer is "no, extract a shared service" instead) — extract a `delegate_to_rest_controller` helper rather than open-coding the request-build/dispatch/unwrap pipeline in each execute callback. This reference documents one helper shape that works, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all. Adapt the exact signature to the plugin you're working in — the guards and unwrap matter more than the parameter list.
 
-Read `plugin-family-patterns.md` first — the helper's exact shape depends on whether your plugin follows the shared-API-client pattern or the zero-arg-controllers pattern.
+Read `plugin-family-patterns.md` first — the helper's exact shape depends on how the backing controller is constructed (shared API client vs. zero-arg).
 
 ## Why this helper exists
 
@@ -21,7 +21,7 @@ After the **second** list-style ability lands. Before the third ability gets add
 
 If the plugin only ever ships one or two abilities, inline the code. The helper's payoff is at 3+ callers.
 
-## Canonical signature (Pattern A — shared-API-client)
+## Helper shape
 
 ```php
 /**
@@ -107,11 +107,11 @@ Note `'\\' . $controller_class` — accept controller class names without a lead
 
 ### 2. Required dependency (API client) null-check
 
-For Pattern A plugins the accessor is a `public static` method on the main plugin class. Both `class_exists` on the plugin class AND `method_exists` on the accessor are guarded because either could be absent during partial bootstraps. A null return from the accessor is also treated as "not initialized".
+When the controller takes a shared API client as a constructor argument, the accessor is typically a `public static` method on the main plugin class. Guard both `class_exists` on the plugin class AND `method_exists` on the accessor because either could be absent during partial bootstraps. Treat a null return from the accessor as "not initialized".
 
 Missing this argument produces `ArgumentCountError: Too few arguments to function <Controller>::__construct(), 0 passed` — a PHP fatal. The standardized `<plugin>_not_initialized` error code is documented in `error-code-vocabulary.md`.
 
-For Pattern B plugins, this guard is either skipped entirely (zero-arg constructor) or replaced with construction-time scalar args passed in via an optional `constructor_args` parameter.
+When the controller takes no constructor args, skip this guard entirely. When it takes only simple scalars (e.g. a post-type string), pass them in via an optional `constructor_args` parameter on the helper.
 
 ### 3. `is_wp_error` short-circuit
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -1,6 +1,6 @@
 # Delegate helper pattern
 
-When an ability's execute callback needs to hand work to an existing REST controller instead of duplicating business logic, extract a `delegate_to_rest_controller` helper. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
+Once you've decided delegation is the right shape for an ability — that is, the backing REST controller is a pure data-fetch, the operation is a read, and the ability runs predominantly inside REST contexts (see `shared-core-service.md` for when the answer is "no, extract a shared service" instead) — extract a `delegate_to_rest_controller` helper rather than open-coding the request-build/dispatch/unwrap pipeline in each execute callback. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
 
 Read `plugin-family-patterns.md` first — the helper's exact shape depends on whether your plugin follows the shared-API-client pattern or the zero-arg-controllers pattern.
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -135,7 +135,33 @@ Both happen. The helper unwraps `WP_REST_Response` via `get_data()` and passes r
 
 ## When NOT to use the helper
 
-Two categories of abilities bypass the helper and call the backing directly:
+Three categories of abilities bypass the helper and call the backing directly:
+
+### Backing request class can be invoked without the controller
+
+If the REST controller's only role is to translate `WP_REST_Request` into a call to an underlying request class (e.g., `Things_Request::from_rest_request( $request )->execute()`) and adds no validation, permission logic, or orchestration on top, bypass the controller and call the request class directly:
+
+```php
+public static function execute_get_things( $input = null ) {
+    if ( ! class_exists( '\My_Plugin\Things_Request' ) ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+
+    $request = new \WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+    foreach ( (array) $input as $param => $value ) {
+        $request->set_param( $param, $value );
+    }
+
+    $things_request = \My_Plugin\Things_Request::from_rest_request( $request );
+    $rows           = $things_request->execute();
+
+    return is_array( $rows ) ? $rows : [];
+}
+```
+
+The `WP_REST_Request` object exists only to satisfy `from_rest_request()`'s parameter contract — nothing dispatches it. This is the shortest path through the layers: no controller construction, no controller-emitted side effects, and (when the request class is hit before any REST traffic in the lifecycle) no `rest_api_init` cost. See `shared-core-service.md` for the broader discussion of REST-path side effects and the first-call bootstrap cost on cold paths.
+
+The tradeoff is real: bypassing the controller bypasses anything the controller does. If the controller runs validation that the request class doesn't, or emits an audit hook the request class doesn't, that work is lost on the ability path. Use this shape when the controller is genuinely a thin wrapper, not when it's doing work you'd want to keep.
 
 ### Zero-arg backing methods
 
@@ -168,7 +194,7 @@ If the execute callback reaches a service directly (e.g. `My_Plugin::get_account
 
 ## Rule of thumb
 
-**If the backing method's signature includes `WP_REST_Request`, use the helper. Otherwise direct-path.**
+**If the backing method takes `WP_REST_Request` and the controller adds something beyond delegating to an underlying request class (validation, permissions, orchestration, side effects you want to keep), use the helper. If the controller is a thin wrapper over a request class, call the request class directly. Otherwise direct-path.**
 
 ## Conversion pattern — before and after
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -44,11 +44,11 @@ If the plugin only ever ships one or two abilities, inline the code. The helper'
  * @return array|\WP_Error             Response payload as an array, or WP_Error on failure.
  */
 private static function delegate_to_rest_controller(
-    string $controller_class,
-    string $method,
-    string $route,
-    ?array $input,
-    string $http_method = 'GET'
+    $controller_class,
+    $method,
+    $route,
+    $input,
+    $http_method = 'GET'
 ) {
     $fqcn = '\\' . $controller_class;
 

--- a/skills/wp-abilities-api/references/error-code-vocabulary.md
+++ b/skills/wp-abilities-api/references/error-code-vocabulary.md
@@ -1,0 +1,123 @@
+# Error code vocabulary
+
+Every `WP_Error` returned from an ability's execute callback should use a code drawn from this small vocabulary. A consistent vocabulary lets the agent (or the caller in your automation) build retry and recovery logic that matches on codes instead of parsing error messages.
+
+## Why standardized codes matter
+
+Agents that orchestrate multiple abilities need to know: "did this fail because of my input, or because something downstream is unreachable?" The answer drives retry strategy:
+
+- Bootstrap failures → surface to the human, don't retry.
+- Input shape errors → fix the input and retry the same call.
+- Transient backend errors → retry with backoff; may succeed on its own.
+- Upstream third-party errors → may need a different strategy entirely.
+
+Without a convention, every plugin invents its own codes and agents can't reason uniformly across them. The categories below cover 95% of real-world ability errors; sticking to them means an agent that learned the retry logic for one plugin can reuse it for the next.
+
+## Vocabulary
+
+Substitute `<plugin>` with the plugin's slug in lowercase, underscores only (e.g. `woopayments`, `jetpack_forms`). This matches WordPress error-code conventions. If the plugin already has a house style for error codes (WooPayments uses `woopayments`, not `woo_payments`), mirror that — consistency within a plugin trumps consistency across the vocabulary.
+
+| Code | When to use | Agent behavior |
+|---|---|---|
+| `<plugin>_not_initialized` | Plugin class missing, shared service accessor returns null, required dependency isn't resolvable. | Not retriable from the agent side. Usually a config or bootstrap-ordering problem. Escalate. |
+| `<plugin>_missing_<field>` | A required input field is missing or empty (your execute callback's own check, not the schema-validator's). | Agent should add the field and retry. |
+| `<plugin>_invalid_<field>` | Field is present but semantically wrong (bad enum value, malformed date, wrong type). | Agent should correct the value and retry. |
+| `<plugin>_<resource>_data_unavailable` | Backing service returned a transient error (cache miss + remote failure, upstream 5xx, stale-while-revalidate failed). | Agent can retry, probably with backoff. |
+| `ability_invalid_input` | The Abilities API's own schema-validator rejected the input before the execute callback ran. | Equivalent to `<plugin>_missing_<field>` or `<plugin>_invalid_<field>`, just thrown earlier in the pipeline. Agent should fix input. |
+
+### `ability_invalid_input` — the earlier path
+
+When an ability is invoked via the Abilities API REST bridge, the registered `input_schema` runs first. Missing required fields or type mismatches produce `WP_Error( 'ability_invalid_input' )` BEFORE the execute callback fires. Direct invocation (unit tests, non-REST wrappers) bypasses schema validation and hits your execute callback's own checks instead, producing `<plugin>_missing_<field>` / `<plugin>_invalid_<field>`.
+
+Both paths are acceptable — end-agent-facing behavior is equivalent (deterministic validation error, no side effects). Document the observation in the ability's PR description or "notes for reviewers" so reviewers know both codes are expected in different harness runs.
+
+## Worked examples
+
+```php
+// Bootstrap incomplete — plugin class missing or accessor returned null.
+return new \WP_Error(
+    '<plugin>_not_initialized',
+    __( '<Plugin> is not initialized.', '<text-domain>' )
+);
+
+// Required field missing (execute-callback check, schema was bypassed).
+return new \WP_Error(
+    '<plugin>_missing_<field>',
+    __( 'A <field> is required to <do the thing>.', '<text-domain>' )
+);
+
+// Field present but malformed.
+return new \WP_Error(
+    '<plugin>_invalid_<field>',
+    sprintf(
+        /* translators: %s: input parameter name. */
+        __( 'The "%s" parameter must be an ISO 8601 date-time string.', '<text-domain>' ),
+        $key
+    )
+);
+
+// Transient backend error.
+return new \WP_Error(
+    '<plugin>_<resource>_data_unavailable',
+    __( 'Unable to retrieve <resource> data. The cache may be stale or the remote service returned an error.', '<text-domain>' )
+);
+```
+
+## Upstream codes can bubble through — and usually should
+
+If the backing controller talks to a third-party API (Stripe, WPCOM, another SaaS), its own error codes may surface verbatim in `WP_Error::get_error_code()` the ability returns. Typical examples:
+
+- `resource_missing` — Stripe's "object ID not found" code. Tells an agent the specific ID was wrong.
+- `rate_limited` — upstream throttling. Tells an agent to slow down.
+
+**Let these through rather than re-wrapping.** A re-wrapped `<plugin>_<resource>_not_found` loses the information that would help the agent act. Document the upstream codes you've observed in the ability's `description` or PR notes so reviewers know they're expected.
+
+## Code naming rules
+
+1. **Lowercase, underscores only.** `<plugin>_missing_order_id`, not `<plugin>-missingOrderId` or `<Plugin>-MissingOrderId`.
+2. **Plugin prefix first.** Multi-word slugs should normalize to a single-word prefix where the plugin already does (e.g. `woopayments` rather than `woo_payments`).
+3. **Action second.** Use one of `missing`, `invalid`, `not_initialized`, `<resource>_data_unavailable`.
+4. **Field or resource name last.** `<plugin>_missing_dispute_id`, not `<plugin>_dispute_id_missing`. This matches English phrasing ("a dispute_id is required") and is faster to skim in error logs.
+
+## Internationalization
+
+Error MESSAGES are translatable via `__()` or `sprintf(__())`. Error CODES are not — they're stable machine identifiers.
+
+```php
+// WRONG — don't translate the code.
+return new \WP_Error( __( '<plugin>_missing_order_id', '<text-domain>' ), ... );
+
+// RIGHT — code is a literal, message is translatable.
+return new \WP_Error(
+    '<plugin>_missing_order_id',
+    __( 'An order_id is required.', '<text-domain>' )
+);
+```
+
+When a message interpolates a parameter name or value, include a translator comment:
+
+```php
+return new \WP_Error(
+    '<plugin>_invalid_date',
+    sprintf(
+        /* translators: %s: input parameter name. */
+        __( 'The "%s" parameter must be an ISO 8601 date-time string.', '<text-domain>' ),
+        $key
+    )
+);
+```
+
+## Don't over-specify
+
+The goal is consistent codes across all of a plugin's abilities, not ultra-fine granularity. `<plugin>_missing_dispute_id` is the right level. `<plugin>_missing_dispute_id_in_submit_evidence_context` is not — the ability name belongs in `WP_Error::get_error_data()` or in the agent's calling context, not in the code.
+
+## Summary — the four questions
+
+When writing an execute callback, ask in order:
+
+1. Can the plugin even service this call? → `<plugin>_not_initialized`.
+2. Is the required input present? → `<plugin>_missing_<field>`.
+3. Is the required input the right shape? → `<plugin>_invalid_<field>`.
+4. Did the backing service choke? → `<plugin>_<resource>_data_unavailable`, or let the upstream code bubble through.
+
+Four categories, one consistent code vocabulary per plugin. That's enough for agents to build reliable retry logic on top.

--- a/skills/wp-abilities-api/references/error-code-vocabulary.md
+++ b/skills/wp-abilities-api/references/error-code-vocabulary.md
@@ -15,7 +15,7 @@ Without a convention, every plugin invents its own codes and agents can't reason
 
 ## Vocabulary
 
-Substitute `<plugin>` with the plugin's slug in lowercase, underscores only (e.g. `woopayments`, `jetpack_forms`). This matches WordPress error-code conventions. If the plugin already has a house style for error codes (WooPayments uses `woopayments`, not `woo_payments`), mirror that — consistency within a plugin trumps consistency across the vocabulary.
+Substitute `<plugin>` with the plugin's slug in lowercase, underscores only. This matches WordPress error-code conventions. If the plugin already has a house style — for example, a single-word slug that deliberately omits underscores between elided words — mirror that. Consistency within a plugin trumps consistency across the vocabulary.
 
 | Code | When to use | Agent behavior |
 |---|---|---|

--- a/skills/wp-abilities-api/references/input-schema-gotchas.md
+++ b/skills/wp-abilities-api/references/input-schema-gotchas.md
@@ -1,0 +1,221 @@
+# Input schema gotchas
+
+Three surprises the Abilities API's `input_schema` will ship with if you rely on schema declarations alone. All three have been caught in real plugin work after the schema looked correct and tests passed; each has a defensive pattern that makes the execute callback robust regardless.
+
+## 1. Schema `default` values are NOT injected into execute callback input
+
+### Problem
+
+`wp_register_ability()` lets you declare per-property defaults in `input_schema`:
+
+```php
+'input_schema' => [
+    'type'       => 'object',
+    'properties' => [
+        'submit' => [
+            'type'        => 'boolean',
+            'default'     => false,
+            'description' => __( 'Whether to submit evidence for review.', '<text-domain>' ),
+        ],
+    ],
+],
+```
+
+The Abilities API's validate path enforces `type` and `required`, but it does NOT populate missing properties with their declared `default`. If an agent invokes the ability with `{ dispute_id: "dp_..." }` and omits `submit`, the execute callback receives `$input` **without** a `submit` key — it does not get `$input['submit'] = false`.
+
+### Symptoms
+
+- Boolean defaults silently become "undefined" in the callback and any `if ( $input['submit'] )` check compares against `null`, which works by accident but fails `isset` checks and strict-type branches.
+- Integer pagination defaults like `'page' => [ 'default' => 1 ]` never reach the backing controller, so pagination falls back to the controller's internal default rather than the one declared in the schema.
+- Object defaults (`'metadata' => [ 'default' => [] ]`) become `null` rather than `[]` and any `foreach ( $input['metadata'] as ... )` hits a type error.
+
+### Fix — normalize defaults explicitly in the execute callback
+
+```php
+public static function execute_submit_evidence( $input = null ) {
+    if ( ! is_array( $input ) ) {
+        $input = [];
+    }
+
+    // Apply schema defaults the Abilities API does not inject.
+    if ( ! array_key_exists( 'submit', $input ) || null === $input['submit'] ) {
+        $input['submit'] = false;
+    }
+    $input['submit'] = (bool) $input['submit'];
+
+    if ( ! array_key_exists( 'metadata', $input ) || null === $input['metadata'] ) {
+        $input['metadata'] = [];
+    }
+
+    // ... rest of callback
+}
+```
+
+The `array_key_exists` + null-check pattern catches both "missing key" and "explicit null" (some serializers produce nulls for optional fields).
+
+Keep the declared `default` in `input_schema` anyway — it documents the expected behavior for anyone reading the registration and is visible to agents in the schema introspection endpoints. Just don't rely on it for runtime population.
+
+## 2. Pagination parameter-name drift
+
+### Problem
+
+The `input_schema` convention across most WordPress REST endpoints is `per_page` (matching WP core REST list endpoints and `WP_REST_Controller`'s `get_collection_params()`). Some plugin REST controllers, however, delegate to an internal request-builder class that reads a different key (e.g. `pagesize` or `page_size`), typically for historical reasons.
+
+If the ability's `input_schema` exposes `per_page` and the backing controller reads `pagesize`, the agent's `per_page: 50` silently never reaches pagination — the value is accepted, forwarded verbatim to the backing, and then ignored. Agents keep getting the default page size and suspect their filter is broken.
+
+### Symptoms
+
+- List abilities return the backing controller's default page size regardless of the agent's `per_page` input.
+- Integration tests that only check "a list came back" pass; only a test asserting `count( $response['data'] )` catches it.
+- Harness runs show the raw response count matching the default (25, 10, etc.) for every call.
+
+### Detection heuristic
+
+Before shipping a paginated ability, grep the backing controller's call chain:
+
+```bash
+# Check the backing controller and anything it delegates to.
+grep -rn "pagesize\|page_size" <path/to/backing-controller.php> <path/to/request-helpers/>
+```
+
+If `pagesize` (or any non-`per_page` key) appears in the chain and the ability's schema exposes `per_page`, the execute callback MUST translate.
+
+### Fix — translate before delegating
+
+```php
+/**
+ * Translate pagination keys for abilities whose backing reads a non-standard key.
+ *
+ * Abilities expose `per_page` uniformly for agent-facing consistency; this
+ * helper rewrites it to whatever key the backing actually reads.
+ *
+ * @param array|null $input Ability input (or null).
+ * @return array|null       Input with `per_page` rewritten to `<backing_key>` when present.
+ */
+private static function translate_pagination_keys( $input ) {
+    if ( ! is_array( $input ) ) {
+        return $input;
+    }
+    if ( isset( $input['per_page'] ) ) {
+        $input['<backing_key>'] = $input['per_page'];
+        unset( $input['per_page'] );
+    }
+    return $input;
+}
+
+public static function execute_get_things( $input = null ) {
+    $input = self::translate_pagination_keys( is_array( $input ) ? $input : null );
+
+    return self::delegate_to_rest_controller(
+        '<Backing_Controller_Class>',
+        'get_things',
+        '/my-plugin/v1/things',
+        $input
+    );
+}
+```
+
+Place the translation BEFORE the delegate call so `per_page` never reaches the backing.
+
+### When NOT to apply this
+
+Do not apply blindly. If the backing reads `per_page` directly (most modern WP REST controllers do), adding this translation would silently break pagination by renaming the key to something the backing doesn't understand.
+
+**Always grep the backing first.** The translation is only correct for a specific backing chain; it's not a general safety net.
+
+## 3. ID validation must not use `empty()`
+
+### Problem
+
+PHP's `empty()` is permissive in ways that bite ID validation:
+
+```php
+empty( '0' )   // true  — but "0" is a legal string ID (order ID, row ID, post ID in some code paths)
+empty( 0 )     // true  — same for integer zero
+empty( [] )    // true  — expected, but same keyword used for different cases
+```
+
+An execute callback that guards required IDs with `empty( $input['order_id'] )` will false-reject a legitimate `"0"` and return a "missing" error for input that's actually present. The agent retries with the same input, gets the same error, and the call is stuck.
+
+### Symptoms
+
+- Abilities reject specific IDs ending in zero or consisting of zero.
+- Unit tests written with non-zero IDs pass; a regression lands the day an agent tries a real zero-ID.
+- `WP_Error( '<plugin>_missing_<field>' )` fires for input the schema validator would have accepted.
+
+### Fix — three explicit checks
+
+```php
+if ( ! isset( $input['order_id'] )
+    || ! is_string( $input['order_id'] )
+    || '' === $input['order_id']
+) {
+    return new \WP_Error(
+        '<plugin>_missing_order_id',
+        __( 'An order_id is required to fetch order detail.', '<text-domain>' )
+    );
+}
+```
+
+Three separate checks, each non-redundant:
+
+1. `! isset( ... )` — the key is present on the array.
+2. `! is_string( ... )` — type is right. (For integer IDs, use `is_int` + non-negative check instead.) Without this, a caller that passes `123` (integer) where the schema documents a string would fall through to a later step that does `rawurlencode( $input['order_id'] )` and produces a cryptic coercion error rather than a clean missing-field response.
+3. `'' === $input[ ... ]` — non-empty in the strict sense. Rejects empty string only; accepts `"0"` as a legal value.
+
+Use the standardized `<plugin>_missing_<field>` error code (see `error-code-vocabulary.md`) for this case.
+
+### Add a regression-guard unit test
+
+The guard is load-bearing enough that it deserves an explicit test — otherwise someone will simplify it back to `empty()` in a future refactor:
+
+```php
+public function test_execute_returns_wp_error_when_id_not_a_string(): void {
+    $result = My_Plugin_Abilities::execute_get_thing( [ 'order_id' => 123 ] );
+    $this->assertInstanceOf( \WP_Error::class, $result );
+    $this->assertSame( '<plugin>_missing_order_id', $result->get_error_code() );
+}
+```
+
+The integer `123` is a fine canary — it's non-empty, it `isset`s, but it's not a string. A callback that only uses `isset` + `empty` would false-pass this input and fall through to the URL construction with an integer argument.
+
+## Putting the three together
+
+A hardened execute callback for a list-style ability with a required ID, schema defaults, and backing pagination drift:
+
+```php
+public static function execute_get_thing_details( $input = null ) {
+    if ( ! is_array( $input ) ) {
+        $input = [];
+    }
+
+    // Gotcha 3: required-ID validation (not empty()).
+    if ( ! isset( $input['thing_id'] )
+        || ! is_string( $input['thing_id'] )
+        || '' === $input['thing_id']
+    ) {
+        return new \WP_Error(
+            '<plugin>_missing_thing_id',
+            __( 'A thing_id is required.', '<text-domain>' )
+        );
+    }
+
+    // Gotcha 1: apply defaults the Abilities API doesn't inject.
+    if ( ! array_key_exists( 'include_history', $input ) || null === $input['include_history'] ) {
+        $input['include_history'] = false;
+    }
+    $input['include_history'] = (bool) $input['include_history'];
+
+    // Gotcha 2: translate pagination before delegating (only if backing reads a non-standard key).
+    $input = self::translate_pagination_keys( $input );
+
+    return self::delegate_to_rest_controller(
+        '<Backing_Controller_Class>',
+        'get_thing',
+        '/my-plugin/v1/things/' . rawurlencode( $input['thing_id'] ),
+        $input
+    );
+}
+```
+
+Each of the three lines the callback adds on top of the "just delegate" pattern has a paid-for bug behind it. Keep them.

--- a/skills/wp-abilities-api/references/input-schema-gotchas.md
+++ b/skills/wp-abilities-api/references/input-schema-gotchas.md
@@ -179,7 +179,51 @@ public function test_execute_returns_wp_error_when_id_not_a_string(): void {
 
 The integer `123` is a fine canary — it's non-empty, it `isset`s, but it's not a string. A callback that only uses `isset` + `empty` would false-pass this input and fall through to the URL construction with an integer argument.
 
-## Putting the three together
+## 4. Direct vs indirect invocation differ in strictness
+
+### Problem
+
+Two ways exist to invoke an ability's `execute_callback`:
+
+- **Direct.** A caller imports the registrar and calls the static method (`Abilities_Registrar::execute_get_things( $input )`). PHP signature defaults apply; no schema validation runs.
+- **Indirect.** A caller resolves the ability through `wp_get_ability( '<id>' )->execute( $input )`. WordPress runs `WP_Ability::normalize_input()` then `validate_input()` (then `check_permissions()`) before the callback is invoked.
+
+The two paths differ in three ways agents trip over:
+
+1. **Validation against `input_schema` runs only on the indirect path.** If the ability declares an object-typed schema with properties and the indirect caller passes `null` (or omits the argument entirely, as `$ability->execute()` does), `validate_input()` rejects with an `ability_invalid_input` error before the callback runs. The PHP-level `$input = null` default in the callback signature is dead code on this path.
+
+2. **Schema's top-level `default` IS applied — but only on the indirect path.** `normalize_input()` substitutes the schema's top-level `default` when the caller passes `null`. Direct callers don't run through this method; they get whatever PHP default the callback signature declares. Declaring `default => (object) array()` at the schema root makes `$ability->execute()` work without arguments — but the same callback called directly still receives PHP `null`.
+
+3. **The callback's first argument arrives only when `input_schema` is non-empty.** WordPress only forwards `$input` to the callback when the schema is declared. Without an input schema, the callback is invoked with zero arguments — PHP-level signature defaults compensate for this if you wrote them; without them, the indirect path produces an `ArgumentCountError`.
+
+### Symptoms
+
+- An ability looks fine when unit-tested by directly invoking the static method, then fails the moment it's exercised through `wp_get_ability(...)->execute()` from MCP / Command Palette / agent harnesses.
+- "Works in the test, breaks in MCP" — typical pattern when a test calls `Abilities_Registrar::execute_get_things( [] )` (passing an empty array) but the agent invocation goes through the indirect pipeline.
+- A schema with all-optional properties still rejects zero-arg indirect calls because `null` is not an object.
+
+### Fix — declare a top-level schema `default` for any zero-arg-allowed ability
+
+```php
+'input_schema' => [
+    'type'       => 'object',
+    'default'    => (object) array(),  // applied by normalize_input() on null inputs
+    'properties' => [
+        'per_page' => [ 'type' => 'integer', 'default' => 10 ],
+        // ...
+    ],
+],
+```
+
+`(object) array()` is preferred over `[]` because it json-encodes to `{}` rather than the array literal `[]`, avoiding PHP's array/object ambiguity at the validator boundary.
+
+### Distinguish from Gotcha 1
+
+Top-level schema `default` is honored by `normalize_input()` and reaches the callback. Property-level `default` (Gotcha 1) is NOT — those values are dropped by the validator, and the callback has to defensively reapply them. Different layers, different fates.
+
+If you've declared the top-level `default` in the schema, the PHP-level signature default exists only for direct callers. Don't add a third layer of fallback inside the callback that re-checks `if ( $input === null )` — three compensating defaults stacked on each other diffuses the meaning of "no input."
+
+## Putting gotchas 1-3 together
 
 A hardened execute callback for a list-style ability with a required ID, schema defaults, and backing pagination drift:
 

--- a/skills/wp-abilities-api/references/input-schema-gotchas.md
+++ b/skills/wp-abilities-api/references/input-schema-gotchas.md
@@ -170,7 +170,7 @@ Use the standardized `<plugin>_missing_<field>` error code (see `error-code-voca
 The guard is load-bearing enough that it deserves an explicit test — otherwise someone will simplify it back to `empty()` in a future refactor:
 
 ```php
-public function test_execute_returns_wp_error_when_id_not_a_string(): void {
+public function test_execute_returns_wp_error_when_id_not_a_string() {
     $result = My_Plugin_Abilities::execute_get_thing( [ 'order_id' => 123 ] );
     $this->assertInstanceOf( \WP_Error::class, $result );
     $this->assertSame( '<plugin>_missing_order_id', $result->get_error_code() );

--- a/skills/wp-abilities-api/references/plugin-family-patterns.md
+++ b/skills/wp-abilities-api/references/plugin-family-patterns.md
@@ -1,12 +1,12 @@
 # Plugin-family patterns
 
-This reference covers shared implementation *mechanics* — the call-shape pattern your execute callbacks follow when handing work to existing business logic. Two patterns cover most real-world WordPress plugins; pick one up front, because the choice ripples through your delegate helper, your tests, and your error codes.
+This reference covers shared implementation *mechanics* — the call shape your execute callbacks follow when handing work to existing business logic. Two shapes are common enough across real-world WordPress plugins to be worth naming; which one fits is determined by how the backing controller is constructed, not by a choice you make up front. The choice still ripples through your delegate helper, your tests, and your error codes, so it's worth confirming early.
 
 Family-specific *registration* conventions — loader path, ability category, MCP exposure defaults, error-code prefix house style — live in separate plugin-family overlays (for example, a WooCommerce-extension overlay), not in this reference. Apply any relevant overlay before scaffolding registration. The patterns below should stay portable: they describe how the execute callback talks to backing code, not what the registration metadata should look like for your plugin family.
 
-There is also a third option that sits *outside* this dichotomy. If the operation does not yet have a shared service class — or if you can refactor toward one — extracting a service that the ability, the REST controller, and the UI all consume is the default per `shared-core-service.md`. Delegation through an existing REST controller (Patterns A and B below) is a conditional shortcut for low-stakes reads, not the starting point. Confirm the shape is right before you reach for either pattern.
+There is also a third option that sits *outside* this dichotomy. If the operation does not yet have a shared service class — or if you can refactor toward one — extracting a service that the ability, the REST controller, and the UI all consume is the default per `shared-core-service.md`. Delegation through an existing REST controller (either shape below) is a conditional shortcut for low-stakes reads, not the starting point. Confirm the shape is right before you reach for either.
 
-## Pattern A — Shared API client
+## Shape: shared API client
 
 Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an upstream API). The plugin bootstraps a single API client, exposes it via a static accessor on a main plugin class, and every REST controller takes that client as a constructor argument.
 
@@ -17,7 +17,7 @@ Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an 
 grep -n "public function __construct" <path/to/rest-controller.php>
 ```
 
-If the constructor takes a required typed argument (e.g. `My_Plugin_API_Client $api_client`), you're in Pattern A. Confirm the plugin has a central accessor:
+If the constructor takes a required typed argument (e.g. `My_Plugin_API_Client $api_client`), you're in the shared-API-client shape. Confirm the plugin has a central accessor:
 
 ```bash
 grep -rn "get_api_client\|get_.*_api_client\|get_service" <path/to/plugin/main-class.php>
@@ -73,7 +73,7 @@ class Abilities_Registrar {
             return new \WP_Error( 'my_plugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
         }
 
-        // Pattern A specifics: fetch the shared API client and null-check.
+        // Shape specifics: fetch the shared API client and null-check.
         $api_client = null;
         if ( class_exists( '\My_Plugin' ) && method_exists( '\My_Plugin', 'get_api_client' ) ) {
             $api_client = \My_Plugin::get_api_client();
@@ -112,7 +112,7 @@ class Abilities_Registrar {
 
 Worked example: a plugin that talks to an external SaaS or upstream HTTP service typically follows this pattern. The plugin's main class exposes the API client via a static accessor (e.g. `Plugin_Main::get_api_client()`); REST controllers extend a base class whose constructor takes that client as a typed argument; the abilities registrar pulls the client through the same accessor before constructing controllers.
 
-## Pattern B — Zero-arg controllers
+## Shape: zero-arg controllers
 
 Common in plugins/packages that delegate primarily to WordPress core mechanisms (custom post types, options, meta) and don't maintain a single shared API client. Controllers instantiate cleanly without a dependency graph.
 
@@ -122,9 +122,9 @@ Common in plugins/packages that delegate primarily to WordPress core mechanisms 
 grep -n "public function __construct" <path/to/rest-controller.php>
 ```
 
-If the constructor takes no required arguments, or takes only simple scalars you can hardcode at the ability call site (e.g. a post-type string), you're in Pattern B.
+If the constructor takes no required arguments, or takes only simple scalars you can hardcode at the ability call site (e.g. a post-type string), you're in the zero-arg shape.
 
-Also grep the plugin's main bootstrap class for the absence of a singleton API accessor — if there isn't one, Pattern B is the honest choice.
+Also grep the plugin's main bootstrap class for the absence of a singleton API accessor — if there isn't one, the zero-arg shape is the honest choice.
 
 ### Minimal skeleton
 
@@ -203,7 +203,7 @@ See `delegate-helper-pattern.md` for the full helper signature and guards.
 ### Testing implications
 
 - **No API-client mock needed.** Unit tests instantiate the ability registrar directly and call `execute_*` with input arrays.
-- **Test at the `wp_get_ability()` level when possible.** In Pattern B the backing controller often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
+- **Test at the `wp_get_ability()` level when possible.** With zero-arg controllers the backing often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
 - **The `<plugin>_not_initialized` failure mode is less common.** It still exists — if a package isn't loaded, `class_exists` on the backing controller still fails — but the surface area is smaller.
 
 Worked example: a plugin whose REST controllers wrap a custom post type, taxonomy, option, or meta typically follows this pattern. Each execute callback constructs its controller inline (e.g. `new My_CPT_Endpoint( 'my_cpt' )`), passing whatever scalar (post-type slug, taxonomy name) the controller needs. No shared helper in the registrar; the construction step is small enough to inline.
@@ -212,14 +212,14 @@ Worked example: a plugin whose REST controllers wrap a custom post type, taxonom
 
 A single plugin can legitimately use both patterns across different abilities:
 
-- A Pattern A ability for backing controllers that talk to the upstream service.
-- A Pattern B ability for backing controllers that only touch WP core (e.g. a CPT-based settings endpoint in the same plugin).
+- A shared-API-client ability for backing controllers that talk to the upstream service.
+- A zero-arg ability for backing controllers that only touch WP core (e.g. a CPT-based settings endpoint in the same plugin).
 
-If this happens, the helper in `delegate-helper-pattern.md` can support both via optional `constructor_args` — but resist the temptation to over-engineer until you have at least two Pattern B abilities that would share the helper.
+If this happens, the helper in `delegate-helper-pattern.md` can support both via optional `constructor_args` — but resist the temptation to over-engineer until you have at least two zero-arg abilities that would share the helper.
 
 ## Anti-pattern — inventing an API client where there isn't one
 
-Don't introduce a fake shared API client to fit Pattern A's helper shape. If the plugin is genuinely stateless / CPT-driven, Pattern B's inline construction is the honest answer. The helper is scaffolding that pays back when you have 4+ abilities sharing the build-request → instantiate → unwrap flow; before that, inline code is faster to read and review.
+Don't introduce a fake shared API client to fit the shared-client helper shape. If the plugin is genuinely stateless / CPT-driven, inline construction is the honest answer. The helper is scaffolding that pays back when you have 4+ abilities sharing the build-request → instantiate → unwrap flow; before that, inline code is faster to read and review.
 
 ## Picking quickly
 

--- a/skills/wp-abilities-api/references/plugin-family-patterns.md
+++ b/skills/wp-abilities-api/references/plugin-family-patterns.md
@@ -1,0 +1,229 @@
+# Plugin-family patterns
+
+When you adopt the Abilities API inside an existing plugin, the plugin's architecture dictates HOW your execute callbacks call the existing business logic. Two patterns cover most real-world WordPress plugins. Pick one up front — the choice ripples through your delegate helper, your tests, and your error codes.
+
+## Pattern A — Shared-API-client ("Woo-family")
+
+Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an upstream API). The plugin bootstraps a single API client, exposes it via a static accessor on a main plugin class, and every REST controller takes that client as a constructor argument.
+
+### Detection
+
+```bash
+# Inspect the backing REST controller's __construct signature.
+grep -n "public function __construct" <path/to/rest-controller.php>
+```
+
+If the constructor takes a required typed argument (e.g. `My_Plugin_API_Client $api_client`), you're in Pattern A. Confirm the plugin has a central accessor:
+
+```bash
+grep -rn "get_api_client\|get_.*_api_client\|get_service" <path/to/plugin/main-class.php>
+```
+
+You're looking for a `public static function get_<something>()` that returns the shared client.
+
+### Minimal skeleton
+
+```php
+<?php
+namespace My_Plugin\Abilities;
+
+class Abilities_Registrar {
+
+    const CATEGORY_SLUG = 'my-plugin';
+
+    public static function init() {
+        add_action( 'wp_abilities_api_categories_init', [ __CLASS__, 'register_category' ] );
+        add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+    }
+
+    public static function register_abilities() {
+        wp_register_ability(
+            'my-plugin/get-things',
+            [
+                'label'               => __( 'Get things', 'my-plugin' ),
+                'description'         => __( 'List things with filters.', 'my-plugin' ),
+                'category'            => self::CATEGORY_SLUG,
+                'input_schema'        => [ /* ... */ ],
+                'execute_callback'    => [ __CLASS__, 'execute_get_things' ],
+                'permission_callback' => [ __CLASS__, 'current_user_has_capability' ],
+                'meta'                => [
+                    'annotations'  => [ 'readonly' => true, 'destructive' => false, 'idempotent' => true ],
+                    'show_in_rest' => true,
+                ],
+            ]
+        );
+    }
+
+    public static function execute_get_things( $input = null ) {
+        return self::delegate_to_rest_controller(
+            'My_Plugin_REST_Things_Controller',
+            'get_things',
+            '/my-plugin/v1/things',
+            is_array( $input ) ? $input : null
+        );
+    }
+
+    private static function delegate_to_rest_controller( $controller_class, $method, $route, $input, $http_method = 'GET' ) {
+        $fqcn = '\\' . $controller_class;
+        if ( ! class_exists( $fqcn ) ) {
+            return new \WP_Error( 'my_plugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
+        }
+
+        // Pattern A specifics: fetch the shared API client and null-check.
+        $api_client = null;
+        if ( class_exists( '\My_Plugin' ) && method_exists( '\My_Plugin', 'get_api_client' ) ) {
+            $api_client = \My_Plugin::get_api_client();
+        }
+        if ( null === $api_client ) {
+            return new \WP_Error( 'my_plugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
+        }
+
+        $request = new \WP_REST_Request( $http_method, $route );
+        if ( is_array( $input ) ) {
+            foreach ( $input as $param => $value ) {
+                $request->set_param( $param, $value );
+            }
+        }
+
+        $controller = new $fqcn( $api_client );
+        $response   = $controller->{$method}( $request );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+        if ( $response instanceof \WP_REST_Response ) {
+            $data = $response->get_data();
+            return is_array( $data ) ? $data : [];
+        }
+        return is_array( $response ) ? $response : [];
+    }
+}
+```
+
+### Testing implications
+
+- **Bootstrap test doubles need the API client.** Unit tests that instantiate controllers must provide a mocked or stubbed client; otherwise the constructor fails with `ArgumentCountError: Too few arguments`.
+- **The "not initialized" error path is reachable and must be covered.** One unit test should stub the accessor to return null and assert the ability returns `<plugin>_not_initialized`. This is a common failure during partial bootstraps (WP-CLI with restricted loading, test harnesses, admin pages with conditional autoloading).
+- **Integration tests need real or faked HTTP.** The backing controller will hit the upstream unless the API client is mocked, so integration harnesses typically route through a fake transport.
+
+Worked example: WooPayments' `Abilities_Registrar` uses this pattern. Controllers extend `WC_Payments_REST_Controller`, whose constructor takes a `WC_Payments_API_Client`; the shared client comes from `WC_Payments::get_payments_api_client()`.
+
+## Pattern B — Zero-arg controllers ("Jetpack-family")
+
+Common in plugins/packages that delegate primarily to WordPress core mechanisms (custom post types, options, meta) and don't maintain a single shared API client. Controllers instantiate cleanly without a dependency graph.
+
+### Detection
+
+```bash
+grep -n "public function __construct" <path/to/rest-controller.php>
+```
+
+If the constructor takes no required arguments, or takes only simple scalars you can hardcode at the ability call site (e.g. a post-type string), you're in Pattern B.
+
+Also grep the plugin's main bootstrap class for the absence of a singleton API accessor — if there isn't one, Pattern B is the honest choice.
+
+### Minimal skeleton
+
+```php
+<?php
+namespace My_Plugin\Abilities;
+
+class Abilities_Registrar {
+
+    const CATEGORY_SLUG = 'my-plugin';
+
+    public static function init() {
+        add_action( 'wp_abilities_api_categories_init', [ __CLASS__, 'register_category' ] );
+        add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+    }
+
+    public static function register_abilities() {
+        wp_register_ability(
+            'my-plugin/get-things',
+            [
+                /* ... */
+                'execute_callback' => [ __CLASS__, 'execute_get_things' ],
+                /* ... */
+            ]
+        );
+    }
+
+    public static function execute_get_things( $input = null ) {
+        $input    = is_array( $input ) ? $input : [];
+        $endpoint = new \My_Plugin_Things_Endpoint();
+        $request  = new \WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+
+        foreach ( [ 'page', 'per_page', 'status', 'search' ] as $key ) {
+            if ( isset( $input[ $key ] ) ) {
+                $request->set_param( $key, $input[ $key ] );
+            }
+        }
+
+        $response = $endpoint->get_items( $request );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+        return $response instanceof \WP_REST_Response ? $response->get_data() : $response;
+    }
+}
+```
+
+No helper is required — the construction step is a single line and inlining per callback stays readable. If you do extract a helper, it takes a `constructor_args` parameter because the controller class isn't constant across abilities:
+
+```php
+/**
+ * @param string     $controller_class Fully-qualified controller class.
+ * @param string     $method           Method to invoke on the request.
+ * @param string     $route            REST route used when constructing WP_REST_Request.
+ * @param array|null $input            Ability input (or null).
+ * @param string     $http_method      HTTP method. Defaults to 'GET'.
+ * @param array      $constructor_args Optional scalar args for the controller's constructor.
+ * @return array|\WP_Error
+ */
+private static function delegate_to_rest_controller(
+    $controller_class,
+    $method,
+    $route,
+    $input,
+    $http_method = 'GET',
+    $constructor_args = array()
+) {
+    /* ... */
+}
+```
+
+The phpDoc carries the `array|\WP_Error` return shape; the function signature itself stays untyped on the return so this snippet parses on PHP 7.2+.
+
+See `delegate-helper-pattern.md` for the full helper signature and guards.
+
+### Testing implications
+
+- **No API-client mock needed.** Unit tests instantiate the ability registrar directly and call `execute_*` with input arrays.
+- **Test at the `wp_get_ability()` level when possible.** In Pattern B the backing controller often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
+- **The `<plugin>_not_initialized` failure mode is less common.** It still exists — if a package isn't loaded, `class_exists` on the backing controller still fails — but the surface area is smaller.
+
+Worked example: Jetpack Forms' `Forms_Abilities` class instantiates `Contact_Form_Endpoint( 'feedback' )` per execute callback. No shared helper in the registrar; the construction step is inline. Canonical file: [`Automattic/jetpack/projects/packages/forms/src/abilities/class-forms-abilities.php`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/abilities/class-forms-abilities.php).
+
+## Hybrid cases
+
+A single plugin can legitimately use both patterns across different abilities:
+
+- A Pattern A ability for backing controllers that talk to the upstream service.
+- A Pattern B ability for backing controllers that only touch WP core (e.g. a CPT-based settings endpoint in the same plugin).
+
+If this happens, the helper in `delegate-helper-pattern.md` can support both via optional `constructor_args` — but resist the temptation to over-engineer until you have at least two Pattern B abilities that would share the helper.
+
+## Anti-pattern — inventing an API client where there isn't one
+
+Don't introduce a fake shared API client to fit Pattern A's helper shape. If the plugin is genuinely stateless / CPT-driven, Pattern B's inline construction is the honest answer. The helper is scaffolding that pays back when you have 4+ abilities sharing the build-request → instantiate → unwrap flow; before that, inline code is faster to read and review.
+
+## Picking quickly
+
+| Signal | Likely pattern |
+|---|---|
+| Backing controller's `__construct` takes an API-client-like object | A |
+| Plugin has a `Plugin::get_*_client()` static accessor | A |
+| Plugin talks to an external SaaS / upstream HTTP service | A |
+| Backing controller `__construct` is zero-arg or only takes scalars | B |
+| Backing is a CPT / options / meta wrapper | B |
+| Plugin is a Jetpack-style first-party WordPress package | B |

--- a/skills/wp-abilities-api/references/plugin-family-patterns.md
+++ b/skills/wp-abilities-api/references/plugin-family-patterns.md
@@ -1,8 +1,12 @@
 # Plugin-family patterns
 
-When you adopt the Abilities API inside an existing plugin, the plugin's architecture dictates HOW your execute callbacks call the existing business logic. Two patterns cover most real-world WordPress plugins. Pick one up front — the choice ripples through your delegate helper, your tests, and your error codes.
+This reference covers shared implementation *mechanics* — the call-shape pattern your execute callbacks follow when handing work to existing business logic. Two patterns cover most real-world WordPress plugins; pick one up front, because the choice ripples through your delegate helper, your tests, and your error codes.
 
-## Pattern A — Shared-API-client ("Woo-family")
+Family-specific *registration* conventions — loader path, ability category, MCP exposure defaults, error-code prefix house style — live in separate plugin-family overlays (for example, a WooCommerce-extension overlay), not in this reference. Apply any relevant overlay before scaffolding registration. The patterns below should stay portable: they describe how the execute callback talks to backing code, not what the registration metadata should look like for your plugin family.
+
+There is also a third option that sits *outside* this dichotomy. If the operation does not yet have a shared service class — or if you can refactor toward one — extracting a service that the ability, the REST controller, and the UI all consume is the default per `shared-core-service.md`. Delegation through an existing REST controller (Patterns A and B below) is a conditional shortcut for low-stakes reads, not the starting point. Confirm the shape is right before you reach for either pattern.
+
+## Pattern A — Shared API client
 
 Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an upstream API). The plugin bootstraps a single API client, exposes it via a static accessor on a main plugin class, and every REST controller takes that client as a constructor argument.
 
@@ -106,9 +110,9 @@ class Abilities_Registrar {
 - **The "not initialized" error path is reachable and must be covered.** One unit test should stub the accessor to return null and assert the ability returns `<plugin>_not_initialized`. This is a common failure during partial bootstraps (WP-CLI with restricted loading, test harnesses, admin pages with conditional autoloading).
 - **Integration tests need real or faked HTTP.** The backing controller will hit the upstream unless the API client is mocked, so integration harnesses typically route through a fake transport.
 
-Worked example: WooPayments' `Abilities_Registrar` uses this pattern. Controllers extend `WC_Payments_REST_Controller`, whose constructor takes a `WC_Payments_API_Client`; the shared client comes from `WC_Payments::get_payments_api_client()`.
+Worked example: a plugin that talks to an external SaaS or upstream HTTP service typically follows this pattern. The plugin's main class exposes the API client via a static accessor (e.g. `Plugin_Main::get_api_client()`); REST controllers extend a base class whose constructor takes that client as a typed argument; the abilities registrar pulls the client through the same accessor before constructing controllers.
 
-## Pattern B — Zero-arg controllers ("Jetpack-family")
+## Pattern B — Zero-arg controllers
 
 Common in plugins/packages that delegate primarily to WordPress core mechanisms (custom post types, options, meta) and don't maintain a single shared API client. Controllers instantiate cleanly without a dependency graph.
 
@@ -202,7 +206,7 @@ See `delegate-helper-pattern.md` for the full helper signature and guards.
 - **Test at the `wp_get_ability()` level when possible.** In Pattern B the backing controller often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
 - **The `<plugin>_not_initialized` failure mode is less common.** It still exists — if a package isn't loaded, `class_exists` on the backing controller still fails — but the surface area is smaller.
 
-Worked example: Jetpack Forms' `Forms_Abilities` class instantiates `Contact_Form_Endpoint( 'feedback' )` per execute callback. No shared helper in the registrar; the construction step is inline. Canonical file: [`Automattic/jetpack/projects/packages/forms/src/abilities/class-forms-abilities.php`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/abilities/class-forms-abilities.php).
+Worked example: a plugin whose REST controllers wrap a custom post type, taxonomy, option, or meta typically follows this pattern. Each execute callback constructs its controller inline (e.g. `new My_CPT_Endpoint( 'my_cpt' )`), passing whatever scalar (post-type slug, taxonomy name) the controller needs. No shared helper in the registrar; the construction step is small enough to inline.
 
 ## Hybrid cases
 
@@ -226,4 +230,4 @@ Don't introduce a fake shared API client to fit Pattern A's helper shape. If the
 | Plugin talks to an external SaaS / upstream HTTP service | A |
 | Backing controller `__construct` is zero-arg or only takes scalars | B |
 | Backing is a CPT / options / meta wrapper | B |
-| Plugin is a Jetpack-style first-party WordPress package | B |
+| Plugin's REST surface wraps WP-core post types, taxonomies, options, or meta | B |

--- a/skills/wp-abilities-audit/SKILL.md
+++ b/skills/wp-abilities-audit/SKILL.md
@@ -91,7 +91,15 @@ variants into 1.
 
 For each proposed ability, fill in every field in the `proposed_abilities`
 schema: `name`, `intent`, `backing`, `permission`, `return_type`, `effort`
-(S/M/L), `annotations` (readonly/destructive/idempotent), `notes`, `risks`.
+(S/M/L), `annotations` (readonly/destructive/idempotent), `notes`, `risks`,
+`use_case_fit`, `side_effects`, `seed_data_needs`.
+
+The last three are the implementation-readiness facts the implementer
+and the verify-mode tooling both need: which human/agent workflow this
+ability serves (`use_case_fit`), what the backing path emits on every
+call (`side_effects` — empty array is a fact, not a missing value), and
+what representative data must exist in the test environment for the
+ability to execute through the public boundary (`seed_data_needs`).
 
 ### 5. Surface gaps and deferred items
 

--- a/skills/wp-abilities-audit/SKILL.md
+++ b/skills/wp-abilities-audit/SKILL.md
@@ -89,10 +89,22 @@ re-derive the rules here. Short version: one ability per real-world question
 or state transition, with filter parameters in `input_schema` collapsing N
 variants into 1.
 
-For each proposed ability, fill in every field in the `proposed_abilities`
-schema: `name`, `intent`, `backing`, `permission`, `return_type`, `effort`
-(S/M/L), `annotations` (readonly/destructive/idempotent), `notes`, `risks`,
-`use_case_fit`, `side_effects`, `seed_data_needs`.
+**Apply the use-case sanity check before populating any candidate.** Per
+`../wp-abilities-api/references/domain-vs-projection.md`'s use-case-contract
+test: would a human or agent intentionally perform this behavior through a
+supported plugin workflow? If yes, the candidate is a real ability —
+proceed to fill in fields. If no, the route is internal transport plumbing
+(cache invalidation, scheduler ticks, bookkeeping endpoints, debug
+introspection) — keep it in the Controller Inventory section for
+completeness, but do NOT promote it to `proposed_abilities`. The route may
+be useful to inventory; the proposed ability must represent a real
+user/operator question or action.
+
+For each proposed ability that passes the sanity check, fill in every
+field in the `proposed_abilities` schema: `name`, `intent`, `backing`,
+`permission`, `return_type`, `effort` (S/M/L), `annotations`
+(readonly/destructive/idempotent), `notes`, `risks`, `use_case_fit`,
+`side_effects`, `seed_data_needs`.
 
 The last three are the implementation-readiness facts the implementer
 and the verify-mode tooling both need: which human/agent workflow this

--- a/skills/wp-abilities-audit/SKILL.md
+++ b/skills/wp-abilities-audit/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: wp-abilities-audit
+description: "Audit a WordPress plugin's REST surface and produce a standardized audit document proposing Abilities API registrations. Produces a markdown doc with a YAML schema and prose sections that humans and agents can both consume when planning a registration rollout. Works on any WP plugin."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Filesystem-based agent with bash + node. Requires access to the plugin checkout; some workflows benefit from WP-CLI but don't require it."
+---
+
+# WP Abilities Audit
+
+Produce a standardized audit document for a WordPress plugin's REST surface,
+proposing a set of Abilities API registrations grouped by semantic intent. The
+audit doc is a planning artifact for implementers — humans, agents, or both —
+that captures the controller inventory, capability gates, and proposed
+ability shapes in a structured form. A reviewer reading the doc can scope the
+work without re-deriving the survey.
+
+This skill works on any plugin that exposes a REST surface. Plugin
+classification (for purposes of the optional `plugin_family` annotation) is
+the user's call; the workflow itself is plugin-agnostic.
+
+## When to use
+
+- The task is "register Abilities API abilities for a WP plugin" and no audit
+  doc exists yet.
+- Planning participation in a multi-plugin abilities rollout and need a
+  shareable, standardized audit artifact.
+- Pre-flight checking a plugin's agent-readiness before implementing abilities.
+- A PM or non-implementer wants to scope the work before engineering picks it up.
+
+## Inputs required
+
+1. **Plugin checkout path** — working tree of the plugin to audit.
+2. **Triage output** — run `wp-project-triage` first if not already done. The
+   audit consumes `signals.usesAbilitiesApi`, `versions.wordpress`, and
+   `project.kind` from the report.
+3. **Auditor identity** — name and team or context, recorded in the audit's
+   `auditor` field.
+4. **Output path** — where the audit doc should land. Default explicit over
+   implicit; ask if not provided rather than writing into the plugin worktree.
+
+## Prerequisites
+
+- `wp-project-triage` has run successfully and classified the plugin.
+- The plugin has at least one REST controller. If enumeration finds zero
+  controllers, the audit doesn't apply — see "Failure modes" below.
+
+## Procedure
+
+### 1. Enumerate REST controllers
+
+Read `references/controller-enumeration.md` now — it covers the two observed
+enumeration paths (glob for standard layouts, grep as the universal fallback)
+and when to use each.
+
+Record every controller class + file + REST base + routes in a "Controller
+Inventory" table. The inventory is exhaustive even though only a subset
+becomes proposed abilities.
+
+### 2. For each controller, extract the backing fields
+
+For every controller found, extract the fields the audit schema requires:
+class, file, HTTP method, route, route-registration line number, callback
+name, callback line number, permission callback, whether the callback takes
+a `WP_REST_Request` argument or is zero-arg, and the return type.
+
+Read `references/audit-schema.md` now for the exact field list and the shape
+of `proposed_abilities` entries. Line-number fields may be `null` for
+inherited callbacks — the schema allows this and pairs it with an optional
+`inherited_from` field.
+
+### 3. Confirm capability gate(s)
+
+Trace each controller's `permission_callback` to its `current_user_can()` call
+(or to the post-type capability machinery if the controller extends a
+post-type-backed base).
+
+Read `references/capability-gate-tracing.md` now — it documents the two
+common mechanisms (direct `check_permission()` vs post-type-backed
+`wc_rest_check_post_permissions()`) and how to represent each in the schema.
+Note explicitly whether read and write gates differ: compound gates are
+represented as a `{read, write}` object, not a single string.
+
+### 4. Propose abilities using semantic-intent grouping
+
+Do NOT atomize one ability per HTTP method. Apply the semantic-intent grouping
+heuristic — it's the only grouping rule this skill uses.
+
+Read `../wp-abilities-api/references/grouping-heuristic.md` now — do NOT
+re-derive the rules here. Short version: one ability per real-world question
+or state transition, with filter parameters in `input_schema` collapsing N
+variants into 1.
+
+For each proposed ability, fill in every field in the `proposed_abilities`
+schema: `name`, `intent`, `backing`, `permission`, `return_type`, `effort`
+(S/M/L), `annotations` (readonly/destructive/idempotent), `notes`, `risks`.
+
+### 5. Surface gaps and deferred items
+
+Three buckets:
+
+- **`excluded_from_mvp`** — candidates intentionally deferred for risk reasons
+  (real-money writes, irreversible state changes, or prerequisite design
+  work). Each entry gets a one-sentence reason.
+- **`surfaced_gaps`** — MVP candidates with no backing endpoint (ability with
+  `backing: null`), plus high-value endpoints discovered during enumeration
+  that aren't in the MVP list but would be easy future wins.
+- **Risks per ability** — anything about a backing endpoint that the
+  implementer must handle (no idempotency key, two-phase behavior,
+  state-transition caveats, zero-arg endpoints registered with
+  `permission_callback => '__return_true'` that must NOT copy that into the
+  ability registration).
+
+### 6. Write the audit doc
+
+Write to the explicit output path collected in "Inputs required". The
+document structure must match `references/audit-schema.md` exactly:
+
+1. `Last updated: YYYY-MM-DD HH:MM` header.
+2. YAML block with all required top-level metadata + `proposed_abilities`,
+   `excluded_from_mvp`, `surfaced_gaps`.
+3. "Controller Inventory" table.
+4. "Notes and Surprises" prose section.
+
+A copy-pasteable minimal example showing the full shape lives in
+`references/audit-schema.md` under "Minimal valid example" — start there
+when authoring a new audit.
+
+### 7. (Optional) Designate a reference implementation ability
+
+Set `reference_ability: true` on the first ability an implementer should
+land — typically the smallest, safest, highest-leverage read. This gives
+downstream workflows a deterministic starting point.
+
+## Verification
+
+- The audit conforms to `references/audit-schema.md` (all required top-level
+  fields present, at least one entry in `proposed_abilities`, annotations
+  complete on every ability).
+- `capability_gate` is a string for single-cap plugins or a `{read, write}`
+  object for post-type-backed plugins.
+- Every ability with `backing: null` also appears in `surfaced_gaps`.
+- The doc round-trips through the validator in `audit-schema.md` "Known
+  limitations" without errors.
+
+## Failure modes / debugging
+
+- **Plugin has no REST controllers** — audit doesn't apply. Consider
+  hooks/filters-based abilities (out of scope for this skill's current
+  version) or skip abilities adoption for this plugin.
+- **Plugin inherits controllers from another repo** (common for plugins
+  extending core post-type-backed controllers like `WP_REST_Posts_Controller`,
+  or extension plugins built on a parent's REST classes) — capture with
+  `backing.inherited_from: "<parent FQCN>"`. Line-number fields may be
+  `null` per the schema.
+- **Compound capability gate (distinct read/write caps)** — use the
+  structured `{read, write}` form documented in
+  `references/capability-gate-tracing.md`. Don't smuggle a `/`-separated
+  string into a field typed as a single cap.
+- **Ambiguous grouping** — route to
+  `../wp-abilities-api/references/grouping-heuristic.md`. Do not invent
+  alternative grouping rules in the audit doc.
+- **Zero-arg endpoints with `permission_callback => '__return_true'`** —
+  legal at the REST layer, but the ability's own `permission_callback` must
+  match the plugin's merchant gate. Never promote `'__return_true'` into an
+  ability registration. Note this in the ability's `risks`.
+- **Output path defaults to plugin worktree** — always ask the user for an
+  explicit output directory (e.g. their vault `plans/`). Writing the audit
+  into the plugin's own git history pollutes the worktree and buries the
+  artifact.
+
+## Escalation
+
+- If the plugin uses an enumeration convention not covered by
+  `references/controller-enumeration.md` (neither the standard glob nor the
+  grep fallback produces a complete inventory), update that reference with
+  the new convention and open a PR so future audits cover it deterministically.
+- If capability tracing hits a mechanism not covered by
+  `references/capability-gate-tracing.md`, extend that file rather than
+  encoding the new case in the audit's "Notes and Surprises" only.

--- a/skills/wp-abilities-audit/references/audit-schema.md
+++ b/skills/wp-abilities-audit/references/audit-schema.md
@@ -81,6 +81,9 @@ Each entry:
 | `annotations` | object | `{ readonly: bool, destructive: bool, idempotent: bool }`. All three required. |
 | `notes` | array of strings | Implementer-facing detail (filter params, edge cases, alternative backings). |
 | `risks` | array of strings | Anything the implementer must handle (missing idempotency key, two-phase behavior, `permission_callback => '__return_true'` at the REST layer that must not copy into the ability, etc.). |
+| `use_case_fit` | string | One sentence naming the human or agent workflow this ability serves. The use-case-contract check (see `wp-abilities-api/references/domain-vs-projection.md`): if no human would intentionally do this through a supported UI or workflow, the entry probably belongs in `excluded_from_mvp` instead. |
+| `side_effects` | array of strings | Side effects the backing path emits on every call: telemetry hooks fired, audit-log rows written, notifications dispatched, cache writes, lock acquisitions, expensive bootstrap on cold paths. One short line per effect. Empty array (`[]`) when the backing is a pure data-fetch — and that is *itself* a fact downstream tooling uses to decide whether delegation is safe. |
+| `seed_data_needs` | string OR `null` | One line describing what representative data must exist in the test environment for the ability to execute through the public boundary and return something meaningful (e.g. `"at least one completed order under the configured gateway"`, `"no seed required"`). `null` when the auditor has not yet identified the seed shape; downstream verify-mode tooling treats `null` as "ask the implementer" rather than guessing. |
 | `reference_ability` | bool (optional) | If `true`, marks this ability as the reference implementation — the first one an implementer should land (smallest, safest, highest-leverage read). Exactly zero or one ability per audit may set this. |
 
 ### `backing: null` semantics
@@ -193,6 +196,9 @@ proposed_abilities:
     notes:
       - "get_items(WP_REST_Request $request) requires a WP_REST_Request; construct one in the ability execute_callback."
     risks: []
+    use_case_fit: "Agent answers 'which items need attention right now?' in a single call without paging through a UI."
+    side_effects: []
+    seed_data_needs: "at least one item exists in any non-trashed status"
     reference_ability: true
 
   - name: example-plugin/close-item
@@ -216,6 +222,11 @@ proposed_abilities:
       - "Close is terminal — no reopen endpoint exists."
     risks:
       - "No idempotency key on the backing endpoint; duplicate POSTs may produce inconsistent audit trails."
+    use_case_fit: "User or agent closes a stale item from a workflow that surfaces stale items (admin list view, daily-digest agent)."
+    side_effects:
+      - "fires action `example_plugin/item_closed` (downstream listeners may dispatch email)"
+      - "writes audit-log row to `example_plugin_audit_log`"
+    seed_data_needs: "one open item to close; the test must capture the item id before invocation"
 
 excluded_from_mvp:
   - name: example-plugin/delete-item

--- a/skills/wp-abilities-audit/references/audit-schema.md
+++ b/skills/wp-abilities-audit/references/audit-schema.md
@@ -101,20 +101,22 @@ as a warning, not an error:
 
 | Field | Type | Description |
 |---|---|---|
-| `class` | string | Fully-qualified PHP class name. |
+| `kind` | enum (optional, default `rest_controller`) | The implementation path the ability should use or inspect. One of `rest_controller`, `service`, `helper`, `data_store`. When omitted, defaults to `rest_controller` for backwards compatibility with audits authored before this field landed. The kind tells downstream tooling whether the delegation pattern from `wp-abilities-api/references/shared-core-service.md` applies (only `rest_controller` is a candidate; the others select the shared-service shape from the start). |
+| `class` | string | Fully-qualified PHP class name (controller class for `rest_controller`; service / helper / data-store class for the other kinds). May be omitted when `kind: data_store` and the backing is a bare option key, post-meta key, or table without an owning class. |
 | `file` | string | Path relative to plugin root. |
-| `method` | enum | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`. |
-| `route` | string | Full REST route path. |
-| `route_registration_line` | integer OR `null` | Line number of the `register_rest_route(` call, or `null` when inherited from a parent controller that lives outside the plugin repo. |
-| `callback` | string | Controller method name that handles the route. |
-| `callback_line` | integer OR `null` | Line number of the callback method definition, or `null` when inherited. |
-| `inherited_from` | string (optional) | Fully-qualified parent class name when the route and/or callback is inherited from a class outside this plugin's repo (e.g. `WP_REST_Posts_Controller` from WordPress core, or another plugin's REST base class for extension plugins). Pair with `null` line numbers. Lets downstream tooling skip the re-grep step cleanly. |
+| `method` | enum (required when `kind: rest_controller`) | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`. Not applicable when `kind` is `service`, `helper`, or `data_store`. |
+| `route` | string (required when `kind: rest_controller`) | Full REST route path. Not applicable to non-REST kinds. |
+| `route_registration_line` | integer OR `null` | For `kind: rest_controller`: line number of the `register_rest_route(` call, or `null` when inherited. Omit for other kinds. |
+| `callback` | string | For `kind: rest_controller`: controller method name that handles the route. For `kind: service` / `helper`: method name on the service / helper class. For `kind: data_store`: the operation name (`get_option`, `get_post_meta`) or the table-read pattern; may be omitted. |
+| `callback_line` | integer OR `null` | Line number of the callback or method definition, or `null` when inherited or not applicable. |
+| `inherited_from` | string (optional) | Fully-qualified parent class name when the route and/or callback is inherited from a class outside this plugin's repo (e.g. `WP_REST_Posts_Controller` from WordPress core, or another plugin's REST base class for extension plugins). Pair with `null` line numbers. Lets downstream tooling skip the re-grep step cleanly. Primarily relevant for `kind: rest_controller`. |
 
 ### `permission` object
 
 | Field | Type | Description |
 |---|---|---|
-| `callback` | string | The method name used as `permission_callback`. |
+| `source` | enum (optional, default `rest_controller`) | Where the canonical permission for this behavior lives — not always the REST controller's `permission_callback`. One of `rest_controller`, `admin_action`, `service`, `domain_policy`, `post_type_map`, `none`. When omitted, defaults to `rest_controller` for backwards compatibility. `admin_action` for behaviors gated by `check_admin_referer` / `current_user_can` on an admin handler; `service` when a shared method enforces the cap; `domain_policy` for plugins with a policy / authorization layer; `post_type_map` for capabilities resolved through `map_meta_cap` on a post-type cap shadow; `none` for genuinely public behavior. Tells the implementer whether the ability's `permission_callback` can mirror the REST callback or must consult a different source of truth. |
+| `callback` | string | The method or function name that enforces the cap at the recorded `source`. For `source: rest_controller`, this is the `permission_callback` value. For `source: admin_action`, the admin handler function or method. For `source: service`, the service method that performs the cap check. |
 | `resolves_to` | string | The `current_user_can()` call(s) it ultimately resolves to. For compound gates, include both (e.g. `"current_user_can('read_private_pages')` for read; `current_user_can('edit_others_pages')` for write"). |
 | `confirmed` | bool | `true` if verified against source; `false` if inferred. |
 
@@ -179,6 +181,7 @@ proposed_abilities:
   - name: example-plugin/get-items
     intent: "List items with filters (status, owner, date range) so an agent can answer 'which items need attention?' in one call."
     backing:
+      kind: rest_controller
       class: Example_REST_Items_Controller
       file: includes/rest-api/class-example-rest-items-controller.php
       method: GET
@@ -187,6 +190,7 @@ proposed_abilities:
       callback: get_items
       callback_line: 52
     permission:
+      source: rest_controller
       callback: check_permission
       resolves_to: "current_user_can('manage_options')"
       confirmed: true
@@ -204,15 +208,14 @@ proposed_abilities:
   - name: example-plugin/close-item
     intent: "Close a single item — terminal state transition, non-reversible."
     backing:
-      class: Example_REST_Items_Controller
-      file: includes/rest-api/class-example-rest-items-controller.php
-      method: POST
-      route: /example/v1/items/{id}/close
-      route_registration_line: 41
-      callback: close_item
-      callback_line: 120
+      kind: service
+      class: Example_Items_Service
+      file: src/Service/class-items-service.php
+      callback: close
+      callback_line: 88
     permission:
-      callback: check_permission
+      source: service
+      callback: Example_Items_Service::assert_can_close
       resolves_to: "current_user_can('manage_options')"
       confirmed: true
     return_type: "WP_REST_Response (updated item object)"
@@ -284,3 +287,14 @@ Documented so downstream skills have an explicit contract:
   fields to nudge backfill the next time the audit is touched; they do
   NOT FAIL, mirroring the legacy `capability_gate` posture above. New
   audits MUST populate all three.
+- **`backing.kind` and `permission.source` added 2026-05-21.** Both
+  are optional with default `rest_controller` so older audits validate
+  as-is. New audits SHOULD populate both explicitly — `backing.kind`
+  to record whether the ability backs a REST controller, a shared
+  service, a helper, or a data store (because the answer drives the
+  delegate-vs-extract-service decision in `wp-abilities-api/references/
+  shared-core-service.md`); `permission.source` to record where the
+  canonical permission lives (REST callback is the common case, but
+  admin actions, service methods, domain policies, and post-type cap
+  maps each happen). Validators treat a missing field as the default,
+  not as an error.

--- a/skills/wp-abilities-audit/references/audit-schema.md
+++ b/skills/wp-abilities-audit/references/audit-schema.md
@@ -82,8 +82,8 @@ Each entry:
 | `notes` | array of strings | Implementer-facing detail (filter params, edge cases, alternative backings). |
 | `risks` | array of strings | Anything the implementer must handle (missing idempotency key, two-phase behavior, `permission_callback => '__return_true'` at the REST layer that must not copy into the ability, etc.). |
 | `use_case_fit` | string | One sentence naming the human or agent workflow this ability serves. The use-case-contract check (see `wp-abilities-api/references/domain-vs-projection.md`): if no human would intentionally do this through a supported UI or workflow, the entry probably belongs in `excluded_from_mvp` instead. |
-| `side_effects` | array of strings | Side effects the backing path emits on every call: telemetry hooks fired, audit-log rows written, notifications dispatched, cache writes, lock acquisitions, expensive bootstrap on cold paths. One short line per effect. Empty array (`[]`) when the backing is a pure data-fetch — and that is *itself* a fact downstream tooling uses to decide whether delegation is safe. |
-| `seed_data_needs` | string OR `null` | One line describing what representative data must exist in the test environment for the ability to execute through the public boundary and return something meaningful (e.g. `"at least one completed order under the configured gateway"`, `"no seed required"`). `null` when the auditor has not yet identified the seed shape; downstream verify-mode tooling treats `null` as "ask the implementer" rather than guessing. |
+| `side_effects` | array of strings | Side effects the backing path emits on every call: telemetry hooks, audit-log rows, notifications, cache writes. One short line per effect. Empty array (`[]`) when the backing is a pure data-fetch — that is *itself* a load-bearing fact: it is what unlocks the conditional delegation shortcut in `wp-abilities-api/references/shared-core-service.md`. A non-empty array tells the implementer (and downstream verify-mode tooling) that this ability needs the shared-service shape, not the delegate-through-REST shortcut. |
+| `seed_data_needs` | string OR `null` | One line describing what representative data must exist in the test environment for the ability to execute through the public boundary and return something meaningful (e.g. `"at least one entity in the plugin's primary table"`, `"no seed required"`). `null` when the auditor has not yet identified the seed shape; downstream verify-mode tooling treats `null` as "ask the implementer" rather than guessing. |
 | `reference_ability` | bool (optional) | If `true`, marks this ability as the reference implementation — the first one an implementer should land (smallest, safest, highest-leverage read). Exactly zero or one ability per audit may set this. |
 
 ### `backing: null` semantics
@@ -276,3 +276,11 @@ Documented so downstream skills have an explicit contract:
   gaps and MUST also appear in `surfaced_gaps` by `name`. Validators FAIL
   audits where this invariant is violated (a `null` backing without a
   matching `surfaced_gaps` entry indicates inconsistent audit output).
+- **Implementation-readiness fields added 2026-05-21.** `use_case_fit`,
+  `side_effects`, and `seed_data_needs` are required in the per-ability
+  schema as of this date. Audits authored against an earlier revision of
+  this schema will be missing the three fields. Validators (e.g.
+  `wp-abilities-verify`) emit WARN on missing implementation-readiness
+  fields to nudge backfill the next time the audit is touched; they do
+  NOT FAIL, mirroring the legacy `capability_gate` posture above. New
+  audits MUST populate all three.

--- a/skills/wp-abilities-audit/references/audit-schema.md
+++ b/skills/wp-abilities-audit/references/audit-schema.md
@@ -112,7 +112,7 @@ as a warning, not an error:
 | Field | Type | Description |
 |---|---|---|
 | `callback` | string | The method name used as `permission_callback`. |
-| `resolves_to` | string | The `current_user_can()` call(s) it ultimately resolves to. For compound gates, include both (e.g. `"current_user_can('read_private_shop_orders')` for read; `current_user_can('edit_shop_orders')` for write"). |
+| `resolves_to` | string | The `current_user_can()` call(s) it ultimately resolves to. For compound gates, include both (e.g. `"current_user_can('read_private_pages')` for read; `current_user_can('edit_others_pages')` for write"). |
 | `confirmed` | bool | `true` if verified against source; `false` if inferred. |
 
 ## `excluded_from_mvp` — array

--- a/skills/wp-abilities-audit/references/audit-schema.md
+++ b/skills/wp-abilities-audit/references/audit-schema.md
@@ -1,0 +1,267 @@
+# Audit Document Schema
+
+The canonical schema for an abilities audit doc. Every audit produced by
+`wp-abilities-audit` must conform to this schema so downstream tooling
+(humans reviewing, agents implementing, or validators like
+`wp-abilities-verify`) can consume it without parsing surprises.
+
+A copy-pasteable minimal example with both a read ability and a write
+ability lives under "Minimal valid example" below.
+
+## File layout
+
+```
+<output-dir>/<YYYY-MM-DD>-abilities-audit-<plugin-slug>.md
+```
+
+`<output-dir>` is explicit — collected from the user, not inferred. Typical
+values are the user's vault `plans/` directory or a dedicated audit repo.
+Writing into the plugin worktree is discouraged (pollutes git history).
+
+The body has two parts:
+
+1. A fenced ` ```yaml ` block holding structured fields (top-level metadata
+   + `proposed_abilities`, `excluded_from_mvp`, `surfaced_gaps`).
+2. Prose sections below: "Controller Inventory" table + "Notes and Surprises".
+
+A `Last updated: YYYY-MM-DD HH:MM` header sits above everything.
+
+## Top-level fields (all required)
+
+| Field | Type | Description |
+|---|---|---|
+| `plugin` | string | Plugin slug (e.g. `my-plugin`, `tasks-plugin`, `notifications`). |
+| `repo` | string | `Owner/Repository`. |
+| `branch_audited` | string | Git branch the audit was run against. |
+| `audited_at` | string | ISO date (YYYY-MM-DD). |
+| `auditor` | string | Human auditor name + team or context (e.g. `Your Name (Your Team)`). |
+| `baseline_abilities` | integer | Count of abilities already registered by the plugin at audit time. Usually 0. |
+| `capability_gate` | string OR object | The capability gate the base controller resolves to. Accept either a single string (single-cap plugins) OR a `{read, write}` object (post-type-backed or otherwise compound gates). See `capability-gate-tracing.md` for the mechanisms. |
+| `plugin_family` | string (optional) | Free-form classification when useful to downstream readers (e.g. `core-post-type`, `forms-engine`, or a project-specific family name). Optional and user-supplied — no canonical enum. Downstream consumers treat unknown values as opaque rather than erroring. |
+
+### `capability_gate` representations
+
+Two legal shapes, both consumed by downstream tooling:
+
+```yaml
+# Single-cap plugin (one capability across every controller)
+capability_gate: manage_options  # confirmed at includes/admin/class-my-plugin-rest-controller.php line 64
+```
+
+```yaml
+# Compound read/write (post-type-backed plugins typically need this shape;
+# read and write resolve to different capabilities)
+capability_gate:
+  read: read_private_pages
+  write: edit_others_pages
+  confirmed: true
+  verified_at: "custom_post_type capability_type='page' → core post-type cap map (wp-includes/post.php map_meta_cap)"
+```
+
+Plugin-specific capabilities (e.g. WooCommerce's `manage_woocommerce`,
+`edit_shop_orders`) are equally valid — substitute your plugin's caps. The
+shape is the contract; the literal cap names are project-specific.
+
+A legacy compound-string form exists in the wild (`"<read_cap> / <write_cap>"`)
+and is accepted for backwards compatibility, but the structured form above is
+the preferred representation for new audits.
+
+## `proposed_abilities` — array
+
+Each entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Kebab-case `<plugin-slug>/<ability>`. |
+| `intent` | string | One sentence, user-question framed. |
+| `backing` | object or `null` | See below. `null` marks an ability with no backing endpoint (a known gap). |
+| `permission` | object or `null` | See below. `null` when `backing` is null. |
+| `return_type` | string | Short description (e.g. `WP_REST_Response (wrapping array)`). Hint-only; not machine-parsed. |
+| `effort` | enum | `S`, `M`, or `L`. |
+| `annotations` | object | `{ readonly: bool, destructive: bool, idempotent: bool }`. All three required. |
+| `notes` | array of strings | Implementer-facing detail (filter params, edge cases, alternative backings). |
+| `risks` | array of strings | Anything the implementer must handle (missing idempotency key, two-phase behavior, `permission_callback => '__return_true'` at the REST layer that must not copy into the ability, etc.). |
+| `reference_ability` | bool (optional) | If `true`, marks this ability as the reference implementation — the first one an implementer should land (smallest, safest, highest-leverage read). Exactly zero or one ability per audit may set this. |
+
+### `backing: null` semantics
+
+An ability with `backing: null` is a known gap (the auditor identified a
+valuable ability that has no backing endpoint yet). The schema permits this
+as a warning, not an error:
+
+- The ability MUST also appear in `surfaced_gaps` with a one-line rationale.
+- Implementers pause for resolution rather than guessing a backing.
+- The audit is still valid; `backing: null` is intentional output, not
+  missing data.
+
+### `backing` object
+
+| Field | Type | Description |
+|---|---|---|
+| `class` | string | Fully-qualified PHP class name. |
+| `file` | string | Path relative to plugin root. |
+| `method` | enum | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`. |
+| `route` | string | Full REST route path. |
+| `route_registration_line` | integer OR `null` | Line number of the `register_rest_route(` call, or `null` when inherited from a parent controller that lives outside the plugin repo. |
+| `callback` | string | Controller method name that handles the route. |
+| `callback_line` | integer OR `null` | Line number of the callback method definition, or `null` when inherited. |
+| `inherited_from` | string (optional) | Fully-qualified parent class name when the route and/or callback is inherited from a class outside this plugin's repo (e.g. `WP_REST_Posts_Controller` from WordPress core, or another plugin's REST base class for extension plugins). Pair with `null` line numbers. Lets downstream tooling skip the re-grep step cleanly. |
+
+### `permission` object
+
+| Field | Type | Description |
+|---|---|---|
+| `callback` | string | The method name used as `permission_callback`. |
+| `resolves_to` | string | The `current_user_can()` call(s) it ultimately resolves to. For compound gates, include both (e.g. `"current_user_can('read_private_shop_orders')` for read; `current_user_can('edit_shop_orders')` for write"). |
+| `confirmed` | bool | `true` if verified against source; `false` if inferred. |
+
+## `excluded_from_mvp` — array
+
+Abilities intentionally deferred for risk reasons. Each entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Proposed ability name (kebab-case). |
+| `reason` | string | One sentence why it's deferred. |
+
+## `surfaced_gaps` — array
+
+MVP candidates with no backing endpoint (paired with `backing: null` above),
+plus high-value endpoints discovered during enumeration that aren't in MVP
+but would make future follow-up work. Each entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Proposed ability name. |
+| `one_line_rationale` | string | Why it would be high-leverage. |
+
+## Prose sections (required)
+
+### Controller Inventory
+
+A Markdown table with columns `Class | File | REST Base | Routes`. Must list
+every controller enumeration found, even ones that aren't backing any MVP
+ability. This gives reviewers a full picture and catches "why isn't X in the
+MVP?" questions.
+
+### Notes and Surprises
+
+Free-form prose capturing anything that didn't fit the structured schema:
+capability-gate mismatches between controllers, hardcoded route paths, dual
+controllers with different output shapes, two-phase endpoint semantics, and
+any judgment calls the auditor made.
+
+## Minimal valid example
+
+Copy-pasteable starting point for a new audit:
+
+````markdown
+---
+Last updated: 2026-04-20 14:30
+---
+
+# Example Plugin Abilities — Phase 1 Audit
+
+```yaml
+plugin: example-plugin
+repo: Owner/example-plugin
+branch_audited: feat/abilities-example-plugin
+audited_at: 2026-04-20
+auditor: Your Name (Your Team)
+baseline_abilities: 0
+capability_gate: manage_options  # confirmed at includes/rest-api/class-example-rest-controller.php line 32
+
+proposed_abilities:
+
+  - name: example-plugin/get-items
+    intent: "List items with filters (status, owner, date range) so an agent can answer 'which items need attention?' in one call."
+    backing:
+      class: Example_REST_Items_Controller
+      file: includes/rest-api/class-example-rest-items-controller.php
+      method: GET
+      route: /example/v1/items
+      route_registration_line: 26
+      callback: get_items
+      callback_line: 52
+    permission:
+      callback: check_permission
+      resolves_to: "current_user_can('manage_options')"
+      confirmed: true
+    return_type: "WP_REST_Response (wrapping array)"
+    effort: S
+    annotations: { readonly: true, destructive: false, idempotent: true }
+    notes:
+      - "get_items(WP_REST_Request $request) requires a WP_REST_Request; construct one in the ability execute_callback."
+    risks: []
+    reference_ability: true
+
+  - name: example-plugin/close-item
+    intent: "Close a single item — terminal state transition, non-reversible."
+    backing:
+      class: Example_REST_Items_Controller
+      file: includes/rest-api/class-example-rest-items-controller.php
+      method: POST
+      route: /example/v1/items/{id}/close
+      route_registration_line: 41
+      callback: close_item
+      callback_line: 120
+    permission:
+      callback: check_permission
+      resolves_to: "current_user_can('manage_options')"
+      confirmed: true
+    return_type: "WP_REST_Response (updated item object)"
+    effort: M
+    annotations: { readonly: false, destructive: true, idempotent: false }
+    notes:
+      - "Close is terminal — no reopen endpoint exists."
+    risks:
+      - "No idempotency key on the backing endpoint; duplicate POSTs may produce inconsistent audit trails."
+
+excluded_from_mvp:
+  - name: example-plugin/delete-item
+    reason: "Hard delete is irreversible and lacks an undo endpoint; defer until soft-delete is designed."
+
+surfaced_gaps:
+  - name: example-plugin/get-overview
+    one_line_rationale: "A zero-arg overview endpoint answering 'what's the current state of all items?' would be the highest-leverage ability but no backing endpoint exists yet."
+```
+
+## Controller Inventory
+
+| Class | File | REST Base | Routes |
+|---|---|---|---|
+| Example_REST_Items_Controller | includes/rest-api/class-example-rest-items-controller.php | example/v1/items | GET /example/v1/items, POST /example/v1/items/{id}/close |
+
+## Notes and Surprises
+
+### Capability gate is uniform
+Every controller inherits `Example_Base_REST_Controller` and uses
+`check_permission` verbatim as the `permission_callback`. No per-route
+overrides. Safe to treat `manage_options` as the single gate.
+````
+
+## Known limitations
+
+Documented so downstream skills have an explicit contract:
+
+- **`capability_gate` string-with-inline-comment form** loses data when parsed
+  by strict YAML parsers (comments are dropped). The structured object form is
+  preferred; string form is accepted for backwards compatibility.
+- **Legacy compound-string `capability_gate`** — the `"<read_cap> / <write_cap>"`
+  form predates the structured `{read, write}` object and is still accepted
+  for backwards compatibility. Validators (e.g. `wp-abilities-verify`)
+  emit WARN on this form to nudge migration to the structured shape;
+  they do NOT FAIL. New audits should use the object form.
+- **`return_type` is hint-only.** Prose for the human auditor; not
+  machine-parseable. Downstream skills use runtime `is_wp_error(...)` and
+  `instanceof WP_REST_Response` checks regardless of what this field says.
+- **Line numbers drift.** `route_registration_line` and `callback_line` are
+  captured at audit time and may bit-rot. Downstream skills re-locate routes
+  by `(class, callback)` and do not rely on exact line numbers.
+- **`inherited_from` + `null` line numbers** are the canonical way to
+  represent routes/callbacks defined in a parent class that lives outside
+  the plugin repo.
+- **`backing: null` invariant.** Abilities with `backing: null` are intentional
+  gaps and MUST also appear in `surfaced_gaps` by `name`. Validators FAIL
+  audits where this invariant is violated (a `null` backing without a
+  matching `surfaced_gaps` entry indicates inconsistent audit output).

--- a/skills/wp-abilities-audit/references/capability-gate-tracing.md
+++ b/skills/wp-abilities-audit/references/capability-gate-tracing.md
@@ -1,0 +1,171 @@
+# Capability-Gate Tracing
+
+How to resolve the actual capability (or capabilities) a plugin's REST
+controllers gate on. The audit's `capability_gate` field and each ability's
+`permission.resolves_to` field need to reflect reality, not what the
+controller docblock says.
+
+Two common mechanisms cover most plugins. Document both explicitly so the
+auditor doesn't hard-code one plugin family's assumptions.
+
+## Mechanism A — Direct (`check_permission()` returning a single cap)
+
+The base REST controller declares a `check_permission()` (or
+`permissions_check()`) method that calls `current_user_can('<some_cap>')`
+once. Every route in the controller uses that method as
+`permission_callback`.
+
+### Identifying signs
+
+- The base controller has a method like:
+  ```php
+  public function check_permission() {
+      return current_user_can( 'manage_options' );
+  }
+  ```
+- Controllers extend the plugin's own base, not a WordPress core
+  post-type-backed class.
+- The grep `grep -n 'current_user_can' <base-controller>.php` yields one hit.
+
+### How to trace
+
+```bash
+# Locate the base controller (usually the parent of every REST controller).
+grep -rn 'extends .*REST_Controller' includes/ | head
+
+# Read its permission_callback implementation.
+grep -n 'check_permission\|permissions_check' <base-controller>.php
+```
+
+Trace once: the single `current_user_can()` call is the plugin's gate.
+
+### How to represent in the audit
+
+```yaml
+capability_gate: manage_options  # confirmed at includes/admin/class-<plugin>-rest-controller.php line 64
+```
+
+Plugin-specific capabilities (e.g. WooCommerce's `manage_woocommerce` for
+shop-aware contexts, Jetpack Forms' `edit_pages`) substitute for
+`manage_options` cleanly — the shape stays the same.
+
+## Mechanism B — Post-type-backed (core CPT capability machinery)
+
+The controller extends a WordPress core post-type-backed class that
+dispatches to the post-type capability map. There is no local
+`check_permission()` — the permission callback resolves dynamically at
+request time based on the request context (read vs write) and the post
+type's `cap` object.
+
+### Identifying signs
+
+- The controller's base class is one of:
+  - `WP_REST_Posts_Controller` — the core post-type REST base.
+  - A subclass of it, in or out of this plugin's repo.
+- No local `check_permission()` — permission callbacks are inherited.
+- The post type is registered with `capability_type => '<cpt_or_shadow>'`,
+  and the cap map is resolved by core's `map_meta_cap()`.
+
+### How to trace
+
+```bash
+# Find the post-type registration.
+grep -rn "register_post_type\s*(\s*['\"]<cpt_name>['\"]" .
+
+# Read the registration block. The relevant fields are:
+#   - capability_type: the type whose cap map this post type uses.
+#     A custom post type can either declare its own caps or shadow another
+#     type's (e.g. capability_type => 'page' to reuse Pages' caps).
+#   - capabilities: optional explicit cap-string overrides.
+#   - map_meta_cap: whether meta caps (read_post, edit_post) get mapped to
+#     primitive caps (read_private_<type>s, edit_others_<type>s).
+```
+
+Dynamic resolution typically lands at:
+
+- **Read context** (GET list / GET item): `current_user_can('read_private_<type>s')` or `current_user_can('read_<type>', $id)`.
+- **Write context** (POST / PUT / DELETE): `current_user_can('edit_<type>s')`, `current_user_can('edit_others_<type>s')`, or `current_user_can('delete_<type>s', $id)`.
+
+The two often differ — post-type-backed plugins routinely have distinct read
+and write caps.
+
+### How to represent in the audit
+
+Use the structured `{read, write}` form from `audit-schema.md`:
+
+```yaml
+capability_gate:
+  read: read_private_pages
+  write: edit_others_pages
+  confirmed: true
+  verified_at: "custom_post_type capability_type='page' → core map_meta_cap (wp-includes/post.php) → primitive page caps"
+```
+
+In each ability's `permission` block, spell out both calls:
+
+```yaml
+permission:
+  callback: get_items_permissions_check
+  resolves_to: "WP_REST_Posts_Controller::get_items_permissions_check (inherited) → current_user_can('read_private_pages')"
+  confirmed: true
+```
+
+Example A — generic plugin shadowing core Pages caps. A custom post type
+registered with `capability_type='page'` inherits the Pages cap map, so
+reads gate on `read_private_pages` and writes gate on `edit_others_pages`.
+
+Example B — WooCommerce-style sidebar. WooCommerce's `shop_subscription` is
+registered with `capability_type='shop_order'`, so reads gate on
+`read_private_shop_orders` and writes gate on `edit_shop_orders`.
+Mechanically identical to Example A; the cap names are project-specific.
+WooCommerce also exposes a helper `wc_rest_check_post_permissions()` that
+wraps the same core machinery — the helper is convenience; the underlying
+mechanism is core's `map_meta_cap()`.
+
+## Compound-string form (accepted, not preferred)
+
+Some earlier audits encoded compound gates as a single string with a `/`
+separator:
+
+```yaml
+capability_gate: read_private_shop_orders / edit_shop_orders
+```
+
+This is accepted for backwards compatibility, but:
+
+- Downstream consumers have to heuristically split on `/`.
+- YAML comments after the string are silently dropped by strict parsers, so
+  provenance gets lost.
+- The `{read, write}` object form is machine-parseable and carries
+  `confirmed` and `verified_at` in-band.
+
+Prefer the structured form for any new audit.
+
+## Procedure — trace every route you'll back
+
+For each proposed ability, walk the chain once:
+
+1. Find the route's `permission_callback` in the controller.
+2. Determine whether it's Mechanism A (local method, single cap) or
+   Mechanism B (inherited, post-type-backed, dynamic).
+3. Resolve to the actual `current_user_can()` call(s). For B, resolve BOTH
+   read and write if the ability crosses contexts.
+4. Record in the ability's `permission.resolves_to` field verbatim — the
+   string should read as an actual trace, not a best-guess summary.
+5. If every route in the plugin resolves to the same cap (or same
+   `{read, write}` pair), hoist it into the top-level `capability_gate`. If
+   any route diverges, record the divergence in "Notes and Surprises".
+
+## Common pitfall — `permission_callback => '__return_true'`
+
+Zero-arg public endpoints sometimes declare `permission_callback =>
+'__return_true'` at the REST layer (e.g. status lookups, enumerated lists
+that are safe to expose). The audit still needs a gate:
+
+- Record the REST-layer value as-is (`resolves_to:
+  "__return_true (public)"`) so the auditor isn't hiding reality.
+- Add a risk note: the **ability** registration must NOT copy
+  `'__return_true'` — the ability's own `permission_callback` must match
+  the plugin's intended user gate (e.g. `manage_options`, `edit_pages`, or
+  whatever your plugin uses). The ability layer is the agent-facing surface
+  and needs that gate even when the underlying REST route is public.

--- a/skills/wp-abilities-audit/references/capability-gate-tracing.md
+++ b/skills/wp-abilities-audit/references/capability-gate-tracing.md
@@ -128,7 +128,7 @@ Some earlier audits encoded compound gates as a single string with a `/`
 separator:
 
 ```yaml
-capability_gate: read_private_shop_orders / edit_shop_orders
+capability_gate: read_private_pages / edit_others_pages
 ```
 
 This is accepted for backwards compatibility, but:

--- a/skills/wp-abilities-audit/references/capability-gate-tracing.md
+++ b/skills/wp-abilities-audit/references/capability-gate-tracing.md
@@ -141,20 +141,46 @@ This is accepted for backwards compatibility, but:
 
 Prefer the structured form for any new audit.
 
-## Procedure — trace every route you'll back
+## Procedure — trace the permission source for each proposed behavior
+
+The ability's permission should match the plugin's intended gate for the
+proposed *behavior*, not necessarily the REST route. Often the REST
+controller's `permission_callback` is the right source of truth, but in
+some plugins the canonical permission lives elsewhere — an admin-action
+handler with its own `check_admin_referer` + `current_user_can` block, a
+service / helper method that performs the check before doing the work, a
+domain-policy / authorization layer, or a post-type cap shadow resolved
+through core's `map_meta_cap`. The audit should preserve where the
+permission canonically lives so the implementer doesn't silently drift
+to whichever source the REST layer happens to expose.
 
 For each proposed ability, walk the chain once:
 
-1. Find the route's `permission_callback` in the controller.
-2. Determine whether it's Mechanism A (local method, single cap) or
-   Mechanism B (inherited, post-type-backed, dynamic).
-3. Resolve to the actual `current_user_can()` call(s). For B, resolve BOTH
-   read and write if the ability crosses contexts.
-4. Record in the ability's `permission.resolves_to` field verbatim — the
+1. Identify the *behavior* the ability surfaces, then locate where the
+   plugin enforces the cap for that behavior. Check the REST controller's
+   `permission_callback` first; if the REST callback is `'__return_true'`,
+   delegates entirely, or doesn't match the behavior's intended gate,
+   look for the canonical source in an admin handler, a shared service
+   method, a domain-policy class, or a post-type cap map.
+2. Record where the gate lives in the ability's `permission.source` field
+   per `audit-schema.md`: one of `rest_controller`, `admin_action`,
+   `service`, `domain_policy`, `post_type_map`, `none`. Default
+   `rest_controller`; pick another value when the canonical source is
+   elsewhere.
+3. Determine whether the gate is Mechanism A (local method, single cap)
+   or Mechanism B (inherited, post-type-backed, dynamic).
+4. Resolve to the actual `current_user_can()` call(s). For Mechanism B,
+   resolve BOTH read and write if the ability crosses contexts.
+5. Record in the ability's `permission.resolves_to` field verbatim — the
    string should read as an actual trace, not a best-guess summary.
-5. If every route in the plugin resolves to the same cap (or same
-   `{read, write}` pair), hoist it into the top-level `capability_gate`. If
-   any route diverges, record the divergence in "Notes and Surprises".
+6. Add a risk note when the canonical permission source diverges from
+   the REST controller's callback: the ability's `permission_callback`
+   must consult the canonical source (or replicate its check), not
+   copy the REST callback by reflex.
+7. If every behavior in the plugin resolves to the same cap (or same
+   `{read, write}` pair) at the same source, hoist it into the top-level
+   `capability_gate`. If any behavior diverges in cap OR in source,
+   record the divergence in "Notes and Surprises".
 
 ## Common pitfall — `permission_callback => '__return_true'`
 

--- a/skills/wp-abilities-audit/references/controller-enumeration.md
+++ b/skills/wp-abilities-audit/references/controller-enumeration.md
@@ -1,0 +1,116 @@
+# Controller Enumeration
+
+How to produce an exhaustive list of a plugin's REST controllers — the first
+step of every audit. Plugin family classification is handled separately by
+`wp-project-triage`; this reference covers the mechanics of finding controller
+classes inside whatever layout the plugin happens to use.
+
+## Two enumeration paths
+
+Observed across the plugins audited to date, there are exactly two paths that
+together cover every layout seen in the wild:
+
+| Path | When it works | How it works |
+|---|---|---|
+| **Glob** | Plugins that follow the standard `includes/admin/class-*-rest-*-controller.php` layout (WooCommerce core extensions, classic WooPayments). | Fast, deterministic, easy to script. Returns a complete list in one shell call. |
+| **Grep** | Any non-standard layout — `includes/api/`, `includes/rest-api/`, `src/rest/`, monorepo package directories, or anything else. | Universal fallback: grep every PHP file under the plugin root for `register_rest_route(` call sites, then collect the enclosing class for each hit. |
+
+### Default order
+
+1. **Try glob first** — it's faster and produces a cleaner inventory.
+2. **Fall back to grep** if glob returns zero hits (or clearly undercounts
+   against what you see in the plugin's public documentation / admin UI).
+
+Running both and de-duplicating is legal; it catches monorepos that have
+*some* controllers under the standard layout and *others* under a package
+directory.
+
+## Glob — standard layout
+
+```bash
+# From the plugin root:
+ls includes/admin/class-*-rest-*-controller.php 2>/dev/null
+ls includes/reports/class-*-rest-*-controller.php 2>/dev/null
+```
+
+What you'll see in repos that match this convention:
+
+- WooPayments (`Automattic/woocommerce-payments`) — every controller under
+  `includes/admin/class-wc-rest-payments-*-controller.php` plus some under
+  `includes/reports/`.
+- WooCommerce core's internal REST controllers use the same pattern.
+
+If glob returns 5+ hits, it's almost always the complete inventory. If it
+returns 0-2, fall through to grep.
+
+## Grep — universal fallback
+
+```bash
+# From the plugin root:
+grep -rn --include='*.php' 'register_rest_route(' .
+```
+
+For each hit:
+
+1. Open the file.
+2. Walk up to the enclosing class declaration.
+3. Record `(class, file, route, callback, permission_callback)`.
+
+This path matters because it's the only one that finds controllers in
+non-standard locations:
+
+- **WooCommerce Subscriptions** — controllers live under `includes/api/` and
+  `includes/api/legacy/`. The standard WooPayments glob returns zero; grep is
+  mandatory.
+- **Jetpack Forms** (and most Jetpack packages) — controllers live under
+  `projects/packages/<name>/src/` with no conventional filename. Grep is
+  again mandatory.
+- **Custom plugin layouts** — anything with `src/Rest/`, `lib/rest/`,
+  `api/v1/`, etc. Grep catches them all.
+
+## Inherited routes
+
+A controller can extend a base class in a different repo — typically the
+parent plugin (for extensions built on top of another plugin) or WordPress
+core itself (for plugins extending `WP_REST_Posts_Controller` or other core
+REST bases). The `parent::register_routes()` dispatch appears in the
+extending plugin's source, but the literal `register_rest_route(` call lives
+in the parent. WooCommerce extensions extending
+`WC_REST_Orders_Controller`, plugins built on Jetpack package REST classes,
+and CPT plugins inheriting from `WP_REST_Posts_Controller` all hit this
+pattern.
+
+Handling:
+
+- Record the route on the child class (that's where the plugin's REST surface
+  actually exposes it).
+- Set `backing.route_registration_line: null` and
+  `backing.callback_line: null` in the audit schema.
+- Add `backing.inherited_from: "<parent FQCN>"` so downstream skills can tell
+  the inheritance case from a plain missing line number.
+- Consider running grep against the parent repo too when you need to confirm
+  the callback's request handling — inherited callbacks behave as whatever
+  the parent defines, not what the plugin repo documents.
+
+See `audit-schema.md` for the exact field shapes.
+
+## Exhaustiveness is the goal
+
+The "Controller Inventory" table in the audit doc must list every controller
+the enumeration found — not just ones backing proposed abilities. A reviewer
+asking "why isn't controller X in the MVP?" should be able to point at the
+inventory and see the explicit answer (usually: "excluded from MVP because…"
+or "surfaced as a gap because…").
+
+If your inventory has 3 entries and the plugin clearly exposes more, either
+the enumeration is incomplete (re-run grep with broader patterns) or you're
+filtering the inventory instead of the proposal list. Fix the inventory
+first; filter after.
+
+## Escalation
+
+If neither glob nor grep produces a complete inventory — for example a
+plugin that registers routes dynamically from config or via a factory that
+does not contain a literal `register_rest_route(` string — document the
+enumeration gap in "Notes and Surprises", and extend this reference with the
+new pattern once understood.


### PR DESCRIPTION
Adds the `wp-abilities-audit` skill — surveys a plugin's REST surface and produces a structured audit document proposing Abilities API registrations. The audit doc is a planning artifact: readable by humans, parseable by tooling. Stacks on #45 (merged #44 is in `trunk` as `26aa4e8`).

## What lands

| File | Purpose |
|---|---|
| `skills/wp-abilities-audit/SKILL.md` | 7-step procedure: enumerate controllers, extract backing fields, confirm capability gates, propose abilities via semantic-intent grouping, surface gaps, write the doc, optionally designate a reference ability. |
| `references/audit-schema.md` | Canonical schema. Top-level fields (plugin, repo, branch, dates, capability_gate, plus optional plugin_family). Per-ability fields include the three required implementation-readiness fields (`use_case_fit`, `side_effects`, `seed_data_needs`) plus `backing.kind` (`rest_controller` / `service` / `helper` / `data_store`) and `permission.source` (`rest_controller` / `admin_action` / `service` / `domain_policy` / `post_type_map` / `none`). `side_effects: []` is the load-bearing fact that unlocks the conditional delegation shortcut in `shared-core-service.md`; a non-empty array selects the shared-service shape. Two legal `capability_gate` forms (single string vs structured `{read, write}`). `backing: null` semantics. WARN-not-FAIL posture for audits authored before the schema bumps. Copy-pasteable minimal example. |
| `references/capability-gate-tracing.md` | Procedure for tracing the *permission source* (REST callback / admin action / service method / domain policy / post-type cap map) for each proposed behavior, not just the REST route. Mechanism A (direct: base controller calls `current_user_can()` once) and Mechanism B (post-type-backed: controllers extend `WP_REST_Posts_Controller`-family, permission resolves dynamically via core's `map_meta_cap()`). Tracing recipes and YAML representation for each. |
| `references/controller-enumeration.md` | Two enumeration paths — glob for standard layouts, grep as universal fallback — with guidance on monorepos, inherited routes, and the exhaustiveness rule. |
| `eval/scenarios/wp-abilities-audit.json` | Eval scenario covering a non-standard REST layout with post-type-backed capabilities and a missing-backing gap; success criteria assert the three implementation-readiness fields get populated. |

## Verification at tip

- All cross-references resolve within the #45/#46 stack on top of merged #44.
- PHP code blocks parse on PHP 7.2.
- `node eval/harness/run.mjs` passes.

## Status

Round 4 (current tip). Iteration:

- **Round 1** — original scope.
- **Round 2** (`34cfb58`) — added three implementation-readiness fields (`use_case_fit`, `side_effects`, `seed_data_needs`) per @nerrad's 2026-05-21 generalized learning.
- **Round 3** (`ac09d3b`) — tied `side_effects` to the Shape 2 vs Shape 3 decision in `shared-core-service.md`; added the backwards-compat WARN bullet; genericized the `seed_data_needs` example; updated the eval scenario.
- **Round 4** (`238d772` + `1612600` + `e597aaf`) — addressed @nerrad's three inline comments from 2026-05-21 00:18 UTC. `238d772` adds `backing.kind` and `permission.source` enum fields (closes the bullet-1 ask in `#discussion_r3277895737` that bullets 2 and 3 closed in round 2). `1612600` adds the use-case sanity check to the SKILL.md procedure before populating ability fields (closes `#discussion_r3277895795`). `e597aaf` rewrites the permission-tracing procedure to frame drift against plugin behavior rather than REST route, with the new `permission.source` enum as the recording field (closes `#discussion_r3277895951`).

Rebased after #44 merged on 2026-05-26; once #45 merges, this PR's diff narrows to just the 11 audit-skill commits.


