### PR TITLE
wp-abilities-verify: add new skill for verifying Abilities API registrations including adversarial readonly-but-writes detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Agent Skills solve this by giving AI assistants **expert-level WordPress knowled
 | **wp-rest-api** | REST API routes/endpoints, schema, auth, and response shaping |
 | **wp-interactivity-api** | Frontend interactivity with `data-wp-*` directives and stores |
 | **wp-abilities-api** | Capability-based permissions and REST API authentication |
+| **wp-abilities-audit** | Audit a plugin's REST surface and propose Abilities API registrations |
+| **wp-abilities-verify** | Verify a plugin's Abilities API registrations against their declared annotations |
 | **wp-wpcli-and-ops** | WP-CLI commands, automation, multisite, search-replace |
 | **wp-performance** | Profiling, caching, database optimization, Server-Timing |
 | **wp-phpstan** | PHPStan static analysis for WordPress projects (config, baselines, WP-specific typing) |

--- a/eval/scenarios/wp-abilities-audit.json
+++ b/eval/scenarios/wp-abilities-audit.json
@@ -10,7 +10,8 @@
     "Step 5: Apply semantic-intent grouping per wp-abilities-api/references/grouping-heuristic.md; do NOT atomize one ability per HTTP method",
     "Step 6: Mark inherited routes with backing.inherited_from and null line numbers per audit-schema.md",
     "Step 7: Write the audit doc to the user-provided output path, NOT into the plugin worktree",
-    "Step 8: Include at least one entry in surfaced_gaps for a high-leverage zero-arg candidate or a backing: null gap"
+    "Step 8: Include at least one entry in surfaced_gaps for a high-leverage zero-arg candidate or a backing: null gap",
+    "Step 9: For each proposed ability, record the implementation-readiness fields per audit-schema.md: use_case_fit (one-sentence workflow), side_effects (array; empty list is a load-bearing fact, not a missing value), seed_data_needs (representative-data shape or null)"
   ],
   "success_criteria": [
     "Routes to wp-abilities-audit skill",
@@ -19,6 +20,7 @@
     "proposed_abilities has at least 3 entries with at least one read and one write",
     "surfaced_gaps array has at least one entry",
     "Controller Inventory table lists every controller grep enumerated",
-    "Notes and Surprises section captures at least one judgment call"
+    "Notes and Surprises section captures at least one judgment call",
+    "Every entry in proposed_abilities populates use_case_fit, side_effects, and seed_data_needs (the implementation-readiness fields)"
   ]
 }

--- a/eval/scenarios/wp-abilities-audit.json
+++ b/eval/scenarios/wp-abilities-audit.json
@@ -1,0 +1,24 @@
+{
+  "name": "Produce an Abilities API audit doc for a plugin with a non-standard REST layout",
+  "skills": ["wordpress-router", "wp-project-triage", "wp-abilities-audit", "wp-abilities-api"],
+  "query": "I'm working on a plugin checkout that currently registers zero abilities. Its REST controllers live under `includes/api/` (not the standard `includes/admin/` layout) and extend a post-type-backed base controller for a custom post type with distinct read and write capabilities. Produce a Phase-1 Abilities API audit doc at `~/notes/2026-04-20-abilities-audit-<plugin>.md` so we can hand it to engineering for implementation.",
+  "expected_behavior": [
+    "Step 1: Run wordpress-router to classify the repo, then route to wp-abilities-audit",
+    "Step 2: Run wp-project-triage to populate version signals",
+    "Step 3: Use glob-first/grep-fallback enumeration; fall through to grep because includes/admin glob returns zero hits",
+    "Step 4: Trace post-type-backed capabilities and produce a {read, write} structured capability_gate",
+    "Step 5: Apply semantic-intent grouping per wp-abilities-api/references/grouping-heuristic.md; do NOT atomize one ability per HTTP method",
+    "Step 6: Mark inherited routes with backing.inherited_from and null line numbers per audit-schema.md",
+    "Step 7: Write the audit doc to the user-provided output path, NOT into the plugin worktree",
+    "Step 8: Include at least one entry in surfaced_gaps for a high-leverage zero-arg candidate or a backing: null gap"
+  ],
+  "success_criteria": [
+    "Routes to wp-abilities-audit skill",
+    "Output is a markdown file at the user-specified path with Last updated header, YAML block, and prose sections",
+    "capability_gate uses the structured {read, write} object form",
+    "proposed_abilities has at least 3 entries with at least one read and one write",
+    "surfaced_gaps array has at least one entry",
+    "Controller Inventory table lists every controller grep enumerated",
+    "Notes and Surprises section captures at least one judgment call"
+  ]
+}

--- a/eval/scenarios/wp-abilities-verify.json
+++ b/eval/scenarios/wp-abilities-verify.json
@@ -1,0 +1,26 @@
+{
+  "name": "Verify abilities registrations and catch a readonly-but-writes violation",
+  "skills": ["wordpress-router", "wp-abilities-verify", "wp-abilities-audit", "wp-abilities-api", "wp-project-triage"],
+  "query": "I have a WordPress plugin checkout with 7 registered abilities — 6 read abilities annotated readonly: true and 1 write ability annotated readonly: false, destructive: true. One of the six read abilities accidentally calls $wpdb->update(...) inside its execute callback after a recent refactor. I also have an audit doc at ~/vault/plans/2026-04-20-abilities-audit-<plugin>.md that declared the expected annotations before the refactor. Run wp-abilities-verify in static mode against the plugin checkout and write the structured report to ~/vault/plans/2026-04-20-verify-<plugin>.md.",
+  "expected_behavior": [
+    "Step 1: Route to wp-abilities-verify because the task is 'verify abilities registrations'",
+    "Step 2: Validate the audit doc against audit-schema-validation.md (required fields, at-most-one reference_ability, surfaced_gaps consistency for backing: null entries)",
+    "Step 3: Enumerate abilities statically per static-enumeration.md; record 7 registrations and resolve each callback to file + line range",
+    "Step 4: Run the adversarial readonly-but-writes check per annotation-correctness.md against every callback body",
+    "Step 5: FLAG the offending read ability with FAIL, citing file + line of the $wpdb->update(...) call",
+    "Step 6: Return OK on the adversarial check for the other 5 readonly abilities and N/A for the write ability (readonly not claimed)",
+    "Step 7: Run schema lints and permission roundtrip in static-only mode",
+    "Step 8: Cross-reference error codes (non-vocabulary codes WARN, not FAIL)",
+    "Step 9: Write a structured markdown report at the user-specified path with Last updated header and Status: FAIL"
+  ],
+  "success_criteria": [
+    "Routes to wp-abilities-verify skill",
+    "Output is a markdown file at the user-specified path",
+    "Top-line status is FAIL",
+    "Annotation correctness table has exactly one FAIL row, for the ability that calls $wpdb->update, with file + line evidence",
+    "The other 5 read abilities each have a passing readonly row",
+    "The write ability has no FAIL in the annotation-correctness table",
+    "Audit doc validation section confirms well-formedness or flags specific mismatches",
+    "Report header notes Static Mode so reader knows runtime checks weren't executed"
+  ]
+}

--- a/eval/scenarios/wp-abilities-verify.json
+++ b/eval/scenarios/wp-abilities-verify.json
@@ -8,7 +8,7 @@
     "Step 3: Enumerate abilities statically per static-enumeration.md; record 7 registrations and resolve each callback to file + line range",
     "Step 4: Run the adversarial readonly-but-writes check per annotation-correctness.md against every callback body",
     "Step 5: FLAG the offending read ability with FAIL, citing file + line of the $wpdb->update(...) call",
-    "Step 6: Return OK on the adversarial check for the other 5 readonly abilities and N/A for the write ability (readonly not claimed)",
+    "Step 6: Return OK on the adversarial check for the other 5 readonly abilities and OK (write path confirmed) for the write ability (readonly=false annotation acknowledged; check only applies when readonly=true)",
     "Step 7: Run schema lints and permission roundtrip in static-only mode",
     "Step 8: Cross-reference error codes (non-vocabulary codes WARN, not FAIL)",
     "Step 9: Write a structured markdown report at the user-specified path with Last updated header and Status: FAIL"

--- a/skills/wp-abilities-api/SKILL.md
+++ b/skills/wp-abilities-api/SKILL.md
@@ -53,6 +53,10 @@ For grouping decisions (how many abilities to register, and where to put filters
 
 To avoid drift between the ability and the existing UI / REST code path, see `references/shared-core-service.md` — abilities, REST handlers, CLI commands, and UI controllers should be thin adapters over a shared service. The reference also covers the metric trap (REST handlers that emit usage telemetry) and the `AGENTS.md` rule for keeping registrations in sync when underlying code paths change.
 
+For shared helper patterns when multiple execute callbacks delegate to existing REST controllers, see `references/plugin-family-patterns.md` (pick the shared-API-client vs zero-arg-controllers shape) and `references/delegate-helper-pattern.md` (the canonical helper and when not to use it).
+
+For standardized `WP_Error` codes that let agents reason about retry vs. escalation, see `references/error-code-vocabulary.md`.
+
 Implement the ability in PHP registration with:
 
 - stable `id` (namespaced),
@@ -92,6 +96,8 @@ Use the documented init hooks for Abilities API registration so they load at the
   - wrong REST base/namespace,
   - JS dependency not bundled,
   - caching (object/page caches) masking changes.
+- Execute callback returns unexpected errors or silently ignores input:
+  - `input_schema` defaults aren't being applied, pagination key drift between the ability and the backing, or `empty()`-based ID validation — see `references/input-schema-gotchas.md`.
 
 ## Escalation
 

--- a/skills/wp-abilities-api/SKILL.md
+++ b/skills/wp-abilities-api/SKILL.md
@@ -53,7 +53,7 @@ For grouping decisions (how many abilities to register, and where to put filters
 
 To avoid drift between the ability and the existing UI / REST code path, see `references/shared-core-service.md` — abilities, REST handlers, CLI commands, and UI controllers should be thin adapters over a shared service. The reference also covers the metric trap (REST handlers that emit usage telemetry) and the `AGENTS.md` rule for keeping registrations in sync when underlying code paths change.
 
-For shared helper patterns when multiple execute callbacks delegate to existing REST controllers, see `references/plugin-family-patterns.md` (pick the shared-API-client vs zero-arg-controllers shape) and `references/delegate-helper-pattern.md` (the canonical helper and when not to use it).
+For shared helper patterns when multiple execute callbacks delegate to existing REST controllers, see `references/plugin-family-patterns.md` (identify the shared-API-client vs zero-arg-controllers shape) and `references/delegate-helper-pattern.md` (one helper shape that works, and when not to use it).
 
 For standardized `WP_Error` codes that let agents reason about retry vs. escalation, see `references/error-code-vocabulary.md`.
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -1,0 +1,215 @@
+# Delegate helper pattern
+
+When an ability's execute callback needs to hand work to an existing REST controller instead of duplicating business logic, extract a `delegate_to_rest_controller` helper. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
+
+Read `plugin-family-patterns.md` first — the helper's exact shape depends on whether your plugin follows the shared-API-client pattern or the zero-arg-controllers pattern.
+
+## Why this helper exists
+
+List-style read abilities typically repeat the same four steps in every execute callback:
+
+1. Validate the plugin is initialized (class exists + dependencies resolved).
+2. Build a `WP_REST_Request` and copy the ability's `$input` onto it as params.
+3. Instantiate the backing controller and invoke the named method.
+4. Unwrap the response (controllers return either a raw array or a `WP_REST_Response`).
+
+Four abilities × this repetition = the boilerplate dominates the callback body. Extracting a helper keeps each execute callback a 3–4 line function that reads like pseudocode.
+
+## When to extract
+
+After the **second** list-style ability lands. Before the third ability gets added, refactor the duplicated code out of the first two execute callbacks into a private static helper. Convert subsequent abilities to call the helper as you add them.
+
+If the plugin only ever ships one or two abilities, inline the code. The helper's payoff is at 3+ callers.
+
+## Canonical signature (Pattern A — shared-API-client)
+
+```php
+/**
+ * Delegate an ability's execute callback to a REST controller.
+ *
+ * Builds a WP_REST_Request from the ability's input, instantiates the
+ * backing controller with the plugin's shared API client, invokes the
+ * named method, and normalizes the return so callers always see
+ * array|\WP_Error. Controllers in this plugin return either a
+ * WP_REST_Response or a raw array; the helper unwraps both shapes.
+ *
+ * Not used by zero-arg abilities — those call their controller directly
+ * so we don't synthesize a WP_REST_Request just to discard it.
+ *
+ * @param string     $controller_class Fully-qualified controller class (no leading backslash).
+ * @param string     $method           Controller method to invoke on the built request.
+ * @param string     $route            REST route string used when constructing WP_REST_Request.
+ * @param array|null $input            Ability input; each key/value becomes a request param.
+ * @param string     $http_method      HTTP method for WP_REST_Request. Defaults to 'GET'; writes pass 'POST'.
+ * @return array|\WP_Error             Response payload as an array, or WP_Error on failure.
+ */
+private static function delegate_to_rest_controller(
+    string $controller_class,
+    string $method,
+    string $route,
+    ?array $input,
+    string $http_method = 'GET'
+) {
+    $fqcn = '\\' . $controller_class;
+
+    // Guard 1: controller class is loaded.
+    if ( ! class_exists( $fqcn ) ) {
+        return new \WP_Error(
+            '<plugin>_not_initialized',
+            __( '<Plugin> is not initialized.', '<text-domain>' )
+        );
+    }
+
+    // Guard 2: shared API client is available.
+    $api_client = null;
+    if ( class_exists( '\<Plugin_Main_Class>' ) && method_exists( '\<Plugin_Main_Class>', 'get_<client_accessor>' ) ) {
+        $api_client = \<Plugin_Main_Class>::get_<client_accessor>();
+    }
+    if ( null === $api_client ) {
+        return new \WP_Error(
+            '<plugin>_not_initialized',
+            __( '<Plugin> is not initialized.', '<text-domain>' )
+        );
+    }
+
+    // Build the request.
+    $request = new \WP_REST_Request( $http_method, $route );
+    if ( null !== $input ) {
+        foreach ( $input as $param => $value ) {
+            $request->set_param( $param, $value );
+        }
+    }
+
+    // Invoke + guard 3: WP_Error short-circuit + dual-shape unwrap.
+    $controller = new $fqcn( $api_client );
+    $response   = $controller->{$method}( $request );
+
+    if ( is_wp_error( $response ) ) {
+        return $response;
+    }
+    if ( $response instanceof \WP_REST_Response ) {
+        $data = $response->get_data();
+        return is_array( $data ) ? $data : [];
+    }
+    return is_array( $response ) ? $response : [];
+}
+```
+
+Positional (not named) arguments on purpose — the helper is called from every list ability and keyword-args for PHP 8 would add visual noise. Order is intentional: controller, method, route, input, http_method (the defaultable tail).
+
+## The three guards
+
+### 1. `class_exists` on the controller
+
+Execute callbacks can be reached on sites where the plugin's classes haven't loaded (tests, WP-CLI with limited bootstrap, admin pages with conditional autoloading). Check is cheap; without it a missing class produces a fatal.
+
+Note `'\\' . $controller_class` — accept controller class names without a leading backslash (readable in config arrays) and re-add it so `class_exists` and `new $fqcn(...)` both root-resolve.
+
+### 2. Required dependency (API client) null-check
+
+For Pattern A plugins the accessor is a `public static` method on the main plugin class. Both `class_exists` on the plugin class AND `method_exists` on the accessor are guarded because either could be absent during partial bootstraps. A null return from the accessor is also treated as "not initialized".
+
+Missing this argument produces `ArgumentCountError: Too few arguments to function <Controller>::__construct(), 0 passed` — a PHP fatal. The standardized `<plugin>_not_initialized` error code is documented in `error-code-vocabulary.md`.
+
+For Pattern B plugins, this guard is either skipped entirely (zero-arg constructor) or replaced with construction-time scalar args passed in via an optional `constructor_args` parameter.
+
+### 3. `is_wp_error` short-circuit
+
+Before trying to unwrap the response, check if it's already a `WP_Error`. Several controllers return `WP_Error` for both validation failures and upstream failures; that error needs to bubble up intact so the agent can see the upstream code.
+
+## Dual response-shape unwrap
+
+```php
+if ( $response instanceof \WP_REST_Response ) {
+    $data = $response->get_data();
+    return is_array( $data ) ? $data : [];
+}
+return is_array( $response ) ? $response : [];
+```
+
+Real WordPress REST controllers return either:
+- A `WP_REST_Response` (the output of `rest_ensure_response( ... )` or `new WP_REST_Response( ... )`), or
+- A raw array (typical when a controller delegates to an internal request-handler class that returns the decoded transport payload directly).
+
+Both happen. The helper unwraps `WP_REST_Response` via `get_data()` and passes raw arrays through. The `is_array(...) ? ... : []` coalesce defends against a non-array return type that the ability's `output_schema` would have rejected downstream anyway — returning `[]` fails safely rather than leaking a surprising type.
+
+## When NOT to use the helper
+
+Two categories of abilities bypass the helper and call the backing directly:
+
+### Zero-arg backing methods
+
+If the backing method takes no `WP_REST_Request` parameter, don't synthesize a request just to discard it. Call the method directly:
+
+```php
+public static function execute_get_overview( $input = null ) {
+    if ( ! class_exists( '\My_Plugin_REST_Overview_Controller' ) ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+
+    $api_client = /* ... same accessor check ... */;
+    if ( null === $api_client ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+
+    $controller = new \My_Plugin_REST_Overview_Controller( $api_client );
+    $response   = $controller->get_overview(); // No $request argument.
+
+    if ( is_wp_error( $response ) ) {
+        return $response;
+    }
+    return is_array( $response ) ? $response : [];
+}
+```
+
+### Abilities that use a non-REST service
+
+If the execute callback reaches a service directly (e.g. `My_Plugin::get_account_service()->get_cached_account_data()`) rather than a REST controller, stay on the direct path. The ability is not REST-backed and the helper would add a construction step for no gain.
+
+## Rule of thumb
+
+**If the backing method's signature includes `WP_REST_Request`, use the helper. Otherwise direct-path.**
+
+## Conversion pattern — before and after
+
+Before extraction (inline in the execute callback):
+
+```php
+public static function execute_get_things( $input = null ) {
+    if ( ! class_exists( '\My_Plugin_REST_Things_Controller' ) ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+    $api_client = \My_Plugin::get_api_client();
+    if ( ! $api_client ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+    $request = new \WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+    foreach ( (array) $input as $param => $value ) {
+        $request->set_param( $param, $value );
+    }
+    $controller = new \My_Plugin_REST_Things_Controller( $api_client );
+    $response   = $controller->get_things( $request );
+    // ... unwrap ...
+}
+```
+
+After extraction:
+
+```php
+public static function execute_get_things( $input = null ) {
+    return self::delegate_to_rest_controller(
+        'My_Plugin_REST_Things_Controller',
+        'get_things',
+        '/my-plugin/v1/things',
+        is_array( $input ) ? $input : null
+    );
+}
+```
+
+Note the `is_array( $input ) ? $input : null` — the helper signature is `?array`, and passing `null` tells it to build the request with no params at all. This matters because the Abilities API sometimes invokes a callback with no input object.
+
+## Related references
+
+- `plugin-family-patterns.md` — choosing the helper's constructor shape.
+- `error-code-vocabulary.md` — the `<plugin>_not_initialized` code and its siblings.
+- `input-schema-gotchas.md` — callbacks for list abilities often need `per_page` pagination translation BEFORE calling the helper.

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -1,8 +1,8 @@
 # Delegate helper pattern
 
-Once you've decided delegation is the right shape for an ability — that is, the backing REST controller is a pure data-fetch, the operation is a read, and the ability runs predominantly inside REST contexts (see `shared-core-service.md` for when the answer is "no, extract a shared service" instead) — extract a `delegate_to_rest_controller` helper rather than open-coding the request-build/dispatch/unwrap pipeline in each execute callback. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
+Once you've decided delegation is the right shape for an ability — that is, the backing REST controller is a pure data-fetch, the operation is a read, and the ability runs predominantly inside REST contexts (see `shared-core-service.md` for when the answer is "no, extract a shared service" instead) — extract a `delegate_to_rest_controller` helper rather than open-coding the request-build/dispatch/unwrap pipeline in each execute callback. This reference documents one helper shape that works, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all. Adapt the exact signature to the plugin you're working in — the guards and unwrap matter more than the parameter list.
 
-Read `plugin-family-patterns.md` first — the helper's exact shape depends on whether your plugin follows the shared-API-client pattern or the zero-arg-controllers pattern.
+Read `plugin-family-patterns.md` first — the helper's exact shape depends on how the backing controller is constructed (shared API client vs. zero-arg).
 
 ## Why this helper exists
 
@@ -21,7 +21,7 @@ After the **second** list-style ability lands. Before the third ability gets add
 
 If the plugin only ever ships one or two abilities, inline the code. The helper's payoff is at 3+ callers.
 
-## Canonical signature (Pattern A — shared-API-client)
+## Helper shape
 
 ```php
 /**
@@ -107,11 +107,11 @@ Note `'\\' . $controller_class` — accept controller class names without a lead
 
 ### 2. Required dependency (API client) null-check
 
-For Pattern A plugins the accessor is a `public static` method on the main plugin class. Both `class_exists` on the plugin class AND `method_exists` on the accessor are guarded because either could be absent during partial bootstraps. A null return from the accessor is also treated as "not initialized".
+When the controller takes a shared API client as a constructor argument, the accessor is typically a `public static` method on the main plugin class. Guard both `class_exists` on the plugin class AND `method_exists` on the accessor because either could be absent during partial bootstraps. Treat a null return from the accessor as "not initialized".
 
 Missing this argument produces `ArgumentCountError: Too few arguments to function <Controller>::__construct(), 0 passed` — a PHP fatal. The standardized `<plugin>_not_initialized` error code is documented in `error-code-vocabulary.md`.
 
-For Pattern B plugins, this guard is either skipped entirely (zero-arg constructor) or replaced with construction-time scalar args passed in via an optional `constructor_args` parameter.
+When the controller takes no constructor args, skip this guard entirely. When it takes only simple scalars (e.g. a post-type string), pass them in via an optional `constructor_args` parameter on the helper.
 
 ### 3. `is_wp_error` short-circuit
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -1,6 +1,6 @@
 # Delegate helper pattern
 
-When an ability's execute callback needs to hand work to an existing REST controller instead of duplicating business logic, extract a `delegate_to_rest_controller` helper. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
+Once you've decided delegation is the right shape for an ability — that is, the backing REST controller is a pure data-fetch, the operation is a read, and the ability runs predominantly inside REST contexts (see `shared-core-service.md` for when the answer is "no, extract a shared service" instead) — extract a `delegate_to_rest_controller` helper rather than open-coding the request-build/dispatch/unwrap pipeline in each execute callback. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
 
 Read `plugin-family-patterns.md` first — the helper's exact shape depends on whether your plugin follows the shared-API-client pattern or the zero-arg-controllers pattern.
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -135,7 +135,33 @@ Both happen. The helper unwraps `WP_REST_Response` via `get_data()` and passes r
 
 ## When NOT to use the helper
 
-Two categories of abilities bypass the helper and call the backing directly:
+Three categories of abilities bypass the helper and call the backing directly:
+
+### Backing request class can be invoked without the controller
+
+If the REST controller's only role is to translate `WP_REST_Request` into a call to an underlying request class (e.g., `Things_Request::from_rest_request( $request )->execute()`) and adds no validation, permission logic, or orchestration on top, bypass the controller and call the request class directly:
+
+```php
+public static function execute_get_things( $input = null ) {
+    if ( ! class_exists( '\My_Plugin\Things_Request' ) ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+
+    $request = new \WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+    foreach ( (array) $input as $param => $value ) {
+        $request->set_param( $param, $value );
+    }
+
+    $things_request = \My_Plugin\Things_Request::from_rest_request( $request );
+    $rows           = $things_request->execute();
+
+    return is_array( $rows ) ? $rows : [];
+}
+```
+
+The `WP_REST_Request` object exists only to satisfy `from_rest_request()`'s parameter contract — nothing dispatches it. This is the shortest path through the layers: no controller construction, no controller-emitted side effects, and (when the request class is hit before any REST traffic in the lifecycle) no `rest_api_init` cost. See `shared-core-service.md` for the broader discussion of REST-path side effects and the first-call bootstrap cost on cold paths.
+
+The tradeoff is real: bypassing the controller bypasses anything the controller does. If the controller runs validation that the request class doesn't, or emits an audit hook the request class doesn't, that work is lost on the ability path. Use this shape when the controller is genuinely a thin wrapper, not when it's doing work you'd want to keep.
 
 ### Zero-arg backing methods
 
@@ -168,7 +194,7 @@ If the execute callback reaches a service directly (e.g. `My_Plugin::get_account
 
 ## Rule of thumb
 
-**If the backing method's signature includes `WP_REST_Request`, use the helper. Otherwise direct-path.**
+**If the backing method takes `WP_REST_Request` and the controller adds something beyond delegating to an underlying request class (validation, permissions, orchestration, side effects you want to keep), use the helper. If the controller is a thin wrapper over a request class, call the request class directly. Otherwise direct-path.**
 
 ## Conversion pattern — before and after
 

--- a/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -44,11 +44,11 @@ If the plugin only ever ships one or two abilities, inline the code. The helper'
  * @return array|\WP_Error             Response payload as an array, or WP_Error on failure.
  */
 private static function delegate_to_rest_controller(
-    string $controller_class,
-    string $method,
-    string $route,
-    ?array $input,
-    string $http_method = 'GET'
+    $controller_class,
+    $method,
+    $route,
+    $input,
+    $http_method = 'GET'
 ) {
     $fqcn = '\\' . $controller_class;
 

--- a/skills/wp-abilities-api/references/error-code-vocabulary.md
+++ b/skills/wp-abilities-api/references/error-code-vocabulary.md
@@ -1,0 +1,123 @@
+# Error code vocabulary
+
+Every `WP_Error` returned from an ability's execute callback should use a code drawn from this small vocabulary. A consistent vocabulary lets the agent (or the caller in your automation) build retry and recovery logic that matches on codes instead of parsing error messages.
+
+## Why standardized codes matter
+
+Agents that orchestrate multiple abilities need to know: "did this fail because of my input, or because something downstream is unreachable?" The answer drives retry strategy:
+
+- Bootstrap failures → surface to the human, don't retry.
+- Input shape errors → fix the input and retry the same call.
+- Transient backend errors → retry with backoff; may succeed on its own.
+- Upstream third-party errors → may need a different strategy entirely.
+
+Without a convention, every plugin invents its own codes and agents can't reason uniformly across them. The categories below cover 95% of real-world ability errors; sticking to them means an agent that learned the retry logic for one plugin can reuse it for the next.
+
+## Vocabulary
+
+Substitute `<plugin>` with the plugin's slug in lowercase, underscores only (e.g. `woopayments`, `jetpack_forms`). This matches WordPress error-code conventions. If the plugin already has a house style for error codes (WooPayments uses `woopayments`, not `woo_payments`), mirror that — consistency within a plugin trumps consistency across the vocabulary.
+
+| Code | When to use | Agent behavior |
+|---|---|---|
+| `<plugin>_not_initialized` | Plugin class missing, shared service accessor returns null, required dependency isn't resolvable. | Not retriable from the agent side. Usually a config or bootstrap-ordering problem. Escalate. |
+| `<plugin>_missing_<field>` | A required input field is missing or empty (your execute callback's own check, not the schema-validator's). | Agent should add the field and retry. |
+| `<plugin>_invalid_<field>` | Field is present but semantically wrong (bad enum value, malformed date, wrong type). | Agent should correct the value and retry. |
+| `<plugin>_<resource>_data_unavailable` | Backing service returned a transient error (cache miss + remote failure, upstream 5xx, stale-while-revalidate failed). | Agent can retry, probably with backoff. |
+| `ability_invalid_input` | The Abilities API's own schema-validator rejected the input before the execute callback ran. | Equivalent to `<plugin>_missing_<field>` or `<plugin>_invalid_<field>`, just thrown earlier in the pipeline. Agent should fix input. |
+
+### `ability_invalid_input` — the earlier path
+
+When an ability is invoked via the Abilities API REST bridge, the registered `input_schema` runs first. Missing required fields or type mismatches produce `WP_Error( 'ability_invalid_input' )` BEFORE the execute callback fires. Direct invocation (unit tests, non-REST wrappers) bypasses schema validation and hits your execute callback's own checks instead, producing `<plugin>_missing_<field>` / `<plugin>_invalid_<field>`.
+
+Both paths are acceptable — end-agent-facing behavior is equivalent (deterministic validation error, no side effects). Document the observation in the ability's PR description or "notes for reviewers" so reviewers know both codes are expected in different harness runs.
+
+## Worked examples
+
+```php
+// Bootstrap incomplete — plugin class missing or accessor returned null.
+return new \WP_Error(
+    '<plugin>_not_initialized',
+    __( '<Plugin> is not initialized.', '<text-domain>' )
+);
+
+// Required field missing (execute-callback check, schema was bypassed).
+return new \WP_Error(
+    '<plugin>_missing_<field>',
+    __( 'A <field> is required to <do the thing>.', '<text-domain>' )
+);
+
+// Field present but malformed.
+return new \WP_Error(
+    '<plugin>_invalid_<field>',
+    sprintf(
+        /* translators: %s: input parameter name. */
+        __( 'The "%s" parameter must be an ISO 8601 date-time string.', '<text-domain>' ),
+        $key
+    )
+);
+
+// Transient backend error.
+return new \WP_Error(
+    '<plugin>_<resource>_data_unavailable',
+    __( 'Unable to retrieve <resource> data. The cache may be stale or the remote service returned an error.', '<text-domain>' )
+);
+```
+
+## Upstream codes can bubble through — and usually should
+
+If the backing controller talks to a third-party API (Stripe, WPCOM, another SaaS), its own error codes may surface verbatim in `WP_Error::get_error_code()` the ability returns. Typical examples:
+
+- `resource_missing` — Stripe's "object ID not found" code. Tells an agent the specific ID was wrong.
+- `rate_limited` — upstream throttling. Tells an agent to slow down.
+
+**Let these through rather than re-wrapping.** A re-wrapped `<plugin>_<resource>_not_found` loses the information that would help the agent act. Document the upstream codes you've observed in the ability's `description` or PR notes so reviewers know they're expected.
+
+## Code naming rules
+
+1. **Lowercase, underscores only.** `<plugin>_missing_order_id`, not `<plugin>-missingOrderId` or `<Plugin>-MissingOrderId`.
+2. **Plugin prefix first.** Multi-word slugs should normalize to a single-word prefix where the plugin already does (e.g. `woopayments` rather than `woo_payments`).
+3. **Action second.** Use one of `missing`, `invalid`, `not_initialized`, `<resource>_data_unavailable`.
+4. **Field or resource name last.** `<plugin>_missing_dispute_id`, not `<plugin>_dispute_id_missing`. This matches English phrasing ("a dispute_id is required") and is faster to skim in error logs.
+
+## Internationalization
+
+Error MESSAGES are translatable via `__()` or `sprintf(__())`. Error CODES are not — they're stable machine identifiers.
+
+```php
+// WRONG — don't translate the code.
+return new \WP_Error( __( '<plugin>_missing_order_id', '<text-domain>' ), ... );
+
+// RIGHT — code is a literal, message is translatable.
+return new \WP_Error(
+    '<plugin>_missing_order_id',
+    __( 'An order_id is required.', '<text-domain>' )
+);
+```
+
+When a message interpolates a parameter name or value, include a translator comment:
+
+```php
+return new \WP_Error(
+    '<plugin>_invalid_date',
+    sprintf(
+        /* translators: %s: input parameter name. */
+        __( 'The "%s" parameter must be an ISO 8601 date-time string.', '<text-domain>' ),
+        $key
+    )
+);
+```
+
+## Don't over-specify
+
+The goal is consistent codes across all of a plugin's abilities, not ultra-fine granularity. `<plugin>_missing_dispute_id` is the right level. `<plugin>_missing_dispute_id_in_submit_evidence_context` is not — the ability name belongs in `WP_Error::get_error_data()` or in the agent's calling context, not in the code.
+
+## Summary — the four questions
+
+When writing an execute callback, ask in order:
+
+1. Can the plugin even service this call? → `<plugin>_not_initialized`.
+2. Is the required input present? → `<plugin>_missing_<field>`.
+3. Is the required input the right shape? → `<plugin>_invalid_<field>`.
+4. Did the backing service choke? → `<plugin>_<resource>_data_unavailable`, or let the upstream code bubble through.
+
+Four categories, one consistent code vocabulary per plugin. That's enough for agents to build reliable retry logic on top.

--- a/skills/wp-abilities-api/references/error-code-vocabulary.md
+++ b/skills/wp-abilities-api/references/error-code-vocabulary.md
@@ -15,7 +15,7 @@ Without a convention, every plugin invents its own codes and agents can't reason
 
 ## Vocabulary
 
-Substitute `<plugin>` with the plugin's slug in lowercase, underscores only (e.g. `woopayments`, `jetpack_forms`). This matches WordPress error-code conventions. If the plugin already has a house style for error codes (WooPayments uses `woopayments`, not `woo_payments`), mirror that — consistency within a plugin trumps consistency across the vocabulary.
+Substitute `<plugin>` with the plugin's slug in lowercase, underscores only. This matches WordPress error-code conventions. If the plugin already has a house style — for example, a single-word slug that deliberately omits underscores between elided words — mirror that. Consistency within a plugin trumps consistency across the vocabulary.
 
 | Code | When to use | Agent behavior |
 |---|---|---|

--- a/skills/wp-abilities-api/references/input-schema-gotchas.md
+++ b/skills/wp-abilities-api/references/input-schema-gotchas.md
@@ -1,0 +1,221 @@
+# Input schema gotchas
+
+Three surprises the Abilities API's `input_schema` will ship with if you rely on schema declarations alone. All three have been caught in real plugin work after the schema looked correct and tests passed; each has a defensive pattern that makes the execute callback robust regardless.
+
+## 1. Schema `default` values are NOT injected into execute callback input
+
+### Problem
+
+`wp_register_ability()` lets you declare per-property defaults in `input_schema`:
+
+```php
+'input_schema' => [
+    'type'       => 'object',
+    'properties' => [
+        'submit' => [
+            'type'        => 'boolean',
+            'default'     => false,
+            'description' => __( 'Whether to submit evidence for review.', '<text-domain>' ),
+        ],
+    ],
+],
+```
+
+The Abilities API's validate path enforces `type` and `required`, but it does NOT populate missing properties with their declared `default`. If an agent invokes the ability with `{ dispute_id: "dp_..." }` and omits `submit`, the execute callback receives `$input` **without** a `submit` key — it does not get `$input['submit'] = false`.
+
+### Symptoms
+
+- Boolean defaults silently become "undefined" in the callback and any `if ( $input['submit'] )` check compares against `null`, which works by accident but fails `isset` checks and strict-type branches.
+- Integer pagination defaults like `'page' => [ 'default' => 1 ]` never reach the backing controller, so pagination falls back to the controller's internal default rather than the one declared in the schema.
+- Object defaults (`'metadata' => [ 'default' => [] ]`) become `null` rather than `[]` and any `foreach ( $input['metadata'] as ... )` hits a type error.
+
+### Fix — normalize defaults explicitly in the execute callback
+
+```php
+public static function execute_submit_evidence( $input = null ) {
+    if ( ! is_array( $input ) ) {
+        $input = [];
+    }
+
+    // Apply schema defaults the Abilities API does not inject.
+    if ( ! array_key_exists( 'submit', $input ) || null === $input['submit'] ) {
+        $input['submit'] = false;
+    }
+    $input['submit'] = (bool) $input['submit'];
+
+    if ( ! array_key_exists( 'metadata', $input ) || null === $input['metadata'] ) {
+        $input['metadata'] = [];
+    }
+
+    // ... rest of callback
+}
+```
+
+The `array_key_exists` + null-check pattern catches both "missing key" and "explicit null" (some serializers produce nulls for optional fields).
+
+Keep the declared `default` in `input_schema` anyway — it documents the expected behavior for anyone reading the registration and is visible to agents in the schema introspection endpoints. Just don't rely on it for runtime population.
+
+## 2. Pagination parameter-name drift
+
+### Problem
+
+The `input_schema` convention across most WordPress REST endpoints is `per_page` (matching WP core REST list endpoints and `WP_REST_Controller`'s `get_collection_params()`). Some plugin REST controllers, however, delegate to an internal request-builder class that reads a different key (e.g. `pagesize` or `page_size`), typically for historical reasons.
+
+If the ability's `input_schema` exposes `per_page` and the backing controller reads `pagesize`, the agent's `per_page: 50` silently never reaches pagination — the value is accepted, forwarded verbatim to the backing, and then ignored. Agents keep getting the default page size and suspect their filter is broken.
+
+### Symptoms
+
+- List abilities return the backing controller's default page size regardless of the agent's `per_page` input.
+- Integration tests that only check "a list came back" pass; only a test asserting `count( $response['data'] )` catches it.
+- Harness runs show the raw response count matching the default (25, 10, etc.) for every call.
+
+### Detection heuristic
+
+Before shipping a paginated ability, grep the backing controller's call chain:
+
+```bash
+# Check the backing controller and anything it delegates to.
+grep -rn "pagesize\|page_size" <path/to/backing-controller.php> <path/to/request-helpers/>
+```
+
+If `pagesize` (or any non-`per_page` key) appears in the chain and the ability's schema exposes `per_page`, the execute callback MUST translate.
+
+### Fix — translate before delegating
+
+```php
+/**
+ * Translate pagination keys for abilities whose backing reads a non-standard key.
+ *
+ * Abilities expose `per_page` uniformly for agent-facing consistency; this
+ * helper rewrites it to whatever key the backing actually reads.
+ *
+ * @param array|null $input Ability input (or null).
+ * @return array|null       Input with `per_page` rewritten to `<backing_key>` when present.
+ */
+private static function translate_pagination_keys( $input ) {
+    if ( ! is_array( $input ) ) {
+        return $input;
+    }
+    if ( isset( $input['per_page'] ) ) {
+        $input['<backing_key>'] = $input['per_page'];
+        unset( $input['per_page'] );
+    }
+    return $input;
+}
+
+public static function execute_get_things( $input = null ) {
+    $input = self::translate_pagination_keys( is_array( $input ) ? $input : null );
+
+    return self::delegate_to_rest_controller(
+        '<Backing_Controller_Class>',
+        'get_things',
+        '/my-plugin/v1/things',
+        $input
+    );
+}
+```
+
+Place the translation BEFORE the delegate call so `per_page` never reaches the backing.
+
+### When NOT to apply this
+
+Do not apply blindly. If the backing reads `per_page` directly (most modern WP REST controllers do), adding this translation would silently break pagination by renaming the key to something the backing doesn't understand.
+
+**Always grep the backing first.** The translation is only correct for a specific backing chain; it's not a general safety net.
+
+## 3. ID validation must not use `empty()`
+
+### Problem
+
+PHP's `empty()` is permissive in ways that bite ID validation:
+
+```php
+empty( '0' )   // true  — but "0" is a legal string ID (order ID, row ID, post ID in some code paths)
+empty( 0 )     // true  — same for integer zero
+empty( [] )    // true  — expected, but same keyword used for different cases
+```
+
+An execute callback that guards required IDs with `empty( $input['order_id'] )` will false-reject a legitimate `"0"` and return a "missing" error for input that's actually present. The agent retries with the same input, gets the same error, and the call is stuck.
+
+### Symptoms
+
+- Abilities reject specific IDs ending in zero or consisting of zero.
+- Unit tests written with non-zero IDs pass; a regression lands the day an agent tries a real zero-ID.
+- `WP_Error( '<plugin>_missing_<field>' )` fires for input the schema validator would have accepted.
+
+### Fix — three explicit checks
+
+```php
+if ( ! isset( $input['order_id'] )
+    || ! is_string( $input['order_id'] )
+    || '' === $input['order_id']
+) {
+    return new \WP_Error(
+        '<plugin>_missing_order_id',
+        __( 'An order_id is required to fetch order detail.', '<text-domain>' )
+    );
+}
+```
+
+Three separate checks, each non-redundant:
+
+1. `! isset( ... )` — the key is present on the array.
+2. `! is_string( ... )` — type is right. (For integer IDs, use `is_int` + non-negative check instead.) Without this, a caller that passes `123` (integer) where the schema documents a string would fall through to a later step that does `rawurlencode( $input['order_id'] )` and produces a cryptic coercion error rather than a clean missing-field response.
+3. `'' === $input[ ... ]` — non-empty in the strict sense. Rejects empty string only; accepts `"0"` as a legal value.
+
+Use the standardized `<plugin>_missing_<field>` error code (see `error-code-vocabulary.md`) for this case.
+
+### Add a regression-guard unit test
+
+The guard is load-bearing enough that it deserves an explicit test — otherwise someone will simplify it back to `empty()` in a future refactor:
+
+```php
+public function test_execute_returns_wp_error_when_id_not_a_string(): void {
+    $result = My_Plugin_Abilities::execute_get_thing( [ 'order_id' => 123 ] );
+    $this->assertInstanceOf( \WP_Error::class, $result );
+    $this->assertSame( '<plugin>_missing_order_id', $result->get_error_code() );
+}
+```
+
+The integer `123` is a fine canary — it's non-empty, it `isset`s, but it's not a string. A callback that only uses `isset` + `empty` would false-pass this input and fall through to the URL construction with an integer argument.
+
+## Putting the three together
+
+A hardened execute callback for a list-style ability with a required ID, schema defaults, and backing pagination drift:
+
+```php
+public static function execute_get_thing_details( $input = null ) {
+    if ( ! is_array( $input ) ) {
+        $input = [];
+    }
+
+    // Gotcha 3: required-ID validation (not empty()).
+    if ( ! isset( $input['thing_id'] )
+        || ! is_string( $input['thing_id'] )
+        || '' === $input['thing_id']
+    ) {
+        return new \WP_Error(
+            '<plugin>_missing_thing_id',
+            __( 'A thing_id is required.', '<text-domain>' )
+        );
+    }
+
+    // Gotcha 1: apply defaults the Abilities API doesn't inject.
+    if ( ! array_key_exists( 'include_history', $input ) || null === $input['include_history'] ) {
+        $input['include_history'] = false;
+    }
+    $input['include_history'] = (bool) $input['include_history'];
+
+    // Gotcha 2: translate pagination before delegating (only if backing reads a non-standard key).
+    $input = self::translate_pagination_keys( $input );
+
+    return self::delegate_to_rest_controller(
+        '<Backing_Controller_Class>',
+        'get_thing',
+        '/my-plugin/v1/things/' . rawurlencode( $input['thing_id'] ),
+        $input
+    );
+}
+```
+
+Each of the three lines the callback adds on top of the "just delegate" pattern has a paid-for bug behind it. Keep them.

--- a/skills/wp-abilities-api/references/input-schema-gotchas.md
+++ b/skills/wp-abilities-api/references/input-schema-gotchas.md
@@ -179,7 +179,51 @@ public function test_execute_returns_wp_error_when_id_not_a_string(): void {
 
 The integer `123` is a fine canary — it's non-empty, it `isset`s, but it's not a string. A callback that only uses `isset` + `empty` would false-pass this input and fall through to the URL construction with an integer argument.
 
-## Putting the three together
+## 4. Direct vs indirect invocation differ in strictness
+
+### Problem
+
+Two ways exist to invoke an ability's `execute_callback`:
+
+- **Direct.** A caller imports the registrar and calls the static method (`Abilities_Registrar::execute_get_things( $input )`). PHP signature defaults apply; no schema validation runs.
+- **Indirect.** A caller resolves the ability through `wp_get_ability( '<id>' )->execute( $input )`. WordPress runs `WP_Ability::normalize_input()` then `validate_input()` (then `check_permissions()`) before the callback is invoked.
+
+The two paths differ in three ways agents trip over:
+
+1. **Validation against `input_schema` runs only on the indirect path.** If the ability declares an object-typed schema with properties and the indirect caller passes `null` (or omits the argument entirely, as `$ability->execute()` does), `validate_input()` rejects with an `ability_invalid_input` error before the callback runs. The PHP-level `$input = null` default in the callback signature is dead code on this path.
+
+2. **Schema's top-level `default` IS applied — but only on the indirect path.** `normalize_input()` substitutes the schema's top-level `default` when the caller passes `null`. Direct callers don't run through this method; they get whatever PHP default the callback signature declares. Declaring `default => (object) array()` at the schema root makes `$ability->execute()` work without arguments — but the same callback called directly still receives PHP `null`.
+
+3. **The callback's first argument arrives only when `input_schema` is non-empty.** WordPress only forwards `$input` to the callback when the schema is declared. Without an input schema, the callback is invoked with zero arguments — PHP-level signature defaults compensate for this if you wrote them; without them, the indirect path produces an `ArgumentCountError`.
+
+### Symptoms
+
+- An ability looks fine when unit-tested by directly invoking the static method, then fails the moment it's exercised through `wp_get_ability(...)->execute()` from MCP / Command Palette / agent harnesses.
+- "Works in the test, breaks in MCP" — typical pattern when a test calls `Abilities_Registrar::execute_get_things( [] )` (passing an empty array) but the agent invocation goes through the indirect pipeline.
+- A schema with all-optional properties still rejects zero-arg indirect calls because `null` is not an object.
+
+### Fix — declare a top-level schema `default` for any zero-arg-allowed ability
+
+```php
+'input_schema' => [
+    'type'       => 'object',
+    'default'    => (object) array(),  // applied by normalize_input() on null inputs
+    'properties' => [
+        'per_page' => [ 'type' => 'integer', 'default' => 10 ],
+        // ...
+    ],
+],
+```
+
+`(object) array()` is preferred over `[]` because it json-encodes to `{}` rather than the array literal `[]`, avoiding PHP's array/object ambiguity at the validator boundary.
+
+### Distinguish from Gotcha 1
+
+Top-level schema `default` is honored by `normalize_input()` and reaches the callback. Property-level `default` (Gotcha 1) is NOT — those values are dropped by the validator, and the callback has to defensively reapply them. Different layers, different fates.
+
+If you've declared the top-level `default` in the schema, the PHP-level signature default exists only for direct callers. Don't add a third layer of fallback inside the callback that re-checks `if ( $input === null )` — three compensating defaults stacked on each other diffuses the meaning of "no input."
+
+## Putting gotchas 1-3 together
 
 A hardened execute callback for a list-style ability with a required ID, schema defaults, and backing pagination drift:
 

--- a/skills/wp-abilities-api/references/input-schema-gotchas.md
+++ b/skills/wp-abilities-api/references/input-schema-gotchas.md
@@ -170,7 +170,7 @@ Use the standardized `<plugin>_missing_<field>` error code (see `error-code-voca
 The guard is load-bearing enough that it deserves an explicit test — otherwise someone will simplify it back to `empty()` in a future refactor:
 
 ```php
-public function test_execute_returns_wp_error_when_id_not_a_string(): void {
+public function test_execute_returns_wp_error_when_id_not_a_string() {
     $result = My_Plugin_Abilities::execute_get_thing( [ 'order_id' => 123 ] );
     $this->assertInstanceOf( \WP_Error::class, $result );
     $this->assertSame( '<plugin>_missing_order_id', $result->get_error_code() );

--- a/skills/wp-abilities-api/references/plugin-family-patterns.md
+++ b/skills/wp-abilities-api/references/plugin-family-patterns.md
@@ -1,12 +1,12 @@
 # Plugin-family patterns
 
-This reference covers shared implementation *mechanics* — the call-shape pattern your execute callbacks follow when handing work to existing business logic. Two patterns cover most real-world WordPress plugins; pick one up front, because the choice ripples through your delegate helper, your tests, and your error codes.
+This reference covers shared implementation *mechanics* — the call shape your execute callbacks follow when handing work to existing business logic. Two shapes are common enough across real-world WordPress plugins to be worth naming; which one fits is determined by how the backing controller is constructed, not by a choice you make up front. The choice still ripples through your delegate helper, your tests, and your error codes, so it's worth confirming early.
 
 Family-specific *registration* conventions — loader path, ability category, MCP exposure defaults, error-code prefix house style — live in separate plugin-family overlays (for example, a WooCommerce-extension overlay), not in this reference. Apply any relevant overlay before scaffolding registration. The patterns below should stay portable: they describe how the execute callback talks to backing code, not what the registration metadata should look like for your plugin family.
 
-There is also a third option that sits *outside* this dichotomy. If the operation does not yet have a shared service class — or if you can refactor toward one — extracting a service that the ability, the REST controller, and the UI all consume is the default per `shared-core-service.md`. Delegation through an existing REST controller (Patterns A and B below) is a conditional shortcut for low-stakes reads, not the starting point. Confirm the shape is right before you reach for either pattern.
+There is also a third option that sits *outside* this dichotomy. If the operation does not yet have a shared service class — or if you can refactor toward one — extracting a service that the ability, the REST controller, and the UI all consume is the default per `shared-core-service.md`. Delegation through an existing REST controller (either shape below) is a conditional shortcut for low-stakes reads, not the starting point. Confirm the shape is right before you reach for either.
 
-## Pattern A — Shared API client
+## Shape: shared API client
 
 Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an upstream API). The plugin bootstraps a single API client, exposes it via a static accessor on a main plugin class, and every REST controller takes that client as a constructor argument.
 
@@ -17,7 +17,7 @@ Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an 
 grep -n "public function __construct" <path/to/rest-controller.php>
 ```
 
-If the constructor takes a required typed argument (e.g. `My_Plugin_API_Client $api_client`), you're in Pattern A. Confirm the plugin has a central accessor:
+If the constructor takes a required typed argument (e.g. `My_Plugin_API_Client $api_client`), you're in the shared-API-client shape. Confirm the plugin has a central accessor:
 
 ```bash
 grep -rn "get_api_client\|get_.*_api_client\|get_service" <path/to/plugin/main-class.php>
@@ -73,7 +73,7 @@ class Abilities_Registrar {
             return new \WP_Error( 'my_plugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
         }
 
-        // Pattern A specifics: fetch the shared API client and null-check.
+        // Shape specifics: fetch the shared API client and null-check.
         $api_client = null;
         if ( class_exists( '\My_Plugin' ) && method_exists( '\My_Plugin', 'get_api_client' ) ) {
             $api_client = \My_Plugin::get_api_client();
@@ -112,7 +112,7 @@ class Abilities_Registrar {
 
 Worked example: a plugin that talks to an external SaaS or upstream HTTP service typically follows this pattern. The plugin's main class exposes the API client via a static accessor (e.g. `Plugin_Main::get_api_client()`); REST controllers extend a base class whose constructor takes that client as a typed argument; the abilities registrar pulls the client through the same accessor before constructing controllers.
 
-## Pattern B — Zero-arg controllers
+## Shape: zero-arg controllers
 
 Common in plugins/packages that delegate primarily to WordPress core mechanisms (custom post types, options, meta) and don't maintain a single shared API client. Controllers instantiate cleanly without a dependency graph.
 
@@ -122,9 +122,9 @@ Common in plugins/packages that delegate primarily to WordPress core mechanisms 
 grep -n "public function __construct" <path/to/rest-controller.php>
 ```
 
-If the constructor takes no required arguments, or takes only simple scalars you can hardcode at the ability call site (e.g. a post-type string), you're in Pattern B.
+If the constructor takes no required arguments, or takes only simple scalars you can hardcode at the ability call site (e.g. a post-type string), you're in the zero-arg shape.
 
-Also grep the plugin's main bootstrap class for the absence of a singleton API accessor — if there isn't one, Pattern B is the honest choice.
+Also grep the plugin's main bootstrap class for the absence of a singleton API accessor — if there isn't one, the zero-arg shape is the honest choice.
 
 ### Minimal skeleton
 
@@ -203,7 +203,7 @@ See `delegate-helper-pattern.md` for the full helper signature and guards.
 ### Testing implications
 
 - **No API-client mock needed.** Unit tests instantiate the ability registrar directly and call `execute_*` with input arrays.
-- **Test at the `wp_get_ability()` level when possible.** In Pattern B the backing controller often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
+- **Test at the `wp_get_ability()` level when possible.** With zero-arg controllers the backing often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
 - **The `<plugin>_not_initialized` failure mode is less common.** It still exists — if a package isn't loaded, `class_exists` on the backing controller still fails — but the surface area is smaller.
 
 Worked example: a plugin whose REST controllers wrap a custom post type, taxonomy, option, or meta typically follows this pattern. Each execute callback constructs its controller inline (e.g. `new My_CPT_Endpoint( 'my_cpt' )`), passing whatever scalar (post-type slug, taxonomy name) the controller needs. No shared helper in the registrar; the construction step is small enough to inline.
@@ -212,14 +212,14 @@ Worked example: a plugin whose REST controllers wrap a custom post type, taxonom
 
 A single plugin can legitimately use both patterns across different abilities:
 
-- A Pattern A ability for backing controllers that talk to the upstream service.
-- A Pattern B ability for backing controllers that only touch WP core (e.g. a CPT-based settings endpoint in the same plugin).
+- A shared-API-client ability for backing controllers that talk to the upstream service.
+- A zero-arg ability for backing controllers that only touch WP core (e.g. a CPT-based settings endpoint in the same plugin).
 
-If this happens, the helper in `delegate-helper-pattern.md` can support both via optional `constructor_args` — but resist the temptation to over-engineer until you have at least two Pattern B abilities that would share the helper.
+If this happens, the helper in `delegate-helper-pattern.md` can support both via optional `constructor_args` — but resist the temptation to over-engineer until you have at least two zero-arg abilities that would share the helper.
 
 ## Anti-pattern — inventing an API client where there isn't one
 
-Don't introduce a fake shared API client to fit Pattern A's helper shape. If the plugin is genuinely stateless / CPT-driven, Pattern B's inline construction is the honest answer. The helper is scaffolding that pays back when you have 4+ abilities sharing the build-request → instantiate → unwrap flow; before that, inline code is faster to read and review.
+Don't introduce a fake shared API client to fit the shared-client helper shape. If the plugin is genuinely stateless / CPT-driven, inline construction is the honest answer. The helper is scaffolding that pays back when you have 4+ abilities sharing the build-request → instantiate → unwrap flow; before that, inline code is faster to read and review.
 
 ## Picking quickly
 

--- a/skills/wp-abilities-api/references/plugin-family-patterns.md
+++ b/skills/wp-abilities-api/references/plugin-family-patterns.md
@@ -1,0 +1,229 @@
+# Plugin-family patterns
+
+When you adopt the Abilities API inside an existing plugin, the plugin's architecture dictates HOW your execute callbacks call the existing business logic. Two patterns cover most real-world WordPress plugins. Pick one up front — the choice ripples through your delegate helper, your tests, and your error codes.
+
+## Pattern A — Shared-API-client ("Woo-family")
+
+Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an upstream API). The plugin bootstraps a single API client, exposes it via a static accessor on a main plugin class, and every REST controller takes that client as a constructor argument.
+
+### Detection
+
+```bash
+# Inspect the backing REST controller's __construct signature.
+grep -n "public function __construct" <path/to/rest-controller.php>
+```
+
+If the constructor takes a required typed argument (e.g. `My_Plugin_API_Client $api_client`), you're in Pattern A. Confirm the plugin has a central accessor:
+
+```bash
+grep -rn "get_api_client\|get_.*_api_client\|get_service" <path/to/plugin/main-class.php>
+```
+
+You're looking for a `public static function get_<something>()` that returns the shared client.
+
+### Minimal skeleton
+
+```php
+<?php
+namespace My_Plugin\Abilities;
+
+class Abilities_Registrar {
+
+    const CATEGORY_SLUG = 'my-plugin';
+
+    public static function init() {
+        add_action( 'wp_abilities_api_categories_init', [ __CLASS__, 'register_category' ] );
+        add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+    }
+
+    public static function register_abilities() {
+        wp_register_ability(
+            'my-plugin/get-things',
+            [
+                'label'               => __( 'Get things', 'my-plugin' ),
+                'description'         => __( 'List things with filters.', 'my-plugin' ),
+                'category'            => self::CATEGORY_SLUG,
+                'input_schema'        => [ /* ... */ ],
+                'execute_callback'    => [ __CLASS__, 'execute_get_things' ],
+                'permission_callback' => [ __CLASS__, 'current_user_has_capability' ],
+                'meta'                => [
+                    'annotations'  => [ 'readonly' => true, 'destructive' => false, 'idempotent' => true ],
+                    'show_in_rest' => true,
+                ],
+            ]
+        );
+    }
+
+    public static function execute_get_things( $input = null ) {
+        return self::delegate_to_rest_controller(
+            'My_Plugin_REST_Things_Controller',
+            'get_things',
+            '/my-plugin/v1/things',
+            is_array( $input ) ? $input : null
+        );
+    }
+
+    private static function delegate_to_rest_controller( $controller_class, $method, $route, $input, $http_method = 'GET' ) {
+        $fqcn = '\\' . $controller_class;
+        if ( ! class_exists( $fqcn ) ) {
+            return new \WP_Error( 'my_plugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
+        }
+
+        // Pattern A specifics: fetch the shared API client and null-check.
+        $api_client = null;
+        if ( class_exists( '\My_Plugin' ) && method_exists( '\My_Plugin', 'get_api_client' ) ) {
+            $api_client = \My_Plugin::get_api_client();
+        }
+        if ( null === $api_client ) {
+            return new \WP_Error( 'my_plugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
+        }
+
+        $request = new \WP_REST_Request( $http_method, $route );
+        if ( is_array( $input ) ) {
+            foreach ( $input as $param => $value ) {
+                $request->set_param( $param, $value );
+            }
+        }
+
+        $controller = new $fqcn( $api_client );
+        $response   = $controller->{$method}( $request );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+        if ( $response instanceof \WP_REST_Response ) {
+            $data = $response->get_data();
+            return is_array( $data ) ? $data : [];
+        }
+        return is_array( $response ) ? $response : [];
+    }
+}
+```
+
+### Testing implications
+
+- **Bootstrap test doubles need the API client.** Unit tests that instantiate controllers must provide a mocked or stubbed client; otherwise the constructor fails with `ArgumentCountError: Too few arguments`.
+- **The "not initialized" error path is reachable and must be covered.** One unit test should stub the accessor to return null and assert the ability returns `<plugin>_not_initialized`. This is a common failure during partial bootstraps (WP-CLI with restricted loading, test harnesses, admin pages with conditional autoloading).
+- **Integration tests need real or faked HTTP.** The backing controller will hit the upstream unless the API client is mocked, so integration harnesses typically route through a fake transport.
+
+Worked example: WooPayments' `Abilities_Registrar` uses this pattern. Controllers extend `WC_Payments_REST_Controller`, whose constructor takes a `WC_Payments_API_Client`; the shared client comes from `WC_Payments::get_payments_api_client()`.
+
+## Pattern B — Zero-arg controllers ("Jetpack-family")
+
+Common in plugins/packages that delegate primarily to WordPress core mechanisms (custom post types, options, meta) and don't maintain a single shared API client. Controllers instantiate cleanly without a dependency graph.
+
+### Detection
+
+```bash
+grep -n "public function __construct" <path/to/rest-controller.php>
+```
+
+If the constructor takes no required arguments, or takes only simple scalars you can hardcode at the ability call site (e.g. a post-type string), you're in Pattern B.
+
+Also grep the plugin's main bootstrap class for the absence of a singleton API accessor — if there isn't one, Pattern B is the honest choice.
+
+### Minimal skeleton
+
+```php
+<?php
+namespace My_Plugin\Abilities;
+
+class Abilities_Registrar {
+
+    const CATEGORY_SLUG = 'my-plugin';
+
+    public static function init() {
+        add_action( 'wp_abilities_api_categories_init', [ __CLASS__, 'register_category' ] );
+        add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+    }
+
+    public static function register_abilities() {
+        wp_register_ability(
+            'my-plugin/get-things',
+            [
+                /* ... */
+                'execute_callback' => [ __CLASS__, 'execute_get_things' ],
+                /* ... */
+            ]
+        );
+    }
+
+    public static function execute_get_things( $input = null ) {
+        $input    = is_array( $input ) ? $input : [];
+        $endpoint = new \My_Plugin_Things_Endpoint();
+        $request  = new \WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+
+        foreach ( [ 'page', 'per_page', 'status', 'search' ] as $key ) {
+            if ( isset( $input[ $key ] ) ) {
+                $request->set_param( $key, $input[ $key ] );
+            }
+        }
+
+        $response = $endpoint->get_items( $request );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+        return $response instanceof \WP_REST_Response ? $response->get_data() : $response;
+    }
+}
+```
+
+No helper is required — the construction step is a single line and inlining per callback stays readable. If you do extract a helper, it takes a `constructor_args` parameter because the controller class isn't constant across abilities:
+
+```php
+/**
+ * @param string     $controller_class Fully-qualified controller class.
+ * @param string     $method           Method to invoke on the request.
+ * @param string     $route            REST route used when constructing WP_REST_Request.
+ * @param array|null $input            Ability input (or null).
+ * @param string     $http_method      HTTP method. Defaults to 'GET'.
+ * @param array      $constructor_args Optional scalar args for the controller's constructor.
+ * @return array|\WP_Error
+ */
+private static function delegate_to_rest_controller(
+    $controller_class,
+    $method,
+    $route,
+    $input,
+    $http_method = 'GET',
+    $constructor_args = array()
+) {
+    /* ... */
+}
+```
+
+The phpDoc carries the `array|\WP_Error` return shape; the function signature itself stays untyped on the return so this snippet parses on PHP 7.2+.
+
+See `delegate-helper-pattern.md` for the full helper signature and guards.
+
+### Testing implications
+
+- **No API-client mock needed.** Unit tests instantiate the ability registrar directly and call `execute_*` with input arrays.
+- **Test at the `wp_get_ability()` level when possible.** In Pattern B the backing controller often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
+- **The `<plugin>_not_initialized` failure mode is less common.** It still exists — if a package isn't loaded, `class_exists` on the backing controller still fails — but the surface area is smaller.
+
+Worked example: Jetpack Forms' `Forms_Abilities` class instantiates `Contact_Form_Endpoint( 'feedback' )` per execute callback. No shared helper in the registrar; the construction step is inline. Canonical file: [`Automattic/jetpack/projects/packages/forms/src/abilities/class-forms-abilities.php`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/abilities/class-forms-abilities.php).
+
+## Hybrid cases
+
+A single plugin can legitimately use both patterns across different abilities:
+
+- A Pattern A ability for backing controllers that talk to the upstream service.
+- A Pattern B ability for backing controllers that only touch WP core (e.g. a CPT-based settings endpoint in the same plugin).
+
+If this happens, the helper in `delegate-helper-pattern.md` can support both via optional `constructor_args` — but resist the temptation to over-engineer until you have at least two Pattern B abilities that would share the helper.
+
+## Anti-pattern — inventing an API client where there isn't one
+
+Don't introduce a fake shared API client to fit Pattern A's helper shape. If the plugin is genuinely stateless / CPT-driven, Pattern B's inline construction is the honest answer. The helper is scaffolding that pays back when you have 4+ abilities sharing the build-request → instantiate → unwrap flow; before that, inline code is faster to read and review.
+
+## Picking quickly
+
+| Signal | Likely pattern |
+|---|---|
+| Backing controller's `__construct` takes an API-client-like object | A |
+| Plugin has a `Plugin::get_*_client()` static accessor | A |
+| Plugin talks to an external SaaS / upstream HTTP service | A |
+| Backing controller `__construct` is zero-arg or only takes scalars | B |
+| Backing is a CPT / options / meta wrapper | B |
+| Plugin is a Jetpack-style first-party WordPress package | B |

--- a/skills/wp-abilities-api/references/plugin-family-patterns.md
+++ b/skills/wp-abilities-api/references/plugin-family-patterns.md
@@ -1,8 +1,12 @@
 # Plugin-family patterns
 
-When you adopt the Abilities API inside an existing plugin, the plugin's architecture dictates HOW your execute callbacks call the existing business logic. Two patterns cover most real-world WordPress plugins. Pick one up front — the choice ripples through your delegate helper, your tests, and your error codes.
+This reference covers shared implementation *mechanics* — the call-shape pattern your execute callbacks follow when handing work to existing business logic. Two patterns cover most real-world WordPress plugins; pick one up front, because the choice ripples through your delegate helper, your tests, and your error codes.
 
-## Pattern A — Shared-API-client ("Woo-family")
+Family-specific *registration* conventions — loader path, ability category, MCP exposure defaults, error-code prefix house style — live in separate plugin-family overlays (for example, a WooCommerce-extension overlay), not in this reference. Apply any relevant overlay before scaffolding registration. The patterns below should stay portable: they describe how the execute callback talks to backing code, not what the registration metadata should look like for your plugin family.
+
+There is also a third option that sits *outside* this dichotomy. If the operation does not yet have a shared service class — or if you can refactor toward one — extracting a service that the ability, the REST controller, and the UI all consume is the default per `shared-core-service.md`. Delegation through an existing REST controller (Patterns A and B below) is a conditional shortcut for low-stakes reads, not the starting point. Confirm the shape is right before you reach for either pattern.
+
+## Pattern A — Shared API client
 
 Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an upstream API). The plugin bootstraps a single API client, exposes it via a static accessor on a main plugin class, and every REST controller takes that client as a constructor argument.
 
@@ -106,9 +110,9 @@ class Abilities_Registrar {
 - **The "not initialized" error path is reachable and must be covered.** One unit test should stub the accessor to return null and assert the ability returns `<plugin>_not_initialized`. This is a common failure during partial bootstraps (WP-CLI with restricted loading, test harnesses, admin pages with conditional autoloading).
 - **Integration tests need real or faked HTTP.** The backing controller will hit the upstream unless the API client is mocked, so integration harnesses typically route through a fake transport.
 
-Worked example: WooPayments' `Abilities_Registrar` uses this pattern. Controllers extend `WC_Payments_REST_Controller`, whose constructor takes a `WC_Payments_API_Client`; the shared client comes from `WC_Payments::get_payments_api_client()`.
+Worked example: a plugin that talks to an external SaaS or upstream HTTP service typically follows this pattern. The plugin's main class exposes the API client via a static accessor (e.g. `Plugin_Main::get_api_client()`); REST controllers extend a base class whose constructor takes that client as a typed argument; the abilities registrar pulls the client through the same accessor before constructing controllers.
 
-## Pattern B — Zero-arg controllers ("Jetpack-family")
+## Pattern B — Zero-arg controllers
 
 Common in plugins/packages that delegate primarily to WordPress core mechanisms (custom post types, options, meta) and don't maintain a single shared API client. Controllers instantiate cleanly without a dependency graph.
 
@@ -202,7 +206,7 @@ See `delegate-helper-pattern.md` for the full helper signature and guards.
 - **Test at the `wp_get_ability()` level when possible.** In Pattern B the backing controller often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
 - **The `<plugin>_not_initialized` failure mode is less common.** It still exists — if a package isn't loaded, `class_exists` on the backing controller still fails — but the surface area is smaller.
 
-Worked example: Jetpack Forms' `Forms_Abilities` class instantiates `Contact_Form_Endpoint( 'feedback' )` per execute callback. No shared helper in the registrar; the construction step is inline. Canonical file: [`Automattic/jetpack/projects/packages/forms/src/abilities/class-forms-abilities.php`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/abilities/class-forms-abilities.php).
+Worked example: a plugin whose REST controllers wrap a custom post type, taxonomy, option, or meta typically follows this pattern. Each execute callback constructs its controller inline (e.g. `new My_CPT_Endpoint( 'my_cpt' )`), passing whatever scalar (post-type slug, taxonomy name) the controller needs. No shared helper in the registrar; the construction step is small enough to inline.
 
 ## Hybrid cases
 
@@ -226,4 +230,4 @@ Don't introduce a fake shared API client to fit Pattern A's helper shape. If the
 | Plugin talks to an external SaaS / upstream HTTP service | A |
 | Backing controller `__construct` is zero-arg or only takes scalars | B |
 | Backing is a CPT / options / meta wrapper | B |
-| Plugin is a Jetpack-style first-party WordPress package | B |
+| Plugin's REST surface wraps WP-core post types, taxonomies, options, or meta | B |

--- a/skills/wp-abilities-audit/SKILL.md
+++ b/skills/wp-abilities-audit/SKILL.md
@@ -91,7 +91,15 @@ variants into 1.
 
 For each proposed ability, fill in every field in the `proposed_abilities`
 schema: `name`, `intent`, `backing`, `permission`, `return_type`, `effort`
-(S/M/L), `annotations` (readonly/destructive/idempotent), `notes`, `risks`.
+(S/M/L), `annotations` (readonly/destructive/idempotent), `notes`, `risks`,
+`use_case_fit`, `side_effects`, `seed_data_needs`.
+
+The last three are the implementation-readiness facts the implementer
+and the verify-mode tooling both need: which human/agent workflow this
+ability serves (`use_case_fit`), what the backing path emits on every
+call (`side_effects` — empty array is a fact, not a missing value), and
+what representative data must exist in the test environment for the
+ability to execute through the public boundary (`seed_data_needs`).
 
 ### 5. Surface gaps and deferred items
 

--- a/skills/wp-abilities-audit/SKILL.md
+++ b/skills/wp-abilities-audit/SKILL.md
@@ -89,10 +89,22 @@ re-derive the rules here. Short version: one ability per real-world question
 or state transition, with filter parameters in `input_schema` collapsing N
 variants into 1.
 
-For each proposed ability, fill in every field in the `proposed_abilities`
-schema: `name`, `intent`, `backing`, `permission`, `return_type`, `effort`
-(S/M/L), `annotations` (readonly/destructive/idempotent), `notes`, `risks`,
-`use_case_fit`, `side_effects`, `seed_data_needs`.
+**Apply the use-case sanity check before populating any candidate.** Per
+`../wp-abilities-api/references/domain-vs-projection.md`'s use-case-contract
+test: would a human or agent intentionally perform this behavior through a
+supported plugin workflow? If yes, the candidate is a real ability —
+proceed to fill in fields. If no, the route is internal transport plumbing
+(cache invalidation, scheduler ticks, bookkeeping endpoints, debug
+introspection) — keep it in the Controller Inventory section for
+completeness, but do NOT promote it to `proposed_abilities`. The route may
+be useful to inventory; the proposed ability must represent a real
+user/operator question or action.
+
+For each proposed ability that passes the sanity check, fill in every
+field in the `proposed_abilities` schema: `name`, `intent`, `backing`,
+`permission`, `return_type`, `effort` (S/M/L), `annotations`
+(readonly/destructive/idempotent), `notes`, `risks`, `use_case_fit`,
+`side_effects`, `seed_data_needs`.
 
 The last three are the implementation-readiness facts the implementer
 and the verify-mode tooling both need: which human/agent workflow this

--- a/skills/wp-abilities-audit/SKILL.md
+++ b/skills/wp-abilities-audit/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: wp-abilities-audit
+description: "Audit a WordPress plugin's REST surface and produce a standardized audit document proposing Abilities API registrations. Produces a markdown doc with a YAML schema and prose sections that humans and agents can both consume when planning a registration rollout. Works on any WP plugin."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Filesystem-based agent with bash + node. Requires access to the plugin checkout; some workflows benefit from WP-CLI but don't require it."
+---
+
+# WP Abilities Audit
+
+Produce a standardized audit document for a WordPress plugin's REST surface,
+proposing a set of Abilities API registrations grouped by semantic intent. The
+audit doc is a planning artifact for implementers — humans, agents, or both —
+that captures the controller inventory, capability gates, and proposed
+ability shapes in a structured form. A reviewer reading the doc can scope the
+work without re-deriving the survey.
+
+This skill works on any plugin that exposes a REST surface. Plugin
+classification (for purposes of the optional `plugin_family` annotation) is
+the user's call; the workflow itself is plugin-agnostic.
+
+## When to use
+
+- The task is "register Abilities API abilities for a WP plugin" and no audit
+  doc exists yet.
+- Planning participation in a multi-plugin abilities rollout and need a
+  shareable, standardized audit artifact.
+- Pre-flight checking a plugin's agent-readiness before implementing abilities.
+- A PM or non-implementer wants to scope the work before engineering picks it up.
+
+## Inputs required
+
+1. **Plugin checkout path** — working tree of the plugin to audit.
+2. **Triage output** — run `wp-project-triage` first if not already done. The
+   audit consumes `signals.usesAbilitiesApi`, `versions.wordpress`, and
+   `project.kind` from the report.
+3. **Auditor identity** — name and team or context, recorded in the audit's
+   `auditor` field.
+4. **Output path** — where the audit doc should land. Default explicit over
+   implicit; ask if not provided rather than writing into the plugin worktree.
+
+## Prerequisites
+
+- `wp-project-triage` has run successfully and classified the plugin.
+- The plugin has at least one REST controller. If enumeration finds zero
+  controllers, the audit doesn't apply — see "Failure modes" below.
+
+## Procedure
+
+### 1. Enumerate REST controllers
+
+Read `references/controller-enumeration.md` now — it covers the two observed
+enumeration paths (glob for standard layouts, grep as the universal fallback)
+and when to use each.
+
+Record every controller class + file + REST base + routes in a "Controller
+Inventory" table. The inventory is exhaustive even though only a subset
+becomes proposed abilities.
+
+### 2. For each controller, extract the backing fields
+
+For every controller found, extract the fields the audit schema requires:
+class, file, HTTP method, route, route-registration line number, callback
+name, callback line number, permission callback, whether the callback takes
+a `WP_REST_Request` argument or is zero-arg, and the return type.
+
+Read `references/audit-schema.md` now for the exact field list and the shape
+of `proposed_abilities` entries. Line-number fields may be `null` for
+inherited callbacks — the schema allows this and pairs it with an optional
+`inherited_from` field.
+
+### 3. Confirm capability gate(s)
+
+Trace each controller's `permission_callback` to its `current_user_can()` call
+(or to the post-type capability machinery if the controller extends a
+post-type-backed base).
+
+Read `references/capability-gate-tracing.md` now — it documents the two
+common mechanisms (direct `check_permission()` vs post-type-backed
+`wc_rest_check_post_permissions()`) and how to represent each in the schema.
+Note explicitly whether read and write gates differ: compound gates are
+represented as a `{read, write}` object, not a single string.
+
+### 4. Propose abilities using semantic-intent grouping
+
+Do NOT atomize one ability per HTTP method. Apply the semantic-intent grouping
+heuristic — it's the only grouping rule this skill uses.
+
+Read `../wp-abilities-api/references/grouping-heuristic.md` now — do NOT
+re-derive the rules here. Short version: one ability per real-world question
+or state transition, with filter parameters in `input_schema` collapsing N
+variants into 1.
+
+For each proposed ability, fill in every field in the `proposed_abilities`
+schema: `name`, `intent`, `backing`, `permission`, `return_type`, `effort`
+(S/M/L), `annotations` (readonly/destructive/idempotent), `notes`, `risks`.
+
+### 5. Surface gaps and deferred items
+
+Three buckets:
+
+- **`excluded_from_mvp`** — candidates intentionally deferred for risk reasons
+  (real-money writes, irreversible state changes, or prerequisite design
+  work). Each entry gets a one-sentence reason.
+- **`surfaced_gaps`** — MVP candidates with no backing endpoint (ability with
+  `backing: null`), plus high-value endpoints discovered during enumeration
+  that aren't in the MVP list but would be easy future wins.
+- **Risks per ability** — anything about a backing endpoint that the
+  implementer must handle (no idempotency key, two-phase behavior,
+  state-transition caveats, zero-arg endpoints registered with
+  `permission_callback => '__return_true'` that must NOT copy that into the
+  ability registration).
+
+### 6. Write the audit doc
+
+Write to the explicit output path collected in "Inputs required". The
+document structure must match `references/audit-schema.md` exactly:
+
+1. `Last updated: YYYY-MM-DD HH:MM` header.
+2. YAML block with all required top-level metadata + `proposed_abilities`,
+   `excluded_from_mvp`, `surfaced_gaps`.
+3. "Controller Inventory" table.
+4. "Notes and Surprises" prose section.
+
+A copy-pasteable minimal example showing the full shape lives in
+`references/audit-schema.md` under "Minimal valid example" — start there
+when authoring a new audit.
+
+### 7. (Optional) Designate a reference implementation ability
+
+Set `reference_ability: true` on the first ability an implementer should
+land — typically the smallest, safest, highest-leverage read. This gives
+downstream workflows a deterministic starting point.
+
+## Verification
+
+- The audit conforms to `references/audit-schema.md` (all required top-level
+  fields present, at least one entry in `proposed_abilities`, annotations
+  complete on every ability).
+- `capability_gate` is a string for single-cap plugins or a `{read, write}`
+  object for post-type-backed plugins.
+- Every ability with `backing: null` also appears in `surfaced_gaps`.
+- The doc round-trips through the validator in `audit-schema.md` "Known
+  limitations" without errors.
+
+## Failure modes / debugging
+
+- **Plugin has no REST controllers** — audit doesn't apply. Consider
+  hooks/filters-based abilities (out of scope for this skill's current
+  version) or skip abilities adoption for this plugin.
+- **Plugin inherits controllers from another repo** (common for plugins
+  extending core post-type-backed controllers like `WP_REST_Posts_Controller`,
+  or extension plugins built on a parent's REST classes) — capture with
+  `backing.inherited_from: "<parent FQCN>"`. Line-number fields may be
+  `null` per the schema.
+- **Compound capability gate (distinct read/write caps)** — use the
+  structured `{read, write}` form documented in
+  `references/capability-gate-tracing.md`. Don't smuggle a `/`-separated
+  string into a field typed as a single cap.
+- **Ambiguous grouping** — route to
+  `../wp-abilities-api/references/grouping-heuristic.md`. Do not invent
+  alternative grouping rules in the audit doc.
+- **Zero-arg endpoints with `permission_callback => '__return_true'`** —
+  legal at the REST layer, but the ability's own `permission_callback` must
+  match the plugin's merchant gate. Never promote `'__return_true'` into an
+  ability registration. Note this in the ability's `risks`.
+- **Output path defaults to plugin worktree** — always ask the user for an
+  explicit output directory (e.g. their vault `plans/`). Writing the audit
+  into the plugin's own git history pollutes the worktree and buries the
+  artifact.
+
+## Escalation
+
+- If the plugin uses an enumeration convention not covered by
+  `references/controller-enumeration.md` (neither the standard glob nor the
+  grep fallback produces a complete inventory), update that reference with
+  the new convention and open a PR so future audits cover it deterministically.
+- If capability tracing hits a mechanism not covered by
+  `references/capability-gate-tracing.md`, extend that file rather than
+  encoding the new case in the audit's "Notes and Surprises" only.

--- a/skills/wp-abilities-audit/references/audit-schema.md
+++ b/skills/wp-abilities-audit/references/audit-schema.md
@@ -81,6 +81,9 @@ Each entry:
 | `annotations` | object | `{ readonly: bool, destructive: bool, idempotent: bool }`. All three required. |
 | `notes` | array of strings | Implementer-facing detail (filter params, edge cases, alternative backings). |
 | `risks` | array of strings | Anything the implementer must handle (missing idempotency key, two-phase behavior, `permission_callback => '__return_true'` at the REST layer that must not copy into the ability, etc.). |
+| `use_case_fit` | string | One sentence naming the human or agent workflow this ability serves. The use-case-contract check (see `wp-abilities-api/references/domain-vs-projection.md`): if no human would intentionally do this through a supported UI or workflow, the entry probably belongs in `excluded_from_mvp` instead. |
+| `side_effects` | array of strings | Side effects the backing path emits on every call: telemetry hooks fired, audit-log rows written, notifications dispatched, cache writes, lock acquisitions, expensive bootstrap on cold paths. One short line per effect. Empty array (`[]`) when the backing is a pure data-fetch — and that is *itself* a fact downstream tooling uses to decide whether delegation is safe. |
+| `seed_data_needs` | string OR `null` | One line describing what representative data must exist in the test environment for the ability to execute through the public boundary and return something meaningful (e.g. `"at least one completed order under the configured gateway"`, `"no seed required"`). `null` when the auditor has not yet identified the seed shape; downstream verify-mode tooling treats `null` as "ask the implementer" rather than guessing. |
 | `reference_ability` | bool (optional) | If `true`, marks this ability as the reference implementation — the first one an implementer should land (smallest, safest, highest-leverage read). Exactly zero or one ability per audit may set this. |
 
 ### `backing: null` semantics
@@ -193,6 +196,9 @@ proposed_abilities:
     notes:
       - "get_items(WP_REST_Request $request) requires a WP_REST_Request; construct one in the ability execute_callback."
     risks: []
+    use_case_fit: "Agent answers 'which items need attention right now?' in a single call without paging through a UI."
+    side_effects: []
+    seed_data_needs: "at least one item exists in any non-trashed status"
     reference_ability: true
 
   - name: example-plugin/close-item
@@ -216,6 +222,11 @@ proposed_abilities:
       - "Close is terminal — no reopen endpoint exists."
     risks:
       - "No idempotency key on the backing endpoint; duplicate POSTs may produce inconsistent audit trails."
+    use_case_fit: "User or agent closes a stale item from a workflow that surfaces stale items (admin list view, daily-digest agent)."
+    side_effects:
+      - "fires action `example_plugin/item_closed` (downstream listeners may dispatch email)"
+      - "writes audit-log row to `example_plugin_audit_log`"
+    seed_data_needs: "one open item to close; the test must capture the item id before invocation"
 
 excluded_from_mvp:
   - name: example-plugin/delete-item

--- a/skills/wp-abilities-audit/references/audit-schema.md
+++ b/skills/wp-abilities-audit/references/audit-schema.md
@@ -101,20 +101,22 @@ as a warning, not an error:
 
 | Field | Type | Description |
 |---|---|---|
-| `class` | string | Fully-qualified PHP class name. |
+| `kind` | enum (optional, default `rest_controller`) | The implementation path the ability should use or inspect. One of `rest_controller`, `service`, `helper`, `data_store`. When omitted, defaults to `rest_controller` for backwards compatibility with audits authored before this field landed. The kind tells downstream tooling whether the delegation pattern from `wp-abilities-api/references/shared-core-service.md` applies (only `rest_controller` is a candidate; the others select the shared-service shape from the start). |
+| `class` | string | Fully-qualified PHP class name (controller class for `rest_controller`; service / helper / data-store class for the other kinds). May be omitted when `kind: data_store` and the backing is a bare option key, post-meta key, or table without an owning class. |
 | `file` | string | Path relative to plugin root. |
-| `method` | enum | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`. |
-| `route` | string | Full REST route path. |
-| `route_registration_line` | integer OR `null` | Line number of the `register_rest_route(` call, or `null` when inherited from a parent controller that lives outside the plugin repo. |
-| `callback` | string | Controller method name that handles the route. |
-| `callback_line` | integer OR `null` | Line number of the callback method definition, or `null` when inherited. |
-| `inherited_from` | string (optional) | Fully-qualified parent class name when the route and/or callback is inherited from a class outside this plugin's repo (e.g. `WP_REST_Posts_Controller` from WordPress core, or another plugin's REST base class for extension plugins). Pair with `null` line numbers. Lets downstream tooling skip the re-grep step cleanly. |
+| `method` | enum (required when `kind: rest_controller`) | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`. Not applicable when `kind` is `service`, `helper`, or `data_store`. |
+| `route` | string (required when `kind: rest_controller`) | Full REST route path. Not applicable to non-REST kinds. |
+| `route_registration_line` | integer OR `null` | For `kind: rest_controller`: line number of the `register_rest_route(` call, or `null` when inherited. Omit for other kinds. |
+| `callback` | string | For `kind: rest_controller`: controller method name that handles the route. For `kind: service` / `helper`: method name on the service / helper class. For `kind: data_store`: the operation name (`get_option`, `get_post_meta`) or the table-read pattern; may be omitted. |
+| `callback_line` | integer OR `null` | Line number of the callback or method definition, or `null` when inherited or not applicable. |
+| `inherited_from` | string (optional) | Fully-qualified parent class name when the route and/or callback is inherited from a class outside this plugin's repo (e.g. `WP_REST_Posts_Controller` from WordPress core, or another plugin's REST base class for extension plugins). Pair with `null` line numbers. Lets downstream tooling skip the re-grep step cleanly. Primarily relevant for `kind: rest_controller`. |
 
 ### `permission` object
 
 | Field | Type | Description |
 |---|---|---|
-| `callback` | string | The method name used as `permission_callback`. |
+| `source` | enum (optional, default `rest_controller`) | Where the canonical permission for this behavior lives — not always the REST controller's `permission_callback`. One of `rest_controller`, `admin_action`, `service`, `domain_policy`, `post_type_map`, `none`. When omitted, defaults to `rest_controller` for backwards compatibility. `admin_action` for behaviors gated by `check_admin_referer` / `current_user_can` on an admin handler; `service` when a shared method enforces the cap; `domain_policy` for plugins with a policy / authorization layer; `post_type_map` for capabilities resolved through `map_meta_cap` on a post-type cap shadow; `none` for genuinely public behavior. Tells the implementer whether the ability's `permission_callback` can mirror the REST callback or must consult a different source of truth. |
+| `callback` | string | The method or function name that enforces the cap at the recorded `source`. For `source: rest_controller`, this is the `permission_callback` value. For `source: admin_action`, the admin handler function or method. For `source: service`, the service method that performs the cap check. |
 | `resolves_to` | string | The `current_user_can()` call(s) it ultimately resolves to. For compound gates, include both (e.g. `"current_user_can('read_private_pages')` for read; `current_user_can('edit_others_pages')` for write"). |
 | `confirmed` | bool | `true` if verified against source; `false` if inferred. |
 
@@ -179,6 +181,7 @@ proposed_abilities:
   - name: example-plugin/get-items
     intent: "List items with filters (status, owner, date range) so an agent can answer 'which items need attention?' in one call."
     backing:
+      kind: rest_controller
       class: Example_REST_Items_Controller
       file: includes/rest-api/class-example-rest-items-controller.php
       method: GET
@@ -187,6 +190,7 @@ proposed_abilities:
       callback: get_items
       callback_line: 52
     permission:
+      source: rest_controller
       callback: check_permission
       resolves_to: "current_user_can('manage_options')"
       confirmed: true
@@ -204,15 +208,14 @@ proposed_abilities:
   - name: example-plugin/close-item
     intent: "Close a single item — terminal state transition, non-reversible."
     backing:
-      class: Example_REST_Items_Controller
-      file: includes/rest-api/class-example-rest-items-controller.php
-      method: POST
-      route: /example/v1/items/{id}/close
-      route_registration_line: 41
-      callback: close_item
-      callback_line: 120
+      kind: service
+      class: Example_Items_Service
+      file: src/Service/class-items-service.php
+      callback: close
+      callback_line: 88
     permission:
-      callback: check_permission
+      source: service
+      callback: Example_Items_Service::assert_can_close
       resolves_to: "current_user_can('manage_options')"
       confirmed: true
     return_type: "WP_REST_Response (updated item object)"
@@ -284,3 +287,14 @@ Documented so downstream skills have an explicit contract:
   fields to nudge backfill the next time the audit is touched; they do
   NOT FAIL, mirroring the legacy `capability_gate` posture above. New
   audits MUST populate all three.
+- **`backing.kind` and `permission.source` added 2026-05-21.** Both
+  are optional with default `rest_controller` so older audits validate
+  as-is. New audits SHOULD populate both explicitly — `backing.kind`
+  to record whether the ability backs a REST controller, a shared
+  service, a helper, or a data store (because the answer drives the
+  delegate-vs-extract-service decision in `wp-abilities-api/references/
+  shared-core-service.md`); `permission.source` to record where the
+  canonical permission lives (REST callback is the common case, but
+  admin actions, service methods, domain policies, and post-type cap
+  maps each happen). Validators treat a missing field as the default,
+  not as an error.

--- a/skills/wp-abilities-audit/references/audit-schema.md
+++ b/skills/wp-abilities-audit/references/audit-schema.md
@@ -82,8 +82,8 @@ Each entry:
 | `notes` | array of strings | Implementer-facing detail (filter params, edge cases, alternative backings). |
 | `risks` | array of strings | Anything the implementer must handle (missing idempotency key, two-phase behavior, `permission_callback => '__return_true'` at the REST layer that must not copy into the ability, etc.). |
 | `use_case_fit` | string | One sentence naming the human or agent workflow this ability serves. The use-case-contract check (see `wp-abilities-api/references/domain-vs-projection.md`): if no human would intentionally do this through a supported UI or workflow, the entry probably belongs in `excluded_from_mvp` instead. |
-| `side_effects` | array of strings | Side effects the backing path emits on every call: telemetry hooks fired, audit-log rows written, notifications dispatched, cache writes, lock acquisitions, expensive bootstrap on cold paths. One short line per effect. Empty array (`[]`) when the backing is a pure data-fetch — and that is *itself* a fact downstream tooling uses to decide whether delegation is safe. |
-| `seed_data_needs` | string OR `null` | One line describing what representative data must exist in the test environment for the ability to execute through the public boundary and return something meaningful (e.g. `"at least one completed order under the configured gateway"`, `"no seed required"`). `null` when the auditor has not yet identified the seed shape; downstream verify-mode tooling treats `null` as "ask the implementer" rather than guessing. |
+| `side_effects` | array of strings | Side effects the backing path emits on every call: telemetry hooks, audit-log rows, notifications, cache writes. One short line per effect. Empty array (`[]`) when the backing is a pure data-fetch — that is *itself* a load-bearing fact: it is what unlocks the conditional delegation shortcut in `wp-abilities-api/references/shared-core-service.md`. A non-empty array tells the implementer (and downstream verify-mode tooling) that this ability needs the shared-service shape, not the delegate-through-REST shortcut. |
+| `seed_data_needs` | string OR `null` | One line describing what representative data must exist in the test environment for the ability to execute through the public boundary and return something meaningful (e.g. `"at least one entity in the plugin's primary table"`, `"no seed required"`). `null` when the auditor has not yet identified the seed shape; downstream verify-mode tooling treats `null` as "ask the implementer" rather than guessing. |
 | `reference_ability` | bool (optional) | If `true`, marks this ability as the reference implementation — the first one an implementer should land (smallest, safest, highest-leverage read). Exactly zero or one ability per audit may set this. |
 
 ### `backing: null` semantics
@@ -276,3 +276,11 @@ Documented so downstream skills have an explicit contract:
   gaps and MUST also appear in `surfaced_gaps` by `name`. Validators FAIL
   audits where this invariant is violated (a `null` backing without a
   matching `surfaced_gaps` entry indicates inconsistent audit output).
+- **Implementation-readiness fields added 2026-05-21.** `use_case_fit`,
+  `side_effects`, and `seed_data_needs` are required in the per-ability
+  schema as of this date. Audits authored against an earlier revision of
+  this schema will be missing the three fields. Validators (e.g.
+  `wp-abilities-verify`) emit WARN on missing implementation-readiness
+  fields to nudge backfill the next time the audit is touched; they do
+  NOT FAIL, mirroring the legacy `capability_gate` posture above. New
+  audits MUST populate all three.

--- a/skills/wp-abilities-audit/references/audit-schema.md
+++ b/skills/wp-abilities-audit/references/audit-schema.md
@@ -112,7 +112,7 @@ as a warning, not an error:
 | Field | Type | Description |
 |---|---|---|
 | `callback` | string | The method name used as `permission_callback`. |
-| `resolves_to` | string | The `current_user_can()` call(s) it ultimately resolves to. For compound gates, include both (e.g. `"current_user_can('read_private_shop_orders')` for read; `current_user_can('edit_shop_orders')` for write"). |
+| `resolves_to` | string | The `current_user_can()` call(s) it ultimately resolves to. For compound gates, include both (e.g. `"current_user_can('read_private_pages')` for read; `current_user_can('edit_others_pages')` for write"). |
 | `confirmed` | bool | `true` if verified against source; `false` if inferred. |
 
 ## `excluded_from_mvp` — array

--- a/skills/wp-abilities-audit/references/audit-schema.md
+++ b/skills/wp-abilities-audit/references/audit-schema.md
@@ -1,0 +1,267 @@
+# Audit Document Schema
+
+The canonical schema for an abilities audit doc. Every audit produced by
+`wp-abilities-audit` must conform to this schema so downstream tooling
+(humans reviewing, agents implementing, or validators like
+`wp-abilities-verify`) can consume it without parsing surprises.
+
+A copy-pasteable minimal example with both a read ability and a write
+ability lives under "Minimal valid example" below.
+
+## File layout
+
+```
+<output-dir>/<YYYY-MM-DD>-abilities-audit-<plugin-slug>.md
+```
+
+`<output-dir>` is explicit — collected from the user, not inferred. Typical
+values are the user's vault `plans/` directory or a dedicated audit repo.
+Writing into the plugin worktree is discouraged (pollutes git history).
+
+The body has two parts:
+
+1. A fenced ` ```yaml ` block holding structured fields (top-level metadata
+   + `proposed_abilities`, `excluded_from_mvp`, `surfaced_gaps`).
+2. Prose sections below: "Controller Inventory" table + "Notes and Surprises".
+
+A `Last updated: YYYY-MM-DD HH:MM` header sits above everything.
+
+## Top-level fields (all required)
+
+| Field | Type | Description |
+|---|---|---|
+| `plugin` | string | Plugin slug (e.g. `my-plugin`, `tasks-plugin`, `notifications`). |
+| `repo` | string | `Owner/Repository`. |
+| `branch_audited` | string | Git branch the audit was run against. |
+| `audited_at` | string | ISO date (YYYY-MM-DD). |
+| `auditor` | string | Human auditor name + team or context (e.g. `Your Name (Your Team)`). |
+| `baseline_abilities` | integer | Count of abilities already registered by the plugin at audit time. Usually 0. |
+| `capability_gate` | string OR object | The capability gate the base controller resolves to. Accept either a single string (single-cap plugins) OR a `{read, write}` object (post-type-backed or otherwise compound gates). See `capability-gate-tracing.md` for the mechanisms. |
+| `plugin_family` | string (optional) | Free-form classification when useful to downstream readers (e.g. `core-post-type`, `forms-engine`, or a project-specific family name). Optional and user-supplied — no canonical enum. Downstream consumers treat unknown values as opaque rather than erroring. |
+
+### `capability_gate` representations
+
+Two legal shapes, both consumed by downstream tooling:
+
+```yaml
+# Single-cap plugin (one capability across every controller)
+capability_gate: manage_options  # confirmed at includes/admin/class-my-plugin-rest-controller.php line 64
+```
+
+```yaml
+# Compound read/write (post-type-backed plugins typically need this shape;
+# read and write resolve to different capabilities)
+capability_gate:
+  read: read_private_pages
+  write: edit_others_pages
+  confirmed: true
+  verified_at: "custom_post_type capability_type='page' → core post-type cap map (wp-includes/post.php map_meta_cap)"
+```
+
+Plugin-specific capabilities (e.g. WooCommerce's `manage_woocommerce`,
+`edit_shop_orders`) are equally valid — substitute your plugin's caps. The
+shape is the contract; the literal cap names are project-specific.
+
+A legacy compound-string form exists in the wild (`"<read_cap> / <write_cap>"`)
+and is accepted for backwards compatibility, but the structured form above is
+the preferred representation for new audits.
+
+## `proposed_abilities` — array
+
+Each entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Kebab-case `<plugin-slug>/<ability>`. |
+| `intent` | string | One sentence, user-question framed. |
+| `backing` | object or `null` | See below. `null` marks an ability with no backing endpoint (a known gap). |
+| `permission` | object or `null` | See below. `null` when `backing` is null. |
+| `return_type` | string | Short description (e.g. `WP_REST_Response (wrapping array)`). Hint-only; not machine-parsed. |
+| `effort` | enum | `S`, `M`, or `L`. |
+| `annotations` | object | `{ readonly: bool, destructive: bool, idempotent: bool }`. All three required. |
+| `notes` | array of strings | Implementer-facing detail (filter params, edge cases, alternative backings). |
+| `risks` | array of strings | Anything the implementer must handle (missing idempotency key, two-phase behavior, `permission_callback => '__return_true'` at the REST layer that must not copy into the ability, etc.). |
+| `reference_ability` | bool (optional) | If `true`, marks this ability as the reference implementation — the first one an implementer should land (smallest, safest, highest-leverage read). Exactly zero or one ability per audit may set this. |
+
+### `backing: null` semantics
+
+An ability with `backing: null` is a known gap (the auditor identified a
+valuable ability that has no backing endpoint yet). The schema permits this
+as a warning, not an error:
+
+- The ability MUST also appear in `surfaced_gaps` with a one-line rationale.
+- Implementers pause for resolution rather than guessing a backing.
+- The audit is still valid; `backing: null` is intentional output, not
+  missing data.
+
+### `backing` object
+
+| Field | Type | Description |
+|---|---|---|
+| `class` | string | Fully-qualified PHP class name. |
+| `file` | string | Path relative to plugin root. |
+| `method` | enum | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`. |
+| `route` | string | Full REST route path. |
+| `route_registration_line` | integer OR `null` | Line number of the `register_rest_route(` call, or `null` when inherited from a parent controller that lives outside the plugin repo. |
+| `callback` | string | Controller method name that handles the route. |
+| `callback_line` | integer OR `null` | Line number of the callback method definition, or `null` when inherited. |
+| `inherited_from` | string (optional) | Fully-qualified parent class name when the route and/or callback is inherited from a class outside this plugin's repo (e.g. `WP_REST_Posts_Controller` from WordPress core, or another plugin's REST base class for extension plugins). Pair with `null` line numbers. Lets downstream tooling skip the re-grep step cleanly. |
+
+### `permission` object
+
+| Field | Type | Description |
+|---|---|---|
+| `callback` | string | The method name used as `permission_callback`. |
+| `resolves_to` | string | The `current_user_can()` call(s) it ultimately resolves to. For compound gates, include both (e.g. `"current_user_can('read_private_shop_orders')` for read; `current_user_can('edit_shop_orders')` for write"). |
+| `confirmed` | bool | `true` if verified against source; `false` if inferred. |
+
+## `excluded_from_mvp` — array
+
+Abilities intentionally deferred for risk reasons. Each entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Proposed ability name (kebab-case). |
+| `reason` | string | One sentence why it's deferred. |
+
+## `surfaced_gaps` — array
+
+MVP candidates with no backing endpoint (paired with `backing: null` above),
+plus high-value endpoints discovered during enumeration that aren't in MVP
+but would make future follow-up work. Each entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Proposed ability name. |
+| `one_line_rationale` | string | Why it would be high-leverage. |
+
+## Prose sections (required)
+
+### Controller Inventory
+
+A Markdown table with columns `Class | File | REST Base | Routes`. Must list
+every controller enumeration found, even ones that aren't backing any MVP
+ability. This gives reviewers a full picture and catches "why isn't X in the
+MVP?" questions.
+
+### Notes and Surprises
+
+Free-form prose capturing anything that didn't fit the structured schema:
+capability-gate mismatches between controllers, hardcoded route paths, dual
+controllers with different output shapes, two-phase endpoint semantics, and
+any judgment calls the auditor made.
+
+## Minimal valid example
+
+Copy-pasteable starting point for a new audit:
+
+````markdown
+---
+Last updated: 2026-04-20 14:30
+---
+
+# Example Plugin Abilities — Phase 1 Audit
+
+```yaml
+plugin: example-plugin
+repo: Owner/example-plugin
+branch_audited: feat/abilities-example-plugin
+audited_at: 2026-04-20
+auditor: Your Name (Your Team)
+baseline_abilities: 0
+capability_gate: manage_options  # confirmed at includes/rest-api/class-example-rest-controller.php line 32
+
+proposed_abilities:
+
+  - name: example-plugin/get-items
+    intent: "List items with filters (status, owner, date range) so an agent can answer 'which items need attention?' in one call."
+    backing:
+      class: Example_REST_Items_Controller
+      file: includes/rest-api/class-example-rest-items-controller.php
+      method: GET
+      route: /example/v1/items
+      route_registration_line: 26
+      callback: get_items
+      callback_line: 52
+    permission:
+      callback: check_permission
+      resolves_to: "current_user_can('manage_options')"
+      confirmed: true
+    return_type: "WP_REST_Response (wrapping array)"
+    effort: S
+    annotations: { readonly: true, destructive: false, idempotent: true }
+    notes:
+      - "get_items(WP_REST_Request $request) requires a WP_REST_Request; construct one in the ability execute_callback."
+    risks: []
+    reference_ability: true
+
+  - name: example-plugin/close-item
+    intent: "Close a single item — terminal state transition, non-reversible."
+    backing:
+      class: Example_REST_Items_Controller
+      file: includes/rest-api/class-example-rest-items-controller.php
+      method: POST
+      route: /example/v1/items/{id}/close
+      route_registration_line: 41
+      callback: close_item
+      callback_line: 120
+    permission:
+      callback: check_permission
+      resolves_to: "current_user_can('manage_options')"
+      confirmed: true
+    return_type: "WP_REST_Response (updated item object)"
+    effort: M
+    annotations: { readonly: false, destructive: true, idempotent: false }
+    notes:
+      - "Close is terminal — no reopen endpoint exists."
+    risks:
+      - "No idempotency key on the backing endpoint; duplicate POSTs may produce inconsistent audit trails."
+
+excluded_from_mvp:
+  - name: example-plugin/delete-item
+    reason: "Hard delete is irreversible and lacks an undo endpoint; defer until soft-delete is designed."
+
+surfaced_gaps:
+  - name: example-plugin/get-overview
+    one_line_rationale: "A zero-arg overview endpoint answering 'what's the current state of all items?' would be the highest-leverage ability but no backing endpoint exists yet."
+```
+
+## Controller Inventory
+
+| Class | File | REST Base | Routes |
+|---|---|---|---|
+| Example_REST_Items_Controller | includes/rest-api/class-example-rest-items-controller.php | example/v1/items | GET /example/v1/items, POST /example/v1/items/{id}/close |
+
+## Notes and Surprises
+
+### Capability gate is uniform
+Every controller inherits `Example_Base_REST_Controller` and uses
+`check_permission` verbatim as the `permission_callback`. No per-route
+overrides. Safe to treat `manage_options` as the single gate.
+````
+
+## Known limitations
+
+Documented so downstream skills have an explicit contract:
+
+- **`capability_gate` string-with-inline-comment form** loses data when parsed
+  by strict YAML parsers (comments are dropped). The structured object form is
+  preferred; string form is accepted for backwards compatibility.
+- **Legacy compound-string `capability_gate`** — the `"<read_cap> / <write_cap>"`
+  form predates the structured `{read, write}` object and is still accepted
+  for backwards compatibility. Validators (e.g. `wp-abilities-verify`)
+  emit WARN on this form to nudge migration to the structured shape;
+  they do NOT FAIL. New audits should use the object form.
+- **`return_type` is hint-only.** Prose for the human auditor; not
+  machine-parseable. Downstream skills use runtime `is_wp_error(...)` and
+  `instanceof WP_REST_Response` checks regardless of what this field says.
+- **Line numbers drift.** `route_registration_line` and `callback_line` are
+  captured at audit time and may bit-rot. Downstream skills re-locate routes
+  by `(class, callback)` and do not rely on exact line numbers.
+- **`inherited_from` + `null` line numbers** are the canonical way to
+  represent routes/callbacks defined in a parent class that lives outside
+  the plugin repo.
+- **`backing: null` invariant.** Abilities with `backing: null` are intentional
+  gaps and MUST also appear in `surfaced_gaps` by `name`. Validators FAIL
+  audits where this invariant is violated (a `null` backing without a
+  matching `surfaced_gaps` entry indicates inconsistent audit output).

--- a/skills/wp-abilities-audit/references/capability-gate-tracing.md
+++ b/skills/wp-abilities-audit/references/capability-gate-tracing.md
@@ -1,0 +1,171 @@
+# Capability-Gate Tracing
+
+How to resolve the actual capability (or capabilities) a plugin's REST
+controllers gate on. The audit's `capability_gate` field and each ability's
+`permission.resolves_to` field need to reflect reality, not what the
+controller docblock says.
+
+Two common mechanisms cover most plugins. Document both explicitly so the
+auditor doesn't hard-code one plugin family's assumptions.
+
+## Mechanism A — Direct (`check_permission()` returning a single cap)
+
+The base REST controller declares a `check_permission()` (or
+`permissions_check()`) method that calls `current_user_can('<some_cap>')`
+once. Every route in the controller uses that method as
+`permission_callback`.
+
+### Identifying signs
+
+- The base controller has a method like:
+  ```php
+  public function check_permission() {
+      return current_user_can( 'manage_options' );
+  }
+  ```
+- Controllers extend the plugin's own base, not a WordPress core
+  post-type-backed class.
+- The grep `grep -n 'current_user_can' <base-controller>.php` yields one hit.
+
+### How to trace
+
+```bash
+# Locate the base controller (usually the parent of every REST controller).
+grep -rn 'extends .*REST_Controller' includes/ | head
+
+# Read its permission_callback implementation.
+grep -n 'check_permission\|permissions_check' <base-controller>.php
+```
+
+Trace once: the single `current_user_can()` call is the plugin's gate.
+
+### How to represent in the audit
+
+```yaml
+capability_gate: manage_options  # confirmed at includes/admin/class-<plugin>-rest-controller.php line 64
+```
+
+Plugin-specific capabilities (e.g. WooCommerce's `manage_woocommerce` for
+shop-aware contexts, Jetpack Forms' `edit_pages`) substitute for
+`manage_options` cleanly — the shape stays the same.
+
+## Mechanism B — Post-type-backed (core CPT capability machinery)
+
+The controller extends a WordPress core post-type-backed class that
+dispatches to the post-type capability map. There is no local
+`check_permission()` — the permission callback resolves dynamically at
+request time based on the request context (read vs write) and the post
+type's `cap` object.
+
+### Identifying signs
+
+- The controller's base class is one of:
+  - `WP_REST_Posts_Controller` — the core post-type REST base.
+  - A subclass of it, in or out of this plugin's repo.
+- No local `check_permission()` — permission callbacks are inherited.
+- The post type is registered with `capability_type => '<cpt_or_shadow>'`,
+  and the cap map is resolved by core's `map_meta_cap()`.
+
+### How to trace
+
+```bash
+# Find the post-type registration.
+grep -rn "register_post_type\s*(\s*['\"]<cpt_name>['\"]" .
+
+# Read the registration block. The relevant fields are:
+#   - capability_type: the type whose cap map this post type uses.
+#     A custom post type can either declare its own caps or shadow another
+#     type's (e.g. capability_type => 'page' to reuse Pages' caps).
+#   - capabilities: optional explicit cap-string overrides.
+#   - map_meta_cap: whether meta caps (read_post, edit_post) get mapped to
+#     primitive caps (read_private_<type>s, edit_others_<type>s).
+```
+
+Dynamic resolution typically lands at:
+
+- **Read context** (GET list / GET item): `current_user_can('read_private_<type>s')` or `current_user_can('read_<type>', $id)`.
+- **Write context** (POST / PUT / DELETE): `current_user_can('edit_<type>s')`, `current_user_can('edit_others_<type>s')`, or `current_user_can('delete_<type>s', $id)`.
+
+The two often differ — post-type-backed plugins routinely have distinct read
+and write caps.
+
+### How to represent in the audit
+
+Use the structured `{read, write}` form from `audit-schema.md`:
+
+```yaml
+capability_gate:
+  read: read_private_pages
+  write: edit_others_pages
+  confirmed: true
+  verified_at: "custom_post_type capability_type='page' → core map_meta_cap (wp-includes/post.php) → primitive page caps"
+```
+
+In each ability's `permission` block, spell out both calls:
+
+```yaml
+permission:
+  callback: get_items_permissions_check
+  resolves_to: "WP_REST_Posts_Controller::get_items_permissions_check (inherited) → current_user_can('read_private_pages')"
+  confirmed: true
+```
+
+Example A — generic plugin shadowing core Pages caps. A custom post type
+registered with `capability_type='page'` inherits the Pages cap map, so
+reads gate on `read_private_pages` and writes gate on `edit_others_pages`.
+
+Example B — WooCommerce-style sidebar. WooCommerce's `shop_subscription` is
+registered with `capability_type='shop_order'`, so reads gate on
+`read_private_shop_orders` and writes gate on `edit_shop_orders`.
+Mechanically identical to Example A; the cap names are project-specific.
+WooCommerce also exposes a helper `wc_rest_check_post_permissions()` that
+wraps the same core machinery — the helper is convenience; the underlying
+mechanism is core's `map_meta_cap()`.
+
+## Compound-string form (accepted, not preferred)
+
+Some earlier audits encoded compound gates as a single string with a `/`
+separator:
+
+```yaml
+capability_gate: read_private_shop_orders / edit_shop_orders
+```
+
+This is accepted for backwards compatibility, but:
+
+- Downstream consumers have to heuristically split on `/`.
+- YAML comments after the string are silently dropped by strict parsers, so
+  provenance gets lost.
+- The `{read, write}` object form is machine-parseable and carries
+  `confirmed` and `verified_at` in-band.
+
+Prefer the structured form for any new audit.
+
+## Procedure — trace every route you'll back
+
+For each proposed ability, walk the chain once:
+
+1. Find the route's `permission_callback` in the controller.
+2. Determine whether it's Mechanism A (local method, single cap) or
+   Mechanism B (inherited, post-type-backed, dynamic).
+3. Resolve to the actual `current_user_can()` call(s). For B, resolve BOTH
+   read and write if the ability crosses contexts.
+4. Record in the ability's `permission.resolves_to` field verbatim — the
+   string should read as an actual trace, not a best-guess summary.
+5. If every route in the plugin resolves to the same cap (or same
+   `{read, write}` pair), hoist it into the top-level `capability_gate`. If
+   any route diverges, record the divergence in "Notes and Surprises".
+
+## Common pitfall — `permission_callback => '__return_true'`
+
+Zero-arg public endpoints sometimes declare `permission_callback =>
+'__return_true'` at the REST layer (e.g. status lookups, enumerated lists
+that are safe to expose). The audit still needs a gate:
+
+- Record the REST-layer value as-is (`resolves_to:
+  "__return_true (public)"`) so the auditor isn't hiding reality.
+- Add a risk note: the **ability** registration must NOT copy
+  `'__return_true'` — the ability's own `permission_callback` must match
+  the plugin's intended user gate (e.g. `manage_options`, `edit_pages`, or
+  whatever your plugin uses). The ability layer is the agent-facing surface
+  and needs that gate even when the underlying REST route is public.

--- a/skills/wp-abilities-audit/references/capability-gate-tracing.md
+++ b/skills/wp-abilities-audit/references/capability-gate-tracing.md
@@ -128,7 +128,7 @@ Some earlier audits encoded compound gates as a single string with a `/`
 separator:
 
 ```yaml
-capability_gate: read_private_shop_orders / edit_shop_orders
+capability_gate: read_private_pages / edit_others_pages
 ```
 
 This is accepted for backwards compatibility, but:

--- a/skills/wp-abilities-audit/references/capability-gate-tracing.md
+++ b/skills/wp-abilities-audit/references/capability-gate-tracing.md
@@ -141,20 +141,46 @@ This is accepted for backwards compatibility, but:
 
 Prefer the structured form for any new audit.
 
-## Procedure — trace every route you'll back
+## Procedure — trace the permission source for each proposed behavior
+
+The ability's permission should match the plugin's intended gate for the
+proposed *behavior*, not necessarily the REST route. Often the REST
+controller's `permission_callback` is the right source of truth, but in
+some plugins the canonical permission lives elsewhere — an admin-action
+handler with its own `check_admin_referer` + `current_user_can` block, a
+service / helper method that performs the check before doing the work, a
+domain-policy / authorization layer, or a post-type cap shadow resolved
+through core's `map_meta_cap`. The audit should preserve where the
+permission canonically lives so the implementer doesn't silently drift
+to whichever source the REST layer happens to expose.
 
 For each proposed ability, walk the chain once:
 
-1. Find the route's `permission_callback` in the controller.
-2. Determine whether it's Mechanism A (local method, single cap) or
-   Mechanism B (inherited, post-type-backed, dynamic).
-3. Resolve to the actual `current_user_can()` call(s). For B, resolve BOTH
-   read and write if the ability crosses contexts.
-4. Record in the ability's `permission.resolves_to` field verbatim — the
+1. Identify the *behavior* the ability surfaces, then locate where the
+   plugin enforces the cap for that behavior. Check the REST controller's
+   `permission_callback` first; if the REST callback is `'__return_true'`,
+   delegates entirely, or doesn't match the behavior's intended gate,
+   look for the canonical source in an admin handler, a shared service
+   method, a domain-policy class, or a post-type cap map.
+2. Record where the gate lives in the ability's `permission.source` field
+   per `audit-schema.md`: one of `rest_controller`, `admin_action`,
+   `service`, `domain_policy`, `post_type_map`, `none`. Default
+   `rest_controller`; pick another value when the canonical source is
+   elsewhere.
+3. Determine whether the gate is Mechanism A (local method, single cap)
+   or Mechanism B (inherited, post-type-backed, dynamic).
+4. Resolve to the actual `current_user_can()` call(s). For Mechanism B,
+   resolve BOTH read and write if the ability crosses contexts.
+5. Record in the ability's `permission.resolves_to` field verbatim — the
    string should read as an actual trace, not a best-guess summary.
-5. If every route in the plugin resolves to the same cap (or same
-   `{read, write}` pair), hoist it into the top-level `capability_gate`. If
-   any route diverges, record the divergence in "Notes and Surprises".
+6. Add a risk note when the canonical permission source diverges from
+   the REST controller's callback: the ability's `permission_callback`
+   must consult the canonical source (or replicate its check), not
+   copy the REST callback by reflex.
+7. If every behavior in the plugin resolves to the same cap (or same
+   `{read, write}` pair) at the same source, hoist it into the top-level
+   `capability_gate`. If any behavior diverges in cap OR in source,
+   record the divergence in "Notes and Surprises".
 
 ## Common pitfall — `permission_callback => '__return_true'`
 

--- a/skills/wp-abilities-audit/references/controller-enumeration.md
+++ b/skills/wp-abilities-audit/references/controller-enumeration.md
@@ -1,0 +1,116 @@
+# Controller Enumeration
+
+How to produce an exhaustive list of a plugin's REST controllers — the first
+step of every audit. Plugin family classification is handled separately by
+`wp-project-triage`; this reference covers the mechanics of finding controller
+classes inside whatever layout the plugin happens to use.
+
+## Two enumeration paths
+
+Observed across the plugins audited to date, there are exactly two paths that
+together cover every layout seen in the wild:
+
+| Path | When it works | How it works |
+|---|---|---|
+| **Glob** | Plugins that follow the standard `includes/admin/class-*-rest-*-controller.php` layout (WooCommerce core extensions, classic WooPayments). | Fast, deterministic, easy to script. Returns a complete list in one shell call. |
+| **Grep** | Any non-standard layout — `includes/api/`, `includes/rest-api/`, `src/rest/`, monorepo package directories, or anything else. | Universal fallback: grep every PHP file under the plugin root for `register_rest_route(` call sites, then collect the enclosing class for each hit. |
+
+### Default order
+
+1. **Try glob first** — it's faster and produces a cleaner inventory.
+2. **Fall back to grep** if glob returns zero hits (or clearly undercounts
+   against what you see in the plugin's public documentation / admin UI).
+
+Running both and de-duplicating is legal; it catches monorepos that have
+*some* controllers under the standard layout and *others* under a package
+directory.
+
+## Glob — standard layout
+
+```bash
+# From the plugin root:
+ls includes/admin/class-*-rest-*-controller.php 2>/dev/null
+ls includes/reports/class-*-rest-*-controller.php 2>/dev/null
+```
+
+What you'll see in repos that match this convention:
+
+- WooPayments (`Automattic/woocommerce-payments`) — every controller under
+  `includes/admin/class-wc-rest-payments-*-controller.php` plus some under
+  `includes/reports/`.
+- WooCommerce core's internal REST controllers use the same pattern.
+
+If glob returns 5+ hits, it's almost always the complete inventory. If it
+returns 0-2, fall through to grep.
+
+## Grep — universal fallback
+
+```bash
+# From the plugin root:
+grep -rn --include='*.php' 'register_rest_route(' .
+```
+
+For each hit:
+
+1. Open the file.
+2. Walk up to the enclosing class declaration.
+3. Record `(class, file, route, callback, permission_callback)`.
+
+This path matters because it's the only one that finds controllers in
+non-standard locations:
+
+- **WooCommerce Subscriptions** — controllers live under `includes/api/` and
+  `includes/api/legacy/`. The standard WooPayments glob returns zero; grep is
+  mandatory.
+- **Jetpack Forms** (and most Jetpack packages) — controllers live under
+  `projects/packages/<name>/src/` with no conventional filename. Grep is
+  again mandatory.
+- **Custom plugin layouts** — anything with `src/Rest/`, `lib/rest/`,
+  `api/v1/`, etc. Grep catches them all.
+
+## Inherited routes
+
+A controller can extend a base class in a different repo — typically the
+parent plugin (for extensions built on top of another plugin) or WordPress
+core itself (for plugins extending `WP_REST_Posts_Controller` or other core
+REST bases). The `parent::register_routes()` dispatch appears in the
+extending plugin's source, but the literal `register_rest_route(` call lives
+in the parent. WooCommerce extensions extending
+`WC_REST_Orders_Controller`, plugins built on Jetpack package REST classes,
+and CPT plugins inheriting from `WP_REST_Posts_Controller` all hit this
+pattern.
+
+Handling:
+
+- Record the route on the child class (that's where the plugin's REST surface
+  actually exposes it).
+- Set `backing.route_registration_line: null` and
+  `backing.callback_line: null` in the audit schema.
+- Add `backing.inherited_from: "<parent FQCN>"` so downstream skills can tell
+  the inheritance case from a plain missing line number.
+- Consider running grep against the parent repo too when you need to confirm
+  the callback's request handling — inherited callbacks behave as whatever
+  the parent defines, not what the plugin repo documents.
+
+See `audit-schema.md` for the exact field shapes.
+
+## Exhaustiveness is the goal
+
+The "Controller Inventory" table in the audit doc must list every controller
+the enumeration found — not just ones backing proposed abilities. A reviewer
+asking "why isn't controller X in the MVP?" should be able to point at the
+inventory and see the explicit answer (usually: "excluded from MVP because…"
+or "surfaced as a gap because…").
+
+If your inventory has 3 entries and the plugin clearly exposes more, either
+the enumeration is incomplete (re-run grep with broader patterns) or you're
+filtering the inventory instead of the proposal list. Fix the inventory
+first; filter after.
+
+## Escalation
+
+If neither glob nor grep produces a complete inventory — for example a
+plugin that registers routes dynamically from config or via a factory that
+does not contain a literal `register_rest_route(` string — document the
+enumeration gap in "Notes and Surprises", and extend this reference with the
+new pattern once understood.

--- a/skills/wp-abilities-verify/SKILL.md
+++ b/skills/wp-abilities-verify/SKILL.md
@@ -104,10 +104,10 @@ and verify it matches the annotation claim:
 - `destructive: false` → callback must not delete, refund, void,
   cancel, or trash.
 - `idempotent: true` → repeated calls with the same input have no
-  additional effect on the environment (core's wording at
-  `class-wp-ability.php` lines 47-48). Static catches counter writes
-  and per-call cron schedules; runtime adds a twin-invocation
-  heuristic for visible state changes.
+  additional effect on the environment (per the `idempotent`
+  annotation's docblock in `class-wp-ability.php`). Static catches
+  counter writes and per-call cron schedules; runtime adds a
+  twin-invocation heuristic for visible state changes.
 
 The reference lists common write patterns as a starting set, not a
 checklist — plugin vocabularies vary, and the agent extends with verbs

--- a/skills/wp-abilities-verify/SKILL.md
+++ b/skills/wp-abilities-verify/SKILL.md
@@ -202,7 +202,7 @@ WARNs without FAILs → WARN; otherwise PASS.
   `annotation-correctness.md`. Don't broaden the candidate-pattern
   list speculatively.
 - Audit-schema validator rejects a legitimate audit → the canonical
-  schema in `wp-abilities-audit/references/audit-schema.md` has
+  schema in `../wp-abilities-audit/references/audit-schema.md` has
   evolved. Update `references/audit-schema-validation.md` to match.
 
 ## Out of scope

--- a/skills/wp-abilities-verify/SKILL.md
+++ b/skills/wp-abilities-verify/SKILL.md
@@ -32,7 +32,10 @@ against a live environment.
 - **Runtime mode** — requires a running env. Does everything static does
   PLUS: `wp_get_abilities()` for authoritative enumeration, executes each
   ability with curated inputs, confirms permission roundtrip against real
-  users, verifies idempotent reads are byte-for-byte identical on twin calls.
+  users, and runs a twin-invocation heuristic on `idempotent: true`
+  abilities to flag candidates for review (return-value equality is a
+  signal, not a verdict — core defines idempotent as "no additional
+  effect on the environment").
 
 Both modes produce the same structured report format.
 
@@ -122,8 +125,12 @@ distinct skill rather than just "run the tests". Three claims:
   require runtime confirmation.
 - `destructive: false` → callback must not delete, refund, cancel, close
   disputes, or trash content.
-- `idempotent: true` → no `rand()`, no `wp_create_nonce`, no sequence
-  increments. Runtime: twin invocations must match byte-for-byte.
+- `idempotent: true` → repeated calls with the same input have no
+  additional effect on the environment (core's wording at
+  `class-wp-ability.php` lines 47-48). Static catches counter writes,
+  per-call cron schedules, and sequence increments. Runtime
+  twin-invocation diff is a heuristic — differing returns flag
+  candidates to inspect, not a verdict.
 
 False positives get suppressed via an inline `// verify-ignore: readonly`
 comment — see the reference.

--- a/skills/wp-abilities-verify/SKILL.md
+++ b/skills/wp-abilities-verify/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: wp-abilities-verify
+description: "Verify a WordPress plugin's Abilities API registrations: enumerate abilities via REST, check annotation correctness including the adversarial readonly-but-writes detection, validate permissions and schemas, and validate audit documents produced by wp-abilities-audit."
+compatibility: "Targets WordPress 6.9+ plugins (PHP 7.2.24+). Requires a runnable environment (wp-env, docker-based dev stack, or equivalent) for runtime mode; static mode runs entirely from the plugin checkout with no env. Filesystem-based agent with bash + node."
+---
+
+# WP Abilities Verify
+
+Verify a WordPress plugin's Abilities API registrations. The centerpiece is
+the **adversarial annotation-correctness check**: a `readonly: true` ability
+that actually writes (via `wpdb->update`, `update_option`, `wp_insert_*`, a
+non-GET delegate, etc.) is a security and UX disaster because agents plan
+actions on the basis of the annotations they introspect. This skill catches
+those lies.
+
+The skill also validates audit docs produced by `wp-abilities-audit`,
+runs permission and schema lints, and optionally executes each ability
+against a live environment.
+
+## When to use
+
+- After abilities have been registered in the plugin but before a PR lands.
+- As a health-check on an already-shipped plugin (catch regressions where a
+  refactor turned a readonly ability into a writing one).
+- To validate an audit document before handing it to an implementer.
+
+## Two modes
+
+- **Static mode** — runs from the plugin checkout. No env. Enumerates via
+  source grep, runs the adversarial readonly-but-writes checks, runs schema
+  and permission lints, and validates audit docs.
+- **Runtime mode** — requires a running env. Does everything static does
+  PLUS: `wp_get_abilities()` for authoritative enumeration, executes each
+  ability with curated inputs, confirms permission roundtrip against real
+  users, verifies idempotent reads are byte-for-byte identical on twin calls.
+
+Both modes produce the same structured report format.
+
+### Static-mode coverage caveats
+
+Static mode is grep-driven. It catches the high-leverage bug class
+(`readonly: true` ability that obviously writes via `$wpdb`, options API,
+`wp_insert_*`, or non-GET delegate) but does NOT detect every possible
+write. Known blind spots:
+
+- **Indirected service writes** — `$service->commit()`, `$repo->persist()`,
+  camelCase verbs (`->markAsPaid()`), or any custom-named mutating method
+  that doesn't match the documented verb list.
+- **Hooks-as-writes** — `do_action()` whose listeners write. The ability
+  itself looks readonly; the side effect happens in a registered listener.
+- **Cron / scheduling writes** — `wp_schedule_event` and friends mutate
+  the cron options table.
+- **Filesystem writes** — `file_put_contents`, `wp_upload_bits`,
+  `WP_Filesystem->put_contents`, `fwrite`, `unlink`, `rename`.
+- **Method-default in delegate helpers** — a `delegate_to_rest_controller`
+  whose HTTP method is built from a variable or a default-changed
+  signature won't trip the literal-method regex.
+- **Inline `new WP_REST_Request('POST', ...)`** without going through
+  the delegate helper.
+
+Treat a static-mode PASS as "no obvious-shape violations," not "verified
+write-free." Runtime mode catches some of these via the twin-invocation
+diff (a `readonly: true` ability that mutates state will return different
+data on second call). For high-stakes plugins, run runtime mode before
+landing.
+
+## Inputs required
+
+1. **Plugin checkout path** — working tree to verify.
+2. **Mode** — `static` or `runtime`. Default to static if unspecified.
+3. **(Runtime only) Env-up command** — read the plugin's `AGENTS.md`.
+   Common patterns: `npm run wp-env start`, `jetpack docker up`, or a
+   composer-based bring-up. Do NOT assume `npm run wp-env` works.
+4. **(Optional) Audit doc path** — enables cross-checks between the audit
+   and the registered abilities, and validates the audit itself.
+5. **Report output path** — explicit path, typically the user's vault.
+
+## Prerequisites
+
+- `wp-project-triage` has been run on the plugin.
+- The plugin has at least one registered ability in source. If
+  `wp_register_ability(` returns zero hits, there is nothing to verify —
+  return a clear "no abilities registered" report, not an empty PASS.
+
+## Procedure
+
+### 1. (If audit provided) Validate the audit doc
+
+Read `references/audit-schema-validation.md`. Validate the audit against
+the canonical schema owned by `wp-abilities-audit`. Surface missing
+required top-level fields, missing per-ability fields, or more than one
+ability with `reference_ability: true`. `backing: null` is a WARN, not
+a FAIL — it's intentional gap output, paired with a `surfaced_gaps`
+entry.
+
+### 2. Enumerate abilities statically
+
+Read `references/static-enumeration.md`. Scan for `wp_register_ability(`
+calls, extract names and annotation blocks. Handle fluent builders,
+variable-indirected `input_schema` values, multi-line arrays, and heredoc
+callbacks. Record ability-name → source-file + line + annotations.
+
+### 3. (Runtime only) Enumerate via REST + wp-cli
+
+Read `references/runtime-harness.md`. Bring up the env using the command
+from AGENTS.md, then enumerate via `wp_get_abilities()` over wp-cli and
+cross-check against the static inventory. Source-only → FAIL (registration
+not firing). Runtime-only → WARN (dynamic registration path).
+
+### 4. Annotation-correctness checks (the adversarial core)
+
+Read `references/annotation-correctness.md`. This is what makes verify a
+distinct skill rather than just "run the tests". Three claims:
+
+- `readonly: true` → callback must not write. The reference covers grep
+  patterns for direct `$wpdb` writes, options API, post/user/term/comment
+  writes, write-verb method names on services, non-GET HTTP delegations
+  (including inline `new WP_REST_Request('POST', ...)`), filesystem
+  writes, and cron-scheduling calls. It also flags hooks-as-writes
+  (`do_action` whose listeners write) and indirected service mutators
+  (`->commit`, `->persist`, camelCase verbs) as known blind spots that
+  require runtime confirmation.
+- `destructive: false` → callback must not delete, refund, cancel, close
+  disputes, or trash content.
+- `idempotent: true` → no `rand()`, no `wp_create_nonce`, no sequence
+  increments. Runtime: twin invocations must match byte-for-byte.
+
+False positives get suppressed via an inline `// verify-ignore: readonly`
+comment — see the reference.
+
+### 5. Permission gate roundtrip
+
+Read `references/permission-roundtrip.md`. Static: the registered
+`permission_callback` must reference a capability via `current_user_can(...)`,
+or be `'__return_true'` (WARN), or match the allow-list. Runtime: subscriber
+and unauthenticated denied; admin allowed (unless deliberately public).
+
+If an audit was provided, cross-check the registered capability against
+the audit's `capability_gate`. Mismatch → FAIL.
+
+### 6. Schema lints
+
+Read `references/schema-lints.md`. Static lints: `additionalProperties:
+false` unless deliberately accepting extras; every required field has a
+description; enums non-empty; no `$ref`; defaults primitive or `null`;
+`reference_ability: true` implies no `required` inputs.
+
+Cross-reference `../wp-abilities-api/references/input-schema-gotchas.md`
+for the three runtime gotchas (defaults not injected, pagination drift,
+`empty()` ID validation).
+
+### 7. Error-code vocabulary conformance
+
+Cross-reference `../wp-abilities-api/references/error-code-vocabulary.md`.
+Grep each callback for `new WP_Error(` / `new \WP_Error(` and lint the
+first-argument code literal. Non-vocabulary codes → WARN.
+
+## Verification
+
+The run produces a structured markdown report at the user-specified path:
+
+```
+---
+Last updated: <YYYY-MM-DD HH:MM>
+---
+
+# <Plugin> Abilities Verification — <Static|Runtime> Mode
+
+## Status: <PASS|WARN|FAIL>
+
+## Audit doc validation (if provided)
+
+## Static inventory
+
+## Annotation correctness
+| Ability | Claim | Result | Evidence |
+|---|---|---|---|
+| <ability> | readonly=true | FAIL | line 142: `wpdb->update()` |
+
+## Permission gates
+
+## Schema lints
+
+## Error-code vocabulary
+```
+
+Every ability is OK, WARN, or FAIL. A single FAIL → top-line FAIL; WARNs
+without FAILs → WARN; otherwise PASS.
+
+## Failure modes / debugging
+
+- **Env not reachable (runtime)** — env-up failed or Docker isn't running.
+  Re-run `wp-project-triage`, then fix the env. Don't fall back silently
+  to static without noting it in the report.
+- **No abilities in source** — return a clear "nothing to verify" report.
+- **Audit schema mismatch** — point at
+  `references/audit-schema-validation.md`; don't auto-fix the audit.
+- **False positive on readonly-writes** — see
+  `references/annotation-correctness.md` for the `// verify-ignore`
+  mechanism. Document why each suppression is legitimate.
+- **Runtime enumeration smaller than static** — registration hook isn't
+  firing. Check init hook timing, activation state, autoloader order.
+
+## Escalation
+
+- Adversarial false positives on a legitimate pattern → add an allow-list
+  entry to `references/annotation-correctness.md` and document the
+  rationale. Don't loosen the regexes themselves.
+- Audit-schema validator rejects a legitimate audit → the canonical schema
+  in `wp-abilities-audit/references/audit-schema.md` has evolved. Update
+  `references/audit-schema-validation.md` to match and sync both.
+
+## Out of scope
+
+Token-budget measurement is a separate verification axis — an
+annotation-clean, schema-clean, runtime-passing ability set can still
+be unshippable if its `tools/list` form burns through an agent's
+context budget. That axis is tracked separately, not by this skill.
+Do NOT aggregate manual or external measurement into this skill's
+PASS/FAIL verdict.

--- a/skills/wp-abilities-verify/SKILL.md
+++ b/skills/wp-abilities-verify/SKILL.md
@@ -52,8 +52,10 @@ for the static blind spots.
 1. **Plugin checkout path** — working tree to verify.
 2. **Mode** — `static` or `runtime`. Default to static if unspecified.
 3. **(Runtime only) Env-up command** — read the plugin's `AGENTS.md`.
-   Common patterns: `npm run wp-env start`, `jetpack docker up`, or a
-   composer-based bring-up. Do NOT assume `npm run wp-env` works.
+   Common patterns: `npm run wp-env start`, `npx wp-env start`, or a
+   composer-based bring-up. Plugin families with their own dev tooling
+   will document their own command. Do NOT assume `npm run wp-env`
+   works.
 4. **(Optional) Audit doc path** — enables cross-checks between the
    audit and the registered abilities, and validates the audit itself.
 5. **Report output path** — explicit path, typically the user's vault.

--- a/skills/wp-abilities-verify/SKILL.md
+++ b/skills/wp-abilities-verify/SKILL.md
@@ -1,71 +1,51 @@
 ---
 name: wp-abilities-verify
-description: "Verify a WordPress plugin's Abilities API registrations: enumerate abilities via REST, check annotation correctness including the adversarial readonly-but-writes detection, validate permissions and schemas, and validate audit documents produced by wp-abilities-audit."
+description: "Verify a WordPress plugin's Abilities API registrations: enumerate abilities, check that callback behavior matches each annotation's claim (the adversarial readonly-but-writes detection), validate permissions and schemas, and validate audit documents produced by wp-abilities-audit."
 compatibility: "Targets WordPress 6.9+ plugins (PHP 7.2.24+). Requires a runnable environment (wp-env, docker-based dev stack, or equivalent) for runtime mode; static mode runs entirely from the plugin checkout with no env. Filesystem-based agent with bash + node."
 ---
 
 # WP Abilities Verify
 
-Verify a WordPress plugin's Abilities API registrations. The centerpiece is
-the **adversarial annotation-correctness check**: a `readonly: true` ability
-that actually writes (via `wpdb->update`, `update_option`, `wp_insert_*`, a
-non-GET delegate, etc.) is a security and UX disaster because agents plan
-actions on the basis of the annotations they introspect. This skill catches
-those lies.
+Verify a WordPress plugin's Abilities API registrations. The
+centerpiece is the **adversarial annotation correctness check**: a
+`readonly: true` ability that actually writes (via `$wpdb->update`,
+`update_option`, a non-GET delegate, etc.) is a security and UX
+disaster because agents plan actions on the basis of the annotations
+they introspect. This skill catches those lies by reading the callback
+body and comparing what it does against what the annotation claims.
 
 The skill also validates audit docs produced by `wp-abilities-audit`,
-runs permission and schema lints, and optionally executes each ability
-against a live environment.
+checks permission gates and schema hygiene, and optionally executes
+each ability against a live environment.
 
 ## When to use
 
-- After abilities have been registered in the plugin but before a PR lands.
-- As a health-check on an already-shipped plugin (catch regressions where a
-  refactor turned a readonly ability into a writing one).
+- After abilities have been registered in a plugin but before a PR
+  lands.
+- As a health-check on an already-shipped plugin (catch regressions
+  where a refactor turned a readonly ability into a writing one).
 - To validate an audit document before handing it to an implementer.
 
 ## Two modes
 
-- **Static mode** — runs from the plugin checkout. No env. Enumerates via
-  source grep, runs the adversarial readonly-but-writes checks, runs schema
-  and permission lints, and validates audit docs.
-- **Runtime mode** — requires a running env. Does everything static does
-  PLUS: `wp_get_abilities()` for authoritative enumeration, executes each
-  ability with curated inputs, confirms permission roundtrip against real
-  users, and runs a twin-invocation heuristic on `idempotent: true`
-  abilities to flag candidates for review (return-value equality is a
-  signal, not a verdict — core defines idempotent as "no additional
-  effect on the environment").
+- **Static mode** — runs from the plugin checkout. No env. Enumerates
+  via source inspection, runs the adversarial correctness check, runs
+  schema and permission lints, and validates audit docs.
+- **Runtime mode** — requires a running env. Does everything static
+  does PLUS: `wp_get_abilities()` for authoritative enumeration,
+  executes each ability with curated inputs, confirms permission
+  roundtrip against real users, and runs a twin-invocation heuristic
+  on `idempotent: true` abilities to flag candidates for review
+  (return-value equality is a signal, not a verdict — core defines
+  idempotent as "no additional effect on the environment").
 
 Both modes produce the same structured report format.
 
-### Static-mode coverage caveats
-
-Static mode is grep-driven. It catches the high-leverage bug class
-(`readonly: true` ability that obviously writes via `$wpdb`, options API,
-`wp_insert_*`, or non-GET delegate) but does NOT detect every possible
-write. Known blind spots:
-
-- **Indirected service writes** — `$service->commit()`, `$repo->persist()`,
-  camelCase verbs (`->markAsPaid()`), or any custom-named mutating method
-  that doesn't match the documented verb list.
-- **Hooks-as-writes** — `do_action()` whose listeners write. The ability
-  itself looks readonly; the side effect happens in a registered listener.
-- **Cron / scheduling writes** — `wp_schedule_event` and friends mutate
-  the cron options table.
-- **Filesystem writes** — `file_put_contents`, `wp_upload_bits`,
-  `WP_Filesystem->put_contents`, `fwrite`, `unlink`, `rename`.
-- **Method-default in delegate helpers** — a `delegate_to_rest_controller`
-  whose HTTP method is built from a variable or a default-changed
-  signature won't trip the literal-method regex.
-- **Inline `new WP_REST_Request('POST', ...)`** without going through
-  the delegate helper.
-
-Treat a static-mode PASS as "no obvious-shape violations," not "verified
-write-free." Runtime mode catches some of these via the twin-invocation
-diff (a `readonly: true` ability that mutates state will return different
-data on second call). For high-stakes plugins, run runtime mode before
-landing.
+A static-mode PASS means "no obvious-shape violations," not "verified
+write-free." For high-stakes plugins, run runtime mode before landing
+— it catches bootstrap-order, permission-roundtrip, and idempotency
+issues that static can't. See `references/annotation-correctness.md`
+for the static blind spots.
 
 ## Inputs required
 
@@ -74,97 +54,101 @@ landing.
 3. **(Runtime only) Env-up command** — read the plugin's `AGENTS.md`.
    Common patterns: `npm run wp-env start`, `jetpack docker up`, or a
    composer-based bring-up. Do NOT assume `npm run wp-env` works.
-4. **(Optional) Audit doc path** — enables cross-checks between the audit
-   and the registered abilities, and validates the audit itself.
+4. **(Optional) Audit doc path** — enables cross-checks between the
+   audit and the registered abilities, and validates the audit itself.
 5. **Report output path** — explicit path, typically the user's vault.
 
 ## Prerequisites
 
 - `wp-project-triage` has been run on the plugin.
-- The plugin has at least one registered ability in source. If
-  `wp_register_ability(` returns zero hits, there is nothing to verify —
-  return a clear "no abilities registered" report, not an empty PASS.
+- The plugin has at least one registered ability in source. Zero hits
+  on `wp_register_ability(` → return a clear "no abilities registered"
+  report, not an empty PASS.
 
 ## Procedure
 
 ### 1. (If audit provided) Validate the audit doc
 
-Read `references/audit-schema-validation.md`. Validate the audit against
-the canonical schema owned by `wp-abilities-audit`. Surface missing
-required top-level fields, missing per-ability fields, or more than one
-ability with `reference_ability: true`. `backing: null` is a WARN, not
-a FAIL — it's intentional gap output, paired with a `surfaced_gaps`
-entry.
+Read `references/audit-schema-validation.md`. Validate the audit
+against the canonical schema owned by `wp-abilities-audit`. Surface
+missing required fields, multiple `reference_ability: true`, and
+`backing: null` entries that aren't paired with a `surfaced_gaps`
+entry. `backing: null` alone is WARN (intentional gap output), not
+FAIL.
 
 ### 2. Enumerate abilities statically
 
-Read `references/static-enumeration.md`. Scan for `wp_register_ability(`
-calls, extract names and annotation blocks. Handle fluent builders,
-variable-indirected `input_schema` values, multi-line arrays, and heredoc
-callbacks. Record ability-name → source-file + line + annotations.
+Read `references/static-enumeration.md`. Find each
+`wp_register_ability(` call, extract the name, the annotation block,
+and the execute-callback location. Use a multi-line tool (`rg
+--multiline --pcre2`) — the canonical formatting splits the call
+across lines. Record each ability's source-file + line + annotations +
+callback byte range.
 
 ### 3. (Runtime only) Enumerate via REST + wp-cli
 
-Read `references/runtime-harness.md`. Bring up the env using the command
-from AGENTS.md, then enumerate via `wp_get_abilities()` over wp-cli and
-cross-check against the static inventory. Source-only → FAIL (registration
-not firing). Runtime-only → WARN (dynamic registration path).
+Read `references/runtime-harness.md`. Bring the env up using the
+command from `AGENTS.md`, then enumerate via `wp_get_abilities()` over
+wp-cli and cross-check against the static inventory. Source-only →
+FAIL (registration not firing). Runtime-only → WARN (dynamic
+registration path).
 
-### 4. Annotation-correctness checks (the adversarial core)
+### 4. Annotation correctness (the adversarial core)
 
-Read `references/annotation-correctness.md`. This is what makes verify a
-distinct skill rather than just "run the tests". Three claims:
+Read `references/annotation-correctness.md`. Read each callback body
+and verify it matches the annotation claim:
 
-- `readonly: true` → callback must not write. The reference covers grep
-  patterns for direct `$wpdb` writes, options API, post/user/term/comment
-  writes, write-verb method names on services, non-GET HTTP delegations
-  (including inline `new WP_REST_Request('POST', ...)`), filesystem
-  writes, and cron-scheduling calls. It also flags hooks-as-writes
-  (`do_action` whose listeners write) and indirected service mutators
-  (`->commit`, `->persist`, camelCase verbs) as known blind spots that
-  require runtime confirmation.
-- `destructive: false` → callback must not delete, refund, cancel, close
-  disputes, or trash content.
+- `readonly: true` → callback must not write to the database, the
+  options table, post / user / term / comment data, the filesystem,
+  cron, or via non-GET HTTP / REST delegates.
+- `destructive: false` → callback must not delete, refund, void,
+  cancel, or trash.
 - `idempotent: true` → repeated calls with the same input have no
   additional effect on the environment (core's wording at
-  `class-wp-ability.php` lines 47-48). Static catches counter writes,
-  per-call cron schedules, and sequence increments. Runtime
-  twin-invocation diff is a heuristic — differing returns flag
-  candidates to inspect, not a verdict.
+  `class-wp-ability.php` lines 47-48). Static catches counter writes
+  and per-call cron schedules; runtime adds a twin-invocation
+  heuristic for visible state changes.
 
-False positives get suppressed via an inline `// verify-ignore: readonly`
-comment — see the reference.
+The reference lists common write patterns as a starting set, not a
+checklist — plugin vocabularies vary, and the agent extends with verbs
+specific to the plugin under verification.
 
-### 5. Permission gate roundtrip
+False positives get suppressed via an inline `// verify-ignore:
+<annotation> -- <reason>` comment.
 
-Read `references/permission-roundtrip.md`. Static: the registered
-`permission_callback` must reference a capability via `current_user_can(...)`,
-or be `'__return_true'` (WARN), or match the allow-list. Runtime: subscriber
-and unauthenticated denied; admin allowed (unless deliberately public).
+### 5. Permission roundtrip
 
-If an audit was provided, cross-check the registered capability against
-the audit's `capability_gate`. Mismatch → FAIL.
+Read `references/permission-roundtrip.md`. Static: classify each
+`permission_callback` against the six shapes (preferred Shape A
+`current_user_can(...)`; FAIL on Shape B-bad `WP_REST_Request`
+patterns or Shape E literal `true`). Runtime: anon and subscriber
+denied; admin allowed (unless deliberately public). When an audit was
+provided, cross-check the registered cap against the audit's declared
+gate.
 
 ### 6. Schema lints
 
-Read `references/schema-lints.md`. Static lints: `additionalProperties:
-false` unless deliberately accepting extras; every required field has a
-description; enums non-empty; no `$ref`; defaults primitive or `null`;
-`reference_ability: true` implies no `required` inputs.
+Read `references/schema-lints.md`. Six small principles applied to
+each ability's `input_schema`: object schemas declare
+`additionalProperties`; required fields have descriptions; enums
+non-empty; no `$ref`; defaults are statically constant (including
+`(object) array()`); reference abilities have no required inputs.
 
 Cross-reference `../wp-abilities-api/references/input-schema-gotchas.md`
-for the three runtime gotchas (defaults not injected, pagination drift,
-`empty()` ID validation).
+for the four runtime gotchas (defaults not injected on the
+property-level path, pagination key drift, `empty()` on string IDs,
+direct vs indirect invocation strictness).
 
-### 7. Error-code vocabulary conformance
+### 7. Error-code vocabulary
 
 Cross-reference `../wp-abilities-api/references/error-code-vocabulary.md`.
-Grep each callback for `new WP_Error(` / `new \WP_Error(` and lint the
-first-argument code literal. Non-vocabulary codes → WARN.
+Inspect each callback's `WP_Error` returns; non-vocabulary codes →
+WARN.
 
 ## Verification
 
-The run produces a structured markdown report at the user-specified path:
+The run produces a structured markdown report at the user-specified
+path:
 
 ```
 ---
@@ -182,7 +166,6 @@ Last updated: <YYYY-MM-DD HH:MM>
 ## Annotation correctness
 | Ability | Claim | Result | Evidence |
 |---|---|---|---|
-| <ability> | readonly=true | FAIL | line 142: `wpdb->update()` |
 
 ## Permission gates
 
@@ -191,37 +174,39 @@ Last updated: <YYYY-MM-DD HH:MM>
 ## Error-code vocabulary
 ```
 
-Every ability is OK, WARN, or FAIL. A single FAIL → top-line FAIL; WARNs
-without FAILs → WARN; otherwise PASS.
+Every ability is OK, WARN, or FAIL. A single FAIL → top-line FAIL;
+WARNs without FAILs → WARN; otherwise PASS.
 
 ## Failure modes / debugging
 
-- **Env not reachable (runtime)** — env-up failed or Docker isn't running.
-  Re-run `wp-project-triage`, then fix the env. Don't fall back silently
-  to static without noting it in the report.
-- **No abilities in source** — return a clear "nothing to verify" report.
+- **Env not reachable (runtime)** — env-up failed or Docker isn't
+  running. Re-run `wp-project-triage`, then fix the env. Don't fall
+  back silently to static without noting it in the report.
+- **No abilities in source** — return a clear "nothing to verify"
+  report.
 - **Audit schema mismatch** — point at
   `references/audit-schema-validation.md`; don't auto-fix the audit.
-- **False positive on readonly-writes** — see
-  `references/annotation-correctness.md` for the `// verify-ignore`
-  mechanism. Document why each suppression is legitimate.
-- **Runtime enumeration smaller than static** — registration hook isn't
-  firing. Check init hook timing, activation state, autoloader order.
+- **False positive on readonly-writes** — see the `// verify-ignore`
+  mechanism in `references/annotation-correctness.md`. Document why
+  each suppression is legitimate.
+- **Runtime enumeration smaller than static** — registration hook
+  isn't firing. Check init hook timing, activation state, autoloader
+  order.
 
 ## Escalation
 
-- Adversarial false positives on a legitimate pattern → add an allow-list
-  entry to `references/annotation-correctness.md` and document the
-  rationale. Don't loosen the regexes themselves.
-- Audit-schema validator rejects a legitimate audit → the canonical schema
-  in `wp-abilities-audit/references/audit-schema.md` has evolved. Update
-  `references/audit-schema-validation.md` to match and sync both.
+- Recurring legitimate pattern that trips the adversarial check across
+  multiple plugins → propose adding it to the suppression guidance in
+  `annotation-correctness.md`. Don't broaden the candidate-pattern
+  list speculatively.
+- Audit-schema validator rejects a legitimate audit → the canonical
+  schema in `wp-abilities-audit/references/audit-schema.md` has
+  evolved. Update `references/audit-schema-validation.md` to match.
 
 ## Out of scope
 
 Token-budget measurement is a separate verification axis — an
 annotation-clean, schema-clean, runtime-passing ability set can still
 be unshippable if its `tools/list` form burns through an agent's
-context budget. That axis is tracked separately, not by this skill.
-Do NOT aggregate manual or external measurement into this skill's
-PASS/FAIL verdict.
+context budget. That axis is tracked separately. Do not aggregate
+manual or external measurement into this skill's PASS / FAIL verdict.

--- a/skills/wp-abilities-verify/references/annotation-correctness.md
+++ b/skills/wp-abilities-verify/references/annotation-correctness.md
@@ -102,6 +102,8 @@ means "no obvious-shape violations," not "verified write-free."
 |---|---|---|
 | Indirected service writes — `$repo->persist()`, `$service->commit()`, custom verbs. | Any finite verb list drifts; domain vocabulary varies. | Inspect callbacks that touch custom services or repositories. |
 | `do_action()` whose listeners write. | Provenance ambiguity: ability looks clean; system mutates state in a listener. | Audit listeners on the action. If any writes, downgrade or split. |
+| Implicit core hooks fired by WP API calls — `wp_insert_post()` fires `save_post`; `update_option()` fires `updated_option`; `wp_create_user()` fires `user_register`; etc. | The WP API call IS the write; the hooks fire automatically as a side effect. Agents looking for `do_action()` won't see this. | Treat any WP write-API call as a write regardless of whether the callback also calls `do_action()`. |
+| Action Scheduler / deferred writes — `as_schedule_single_action()`, `WC()->queue()->schedule_single()`, custom job dispatchers. | The callback returns cleanly with no immediately visible DB mutation; the durable write lands later in the AS tables. A static grep for `$wpdb->insert` won't catch it. | Treat scheduler dispatches as writes. The "no additional effect on the environment" promise of `idempotent: true` is violated by accumulating queued jobs even if the immediate return value is constant. |
 | Variable-built HTTP methods on delegate helpers. | Static can't follow runtime values. | Treat callers of helpers whose default method isn't `GET` as suspect. |
 | Tautological capability gates — `current_user_can('read')` on a "private" ability. | The cap looks valid; subscribers happen to hold it. | Cross-reference the permission roundtrip — subscribers should be denied. |
 

--- a/skills/wp-abilities-verify/references/annotation-correctness.md
+++ b/skills/wp-abilities-verify/references/annotation-correctness.md
@@ -105,8 +105,13 @@ grep -nE '\b(update|add|delete)_term_meta\s*\(' <file>
 # Comment writes.
 grep -nE '\bwp_(insert|update|delete|trash|spam)_comment\s*\(' <file>
 
-# Method-name write-verb patterns on controllers / services.
-grep -nE '->(create|insert|update|delete|remove|save|store|write|destroy|purge|archive|restore|disable|enable|activate|deactivate|revoke|grant)_' <file>
+# Method-name write-verb patterns on controllers / services. The verb
+# list below is a representative starting set — extend with verbs in
+# the plugin's own vocabulary (e.g. `->markAsPaid()`, `->commit()`,
+# domain-specific writes). The trailing `(_|\()` matches either a
+# verb-prefixed method name (`->save_record()`) or a direct call
+# (`->save()`).
+grep -nE '->(add|set|save|create|insert|update|delete|remove|destroy|purge|trash|archive|restore|store|write|disable|enable|activate|deactivate|revoke|grant)(_|\()' <file>
 
 # Non-GET HTTP delegations.
 grep -nE '\bwp_remote_(post|request|delete)\b' <file>
@@ -134,7 +139,11 @@ Against callbacks annotated `destructive: false`:
 ```bash
 # Deletion verbs.
 grep -nE '\bwp_(delete|trash)_(post|user|term|comment|attachment)\s*\(' <file>
-grep -nE '->(delete|destroy|purge|revoke|forfeit|cancel|refund|chargeback|close_dispute|void|terminate)_' <file>
+
+# Mutator method calls — same verb-followed-by-(_|\() pattern as the
+# readonly check, narrowed to verbs that imply destruction. Treat the
+# verb list as illustrative, not exhaustive.
+grep -nE '->(delete|destroy|purge|revoke|forfeit|cancel|refund|chargeback|close_dispute|void|terminate)(_|\()' <file>
 
 # Payment-system destructive verbs.
 grep -nE '->(refund|cancel|void|dispute|chargeback)\s*\(' <file>

--- a/skills/wp-abilities-verify/references/annotation-correctness.md
+++ b/skills/wp-abilities-verify/references/annotation-correctness.md
@@ -26,7 +26,9 @@ execute callback body and comparing what it does against what the
 annotation says it does. That's this file.
 
 The same logic applies to `destructive: false` ("won't delete anything")
-and `idempotent: true` ("same input, same result, same effect").
+and `idempotent: true` ("repeated calls with the same arguments produce
+no additional effect on the environment" — core's docblock at
+`class-wp-ability.php` lines 47-48).
 
 ## The three claims
 
@@ -34,12 +36,18 @@ and `idempotent: true` ("same input, same result, same effect").
 |---|---|---|
 | `readonly: true` | No writes. GET-style side-effect-free. | No `wpdb->insert/update/delete`, `update_option`, `wp_insert_*`, non-GET delegates, etc. |
 | `destructive: false` | Won't irreversibly destroy data or forfeit money. | No `wp_delete_*`, `wp_trash_post`, `->refund`, `->cancel`, `->close_dispute`. |
-| `idempotent: true` | Same input always produces same effect. | No `rand()`, nonce generation, sequence increments, timestamps-in-response. Runtime: twin invocations byte-identical. |
+| `idempotent: true` | Repeated calls with the same arguments produce no additional environmental effect (core's definition). | No counter writes that grow per call, no per-call cron schedules, no sequence increments writing back to durable state. Runtime twin-invocation diff is a heuristic to flag candidates, not a verdict. |
 
 These overlap but are not redundant: `readonly` is the strictest,
 `destructive: false` is weaker (updates that don't destroy are OK), and
 `idempotent` is orthogonal (a POST that writes the same row twice is both
 "writes" and "idempotent").
+
+The run controller operationalizes annotations into HTTP method routing
+(`readonly: true` → GET, `destructive && idempotent` → DELETE, otherwise
+POST — see `class-wp-rest-abilities-v1-run-controller.php` lines 110-116).
+That's the load-bearing semantic — verify checks that the callback's
+behavior matches what the routing assumes.
 
 ## Static adversarial checks
 
@@ -135,26 +143,39 @@ grep -nE '->(refund|cancel|void|dispute|chargeback)\s*\(' <file>
 grep -nE '\bwp_delete_user\s*\(' <file>
 ```
 
-### Step 4 — idempotent-but-nondeterministic check
+### Step 4 — idempotent-but-non-idempotent check
 
-Against callbacks annotated `idempotent: true`:
+Against callbacks annotated `idempotent: true`. Idempotency in core
+means *repeated calls with the same arguments have no additional effect
+on the environment* — it's about environmental writes, not return-value
+determinism. The patterns to catch are per-call writes whose effect
+accumulates:
 
 ```bash
-# Randomness.
-grep -nE '\b(rand|mt_rand|random_int|random_bytes|wp_rand)\s*\(' <file>
-grep -nE '\bwp_generate_(uuid4|password|auth_cookie)\s*\(' <file>
+# Counter or sequence-style writes — value grows per call.
+grep -nE '\b(update_option|update_post_meta|update_user_meta)\s*\([^)]*get_(option|post_meta|user_meta)' <file>
 
-# Nonce generation (per-call, non-deterministic by design).
-grep -nE '\bwp_create_nonce\s*\(' <file>
+# Per-call cron schedules — wp_schedule_event creates a new timer each
+# call; wp_schedule_single_event is non-idempotent unless the call site
+# explicitly checks for an existing scheduled hook first.
+grep -nE '\bwp_schedule_(single_)?event\s*\(' <file>
 
-# Time-based payloads — time() in the response means twin calls differ.
-# Flag as WARN, not FAIL: many legitimate read callbacks include a
-# `generated_at` field. Runtime byte-comparison catches the real violations.
-grep -nE '\b(time|microtime|current_time|date|wp_date)\s*\(' <file>
+# Append-only inserts on a per-call basis (logs, audit trails).
+grep -nE '\$wpdb->insert\s*\(' <file>
 
-# Sequence increments.
+# Sequence increments visible in callback scope.
 grep -nE '\+\+\s*;|\$[a-z_]+\s*\+=\s*1\b' <file>
 ```
+
+Patterns that *don't* violate core's idempotent (do not auto-FAIL — kept
+here so the check doesn't snare them):
+
+- `rand()`, `wp_rand()`, `wp_generate_uuid4()`, `wp_create_nonce()` —
+  produce a different return value per call, but the environment is
+  unchanged. Idempotent under core's reading.
+- `time()`, `current_time()`, `microtime()` — read-only clock access.
+  Embedding the result in the response is fine; only flag if the value
+  is *written* into per-call growing state.
 
 ## Precedence and severity
 
@@ -240,8 +261,8 @@ in a real audit.
 
 ## Runtime check complement
 
-When runtime mode is on, add one more check that static cannot do:
-**twin-invocation diff for `idempotent: true` abilities**.
+When runtime mode is on, add a heuristic for `idempotent: true`
+abilities: invoke twice with the same input, then inspect what changed.
 
 ```bash
 # Via wp-cli (substitute the plugin's env-up + wp-cli invocation per AGENTS.md).
@@ -249,19 +270,30 @@ When runtime mode is on, add one more check that static cannot do:
 $a = wp_get_ability( "<plugin>/<ability>" );
 $r1 = $a->execute( [ <same-input> ] );
 $r2 = $a->execute( [ <same-input> ] );
-echo var_export( $r1 === $r2, true ) . PHP_EOL;  // should print "true"
+echo var_export( $r1 === $r2, true ) . PHP_EOL;
 echo md5( serialize( $r1 ) ) . PHP_EOL;
 echo md5( serialize( $r2 ) ) . PHP_EOL;
 '
 ```
 
-Expected output: `true` followed by two identical hashes. Differ → FAIL
-with the two serialized payloads as evidence.
+Interpretation:
 
-Note: `idempotent: true` abilities that legitimately embed a timestamp
-(e.g. `generated_at` in the response) will fail this strict check. Either
-remove the timestamp (preferred — it's never load-bearing for the agent)
-or loosen the annotation to `idempotent: false`.
+- Hashes match → cheap PASS. Same input produced the same response, and
+  any environmental writes (write abilities) were the same on both calls.
+- Hashes differ → *signal*, not verdict. Per core's definition, idempotent
+  means "no additional effect on the environment" — return-value equality
+  is neither necessary nor sufficient. Inspect what changed:
+  - Response embeds a per-call timestamp / nonce / random ID → environment
+    unchanged. Still idempotent. Optionally remove the field if the agent
+    doesn't need it.
+  - Response reflects a counter or sequence that grew between calls →
+    real environmental change. FAIL: drop the `idempotent: true`
+    annotation or fix the underlying write to be input-determined.
+
+For ambiguous cases (response varies but no obvious counter), supplement
+with a state diff: snapshot a representative table or option before call
+1, snapshot after call 2, diff. If state changed by more than what the
+input writes would explain, the ability is non-idempotent.
 
 ## Report format
 

--- a/skills/wp-abilities-verify/references/annotation-correctness.md
+++ b/skills/wp-abilities-verify/references/annotation-correctness.md
@@ -33,7 +33,7 @@ annotation says it does.
 |---|---|
 | `readonly: true` | No writes. GET-style side-effect-free. |
 | `destructive: false` | Won't irreversibly destroy data or forfeit money. |
-| `idempotent: true` | Repeated calls with the same arguments produce no additional effect on the environment (core's docblock at `class-wp-ability.php` lines 47-48). |
+| `idempotent: true` | Repeated calls with the same arguments produce no additional effect on the environment (per the `idempotent` annotation's docblock in `class-wp-ability.php`). |
 
 These overlap but are not redundant: `readonly` is the strictest;
 `destructive: false` is weaker (updates that don't destroy are OK);
@@ -43,7 +43,7 @@ both "writes" and "idempotent").
 The Abilities REST run controller operationalizes annotations into
 HTTP method routing (`readonly: true` → GET, `destructive && idempotent`
 → DELETE, otherwise POST — see
-`class-wp-rest-abilities-v1-run-controller.php` lines 110-116). That
+`WP_REST_Abilities_V1_Run_Controller::validate_request_method()`). That
 mapping is the load-bearing semantic; verify checks that each
 callback's behavior is consistent with how the routing will treat it.
 

--- a/skills/wp-abilities-verify/references/annotation-correctness.md
+++ b/skills/wp-abilities-verify/references/annotation-correctness.md
@@ -1,345 +1,145 @@
 # Annotation Correctness
 
-The adversarial core of this skill. This is what makes `wp-abilities-verify`
-a distinct skill rather than a thin wrapper around "run the tests".
+The adversarial core of this skill: verify what the annotation claims
+by reading the callback. A `readonly: true` ability that actually
+writes is a security and UX disaster, and unit tests don't catch it
+because the mock looks just like the real writer.
 
 ## Why this matters
 
-Agents plan actions on the basis of the annotations they introspect. If an
-ability is annotated `readonly: true`, an orchestrator will confidently
-invoke it in a dry-run, speculative exploration, or multi-agent fan-out
-without thinking twice — because `readonly` means "can't break anything".
+Agents plan actions on the basis of the annotations they introspect.
+If an ability is annotated `readonly: true`, an orchestrator will
+confidently invoke it in a dry-run, speculative exploration, or
+multi-agent fan-out without thinking twice — because `readonly` means
+"can't break anything".
 
 A `readonly: true` ability that actually writes is therefore:
 
-1. **A security hazard** — agents will invoke it in contexts where side
-   effects are forbidden.
-2. **A UX disaster** — the agent's mental model of what happened diverges
-   silently from reality. The human operator can't reason about what
-   state the system is in.
-3. **Undetectable at the annotation-layer** — the annotation says
+1. **A security hazard** — agents will invoke it in contexts where
+   side effects are forbidden.
+2. **A UX disaster** — the agent's mental model of what happened
+   diverges silently from reality.
+3. **Undetectable at the annotation layer** — the annotation says
    `readonly: true`; nothing in the registration forces it to be true.
 
 Unit tests won't catch this class of bug because the mock the test
-constructs looks just like the real writer. What catches it is reading the
-execute callback body and comparing what it does against what the
-annotation says it does. That's this file.
+constructs looks just like the real writer. What catches it is reading
+the execute callback body and comparing what it does against what the
+annotation says it does.
 
-The same logic applies to `destructive: false` ("won't delete anything")
-and `idempotent: true` ("repeated calls with the same arguments produce
-no additional effect on the environment" — core's docblock at
-`class-wp-ability.php` lines 47-48).
+## What each annotation promises
 
-## The three claims
+| Annotation | What it promises (from core) |
+|---|---|
+| `readonly: true` | No writes. GET-style side-effect-free. |
+| `destructive: false` | Won't irreversibly destroy data or forfeit money. |
+| `idempotent: true` | Repeated calls with the same arguments produce no additional effect on the environment (core's docblock at `class-wp-ability.php` lines 47-48). |
 
-| Annotation | What it promises | What to check |
-|---|---|---|
-| `readonly: true` | No writes. GET-style side-effect-free. | No `wpdb->insert/update/delete`, `update_option`, `wp_insert_*`, non-GET delegates, etc. |
-| `destructive: false` | Won't irreversibly destroy data or forfeit money. | No `wp_delete_*`, `wp_trash_post`, `->refund`, `->cancel`, `->close_dispute`. |
-| `idempotent: true` | Repeated calls with the same arguments produce no additional environmental effect (core's definition). | No counter writes that grow per call, no per-call cron schedules, no sequence increments writing back to durable state. Runtime twin-invocation diff is a heuristic to flag candidates, not a verdict. |
+These overlap but are not redundant: `readonly` is the strictest;
+`destructive: false` is weaker (updates that don't destroy are OK);
+`idempotent` is orthogonal (a POST that writes the same row twice is
+both "writes" and "idempotent").
 
-These overlap but are not redundant: `readonly` is the strictest,
-`destructive: false` is weaker (updates that don't destroy are OK), and
-`idempotent` is orthogonal (a POST that writes the same row twice is both
-"writes" and "idempotent").
+The Abilities REST run controller operationalizes annotations into
+HTTP method routing (`readonly: true` → GET, `destructive && idempotent`
+→ DELETE, otherwise POST — see
+`class-wp-rest-abilities-v1-run-controller.php` lines 110-116). That
+mapping is the load-bearing semantic; verify checks that each
+callback's behavior is consistent with how the routing will treat it.
 
-The run controller operationalizes annotations into HTTP method routing
-(`readonly: true` → GET, `destructive && idempotent` → DELETE, otherwise
-POST — see `class-wp-rest-abilities-v1-run-controller.php` lines 110-116).
-That's the load-bearing semantic — verify checks that the callback's
-behavior matches what the routing assumes.
+## How to verify
 
-## Static adversarial checks
+For each ability, locate the `execute_callback` body (see
+`static-enumeration.md` step 4), then:
 
-These grep-based checks run against the plugin checkout with no env.
-They're the heart of the skill.
+1. **Read the callback end-to-end.** Form a model of what it actually
+   does. Don't rely on pattern-matching alone.
+2. **Compare to the claim.** A `readonly: true` callback that writes
+   anywhere — the database via `$wpdb`, options / post / user / term /
+   comment writes, filesystem, cron schedules, or non-GET HTTP/REST
+   delegates — FAILs readonly. A `destructive: false` callback that
+   deletes, refunds, voids, cancels, or trashes FAILs destructive. An
+   `idempotent: true` callback whose environmental effect *accumulates*
+   per call (counters, append-only logs, per-call cron schedules) FAILs
+   idempotent.
+3. **Record evidence.** Cite file + line of the offending pattern so a
+   reviewer can jump straight to it.
 
-### Step 1 — locate the execute callback body
+Use grep or ripgrep to surface *candidates*. Common writes worth
+looking for:
 
-For each ability in the static inventory, resolve its `execute_callback`:
-
-```bash
-# 1. Find the ability registration.
-grep -rn "wp_register_ability( *'<plugin>/<ability-name>'" <plugin-root>/
-
-# 2. Find the execute_callback => key in the same array literal.
-#    Usually a few lines below the name.
-
-# 3. The callback value is either:
-#    a) [ ClassName::class, 'method' ] — look in ClassName for `public function method` or `public static function method`.
-#    b) [ $this, 'method' ] — look in the current class.
-#    c) 'function_name' — look for `function function_name` top-level.
-#    d) An anonymous function — the body is literally there.
+```text
+$wpdb->update / insert / delete / replace
+update_option / add_option / delete_option
+wp_insert_post / wp_update_post / wp_delete_post
+update_post_meta / update_user_meta / update_term_meta
+->save / ->delete / ->set_status / ->add_*
+wp_remote_post / wp_remote_delete
+file_put_contents / wp_upload_bits / unlink / rename
+wp_schedule_event / wp_schedule_single_event
 ```
 
-Record the file + starting line + ending line of the callback. All
-subsequent greps target that byte range.
-
-### Step 2 — readonly-but-writes check
-
-Against callbacks annotated `readonly: true`, run these patterns. ANY hit
-means the annotation is a lie and the ability FAILs the adversarial check.
-
-```bash
-# Direct $wpdb writes.
-grep -nE '\$wpdb->(update|insert|delete|replace)\b' <file> | awk -v s=<start> -v e=<end> '$1 >= s && $1 <= e'
-
-# Raw SQL with write verbs.
-grep -nE '\$wpdb->query\s*\([^)]*(UPDATE|INSERT|DELETE|REPLACE|TRUNCATE|ALTER)' <file>
-
-# Options API writes.
-grep -nE '\b(update_option|add_option|delete_option|update_site_option|add_site_option|delete_site_option)\s*\(' <file>
-
-# Post and post-meta writes.
-grep -nE '\bwp_(insert|update|delete|trash)_post\s*\(' <file>
-grep -nE '\b(update|add|delete)_post_meta\s*\(' <file>
-
-# User writes.
-grep -nE '\bwp_(insert|update|delete)_user\s*\(' <file>
-grep -nE '\b(update|add|delete)_user_meta\s*\(' <file>
-
-# Term writes.
-grep -nE '\bwp_(insert|update|delete)_term\s*\(' <file>
-grep -nE '\b(update|add|delete)_term_meta\s*\(' <file>
-
-# Comment writes.
-grep -nE '\bwp_(insert|update|delete|trash|spam)_comment\s*\(' <file>
-
-# Method-name write-verb patterns on controllers / services. The verb
-# list below is a representative starting set — extend with verbs in
-# the plugin's own vocabulary (e.g. `->markAsPaid()`, `->commit()`,
-# domain-specific writes). The trailing `(_|\()` matches either a
-# verb-prefixed method name (`->save_record()`) or a direct call
-# (`->save()`).
-grep -nE '->(add|set|save|create|insert|update|delete|remove|destroy|purge|trash|archive|restore|store|write|disable|enable|activate|deactivate|revoke|grant)(_|\()' <file>
-
-# Non-GET HTTP delegations.
-grep -nE '\bwp_remote_(post|request|delete)\b' <file>
-grep -nE "delegate_to_rest_controller\s*\([^)]*(POST|PUT|DELETE|PATCH)" <file>
-
-# Inline non-GET WP_REST_Request construction (without the delegate helper).
-grep -nE "new\s+\\\\?WP_REST_Request\s*\(\s*['\"](POST|PUT|DELETE|PATCH)" <file>
-
-# Filesystem writes — durable state changes that tools/list cannot describe.
-grep -nE '\b(file_put_contents|wp_upload_bits|fwrite|fputs|unlink|rename|mkdir|rmdir|copy|move_uploaded_file)\s*\(' <file>
-grep -nE 'WP_Filesystem(_Direct)?\s*->\s*(put_contents|delete|move|copy|mkdir|rmdir)' <file>
-
-# Cron and scheduler writes — mutate the cron options table even on "readonly" abilities.
-grep -nE '\bwp_(schedule_event|schedule_single_event|reschedule_event|unschedule_event|clear_scheduled_hook)\s*\(' <file>
-
-# Transients — may be legitimate read-path caching; flag as WARN not FAIL.
-# See "False-positive allow-list" below.
-grep -nE '\b(set_transient|delete_transient|set_site_transient|delete_site_transient)\s*\(' <file>
-```
-
-### Step 3 — destructive-but-says-false check
-
-Against callbacks annotated `destructive: false`:
-
-```bash
-# Deletion verbs.
-grep -nE '\bwp_(delete|trash)_(post|user|term|comment|attachment)\s*\(' <file>
-
-# Mutator method calls — same verb-followed-by-(_|\() pattern as the
-# readonly check, narrowed to verbs that imply destruction. Treat the
-# verb list as illustrative, not exhaustive.
-grep -nE '->(delete|destroy|purge|revoke|forfeit|cancel|refund|chargeback|close_dispute|void|terminate)(_|\()' <file>
-
-# Payment-system destructive verbs.
-grep -nE '->(refund|cancel|void|dispute|chargeback)\s*\(' <file>
-
-# Data-removal verbs.
-grep -nE '\bwp_delete_user\s*\(' <file>
-```
-
-### Step 4 — idempotent-but-non-idempotent check
-
-Against callbacks annotated `idempotent: true`. Idempotency in core
-means *repeated calls with the same arguments have no additional effect
-on the environment* — it's about environmental writes, not return-value
-determinism. The patterns to catch are per-call writes whose effect
-accumulates:
-
-```bash
-# Counter or sequence-style writes — value grows per call.
-grep -nE '\b(update_option|update_post_meta|update_user_meta)\s*\([^)]*get_(option|post_meta|user_meta)' <file>
-
-# Per-call cron schedules — wp_schedule_event creates a new timer each
-# call; wp_schedule_single_event is non-idempotent unless the call site
-# explicitly checks for an existing scheduled hook first.
-grep -nE '\bwp_schedule_(single_)?event\s*\(' <file>
-
-# Append-only inserts on a per-call basis (logs, audit trails).
-grep -nE '\$wpdb->insert\s*\(' <file>
-
-# Sequence increments visible in callback scope.
-grep -nE '\+\+\s*;|\$[a-z_]+\s*\+=\s*1\b' <file>
-```
-
-Patterns that *don't* violate core's idempotent (do not auto-FAIL — kept
-here so the check doesn't snare them):
-
-- `rand()`, `wp_rand()`, `wp_generate_uuid4()`, `wp_create_nonce()` —
-  produce a different return value per call, but the environment is
-  unchanged. Idempotent under core's reading.
-- `time()`, `current_time()`, `microtime()` — read-only clock access.
-  Embedding the result in the response is fine; only flag if the value
-  is *written* into per-call growing state.
-
-## Precedence and severity
-
-Not every hit is equal weight.
-
-| Pattern | Severity on `readonly: true` | Severity on `destructive: false` |
-|---|---|---|
-| `wpdb->update/insert/delete` | FAIL | FAIL (delete) / WARN (update) |
-| `update_option` / `update_post_meta` | FAIL | WARN |
-| `wp_insert_*` / `wp_update_*` | FAIL | WARN (unless delete) |
-| `wp_delete_*` / `wp_trash_*` | FAIL | FAIL |
-| `->refund`, `->cancel`, `->close_dispute` | FAIL | FAIL |
-| Non-GET `delegate_to_rest_controller` | FAIL | depends on method |
-| Inline `new WP_REST_Request('POST', ...)` | FAIL | depends on method |
-| `wp_remote_post` / `wp_remote_delete` | FAIL | WARN |
-| `file_put_contents`, `wp_upload_bits`, `WP_Filesystem->put_contents`, `unlink`, `rename` | FAIL | FAIL (delete) / WARN (write) |
-| `wp_schedule_event` / `wp_schedule_single_event` / `wp_clear_scheduled_hook` | FAIL | WARN |
-| `set_transient` / `delete_transient` | WARN (caching is ambiguous) | OK |
-| `rand()` / `wp_create_nonce` | N/A | N/A |
-| `time()` in response | N/A | N/A |
-
-Severity is deliberately sharp on the patterns that matter (deletion,
-money-moving verbs, non-GET delegates) and soft on ambiguous patterns
-(transients, time-in-response) to preserve signal quality.
+Treat the list as a starting set, not a checklist. Plugin vocabularies
+vary — domain-specific verbs (`->markAsPaid`, `->commit`, `->refund`)
+and framework patterns (Doctrine `->persist`, queue `->dispatch`) won't
+appear above. Once you've grepped for candidates, read the callback to
+confirm whether each hit is actually a write and whether it
+contradicts the annotation in context.
 
 ## Known blind spots
 
-Grep cannot reach every write. Static-mode PASS is "no obvious-shape
-violations," not "verified write-free." When verifying a high-stakes
-ability, run runtime mode and inspect the callback by hand for these
-patterns:
+Static reading + grep can't reach every write. A static-mode PASS
+means "no obvious-shape violations," not "verified write-free."
 
-| Blind spot | Why grep misses it | Mitigation |
+| Blind spot | Why static misses it | Mitigation |
 |---|---|---|
-| **Indirected service writes** — `$repo->persist()`, `$service->commit()`, `$model->flush()`, `->markAsPaid()` (camelCase), `->set()` (Doctrine), `->put()` (key-value), `->push()` (queue), `->dispatch_job()` | The verb list is finite and excludes domain-specific or framework-specific mutating verbs. | Inspect the callback when the ability touches any custom service/repository. Add the verb to the regex if it's recurring. |
-| **`do_action()` whose listeners write** | The ability itself emits an event; the write happens in a registered listener. Provenance ambiguity: the readonly-by-design ability is conceptually clean but the system mutates state. | Audit registered listeners on the action. If any write, downgrade the ability to `readonly: false` or split the event-emission out of the read path. |
-| **Variable-built or default HTTP method on `delegate_to_rest_controller`** — `$method = $is_write ? 'POST' : 'GET'; delegate_to_rest_controller(..., $method);` | The regex matches a literal token, not a variable. | When the helper signature defaults `$http_method` to anything other than `'GET'`, treat all callers as suspect. |
-| **WP-CLI invocations from inside an ability** — `WP_CLI::runcommand('option update foo bar')` | Not in any pattern list. | Rare in production; if present, treat as a destructive escape hatch and require explicit annotation. |
-| **Tautological capability gates** — `permission_callback` whose body returns `current_user_can('read')` (a cap every logged-in user holds) | Static mode records cap as `read`; subscribers pass. Runtime catches it because subscriber assertions fail. | Cross-reference the permission roundtrip step; flag any cap that all logged-in users hold. |
+| Indirected service writes — `$repo->persist()`, `$service->commit()`, custom verbs. | Any finite verb list drifts; domain vocabulary varies. | Inspect callbacks that touch custom services or repositories. |
+| `do_action()` whose listeners write. | Provenance ambiguity: ability looks clean; system mutates state in a listener. | Audit listeners on the action. If any writes, downgrade or split. |
+| Variable-built HTTP methods on delegate helpers. | Static can't follow runtime values. | Treat callers of helpers whose default method isn't `GET` as suspect. |
+| Tautological capability gates — `current_user_can('read')` on a "private" ability. | The cap looks valid; subscribers happen to hold it. | Cross-reference the permission roundtrip — subscribers should be denied. |
 
-The blind-spot list is the reason the skill lists `readonly: true` as
-the *strongest* claim and `destructive: false` as a *weaker* one. A
-plugin that registers everything as `destructive: true` and
-`idempotent: false` and lets `readonly` be the only annotated promise
-gets the most value out of the static checks.
+For high-stakes plugins, run runtime mode (see `runtime-harness.md`)
+before landing — it catches some blind spots via twin-invocation diff
+and live state inspection.
 
-## False-positive allow-list
+## Suppressing legitimate exceptions
 
-Some legitimate patterns trip these checks. Two suppression mechanisms:
-
-### Inline suppression — per-line
-
-Add a comment immediately before or on the offending line:
+When a pattern that looks like a write is semantically a read (e.g.
+populating a read-through cache via `set_transient`, updating a
+`last_read_at` timestamp for tracking, diagnostic logging), suppress
+with an inline comment on the offending line:
 
 ```php
 // verify-ignore: readonly -- writes to read-through cache; semantically a read.
 set_transient( $cache_key, $data, HOUR_IN_SECONDS );
 ```
 
-Suppression format: `// verify-ignore: <annotation-name> -- <one-line reason>`.
-
-Legal annotation names: `readonly`, `destructive`, `idempotent`, `all`.
-
-The grep-scanner skips any line with a matching `verify-ignore` comment.
-`// verify-ignore: all` suppresses every check on that line; narrower is
-better.
-
-### File-level allow-list — in this reference
-
-Patterns that recur across many plugins get listed here so agents don't
-re-invent the suppression rationale:
-
-| Pattern | Why it's legitimate on a readonly ability | Caveat |
-|---|---|---|
-| `set_transient($cache_key, $data, ...)` after a cache-miss | Read-through cache populating on fetch. Side-effect, but not a semantic write. Suppress with `// verify-ignore: readonly`. | Don't allow when the transient is a rate-limit counter or a write-counter — that's a real state mutation. Reviewers should check what's actually being cached before rubber-stamping the suppression. |
-| `update_user_meta( $user_id, 'last_read_at', time() )` | Tracking that the user read something. Arguably a write, but doesn't change the data the ability returns. WARN, not FAIL. | — |
-| `do_action( 'my_plugin_after_read', ... )` with no known write-listener | Emitting an event. If no registered listener writes, the ability stays clean. | Check listeners. If any listener writes, the ability is no longer cleanly readonly; either downgrade the annotation or move the action emission outside the read path. |
-| `$logger->info(...)` or similar logging | Diagnostic, not a semantic write. OK. | — |
-
-Anything not in this list should be reviewed case-by-case. Don't add
-entries speculatively — only add one after hitting a real false positive
-in a real audit.
+Format: `// verify-ignore: <annotation> -- <reason>`. Legal annotation
+names: `readonly`, `destructive`, `idempotent`, `all`. Narrower is
+better than `all`.
 
 ## Runtime check complement
 
-When runtime mode is on, add a heuristic for `idempotent: true`
-abilities: invoke twice with the same input, then inspect what changed.
-
-```bash
-# Via wp-cli (substitute the plugin's env-up + wp-cli invocation per AGENTS.md).
-<env-cli> wp --user=admin eval '
-$a = wp_get_ability( "<plugin>/<ability>" );
-$r1 = $a->execute( [ <same-input> ] );
-$r2 = $a->execute( [ <same-input> ] );
-echo var_export( $r1 === $r2, true ) . PHP_EOL;
-echo md5( serialize( $r1 ) ) . PHP_EOL;
-echo md5( serialize( $r2 ) ) . PHP_EOL;
-'
-```
-
-Interpretation:
-
-- Hashes match → cheap PASS. Same input produced the same response, and
-  any environmental writes (write abilities) were the same on both calls.
-- Hashes differ → *signal*, not verdict. Per core's definition, idempotent
-  means "no additional effect on the environment" — return-value equality
-  is neither necessary nor sufficient. Inspect what changed:
-  - Response embeds a per-call timestamp / nonce / random ID → environment
-    unchanged. Still idempotent. Optionally remove the field if the agent
-    doesn't need it.
-  - Response reflects a counter or sequence that grew between calls →
-    real environmental change. FAIL: drop the `idempotent: true`
-    annotation or fix the underlying write to be input-determined.
-
-For ambiguous cases (response varies but no obvious counter), supplement
-with a state diff: snapshot a representative table or option before call
-1, snapshot after call 2, diff. If state changed by more than what the
-input writes would explain, the ability is non-idempotent.
+For `idempotent: true` abilities, runtime mode adds a heuristic: invoke
+twice with the same input and compare. See `runtime-harness.md`
+Check 6. Differing returns are a *signal* to inspect, not a verdict —
+under core's definition, the question is whether the *environment*
+changed, not whether the *return value* matches. A response that
+embeds a per-call timestamp / nonce / random ID is fine; a response
+that reflects a counter that grew between calls is not.
 
 ## Report format
 
-Each adversarial check finding gets one row in the run's
-"Annotation correctness" table:
+Each finding gets one row in the run's "Annotation correctness" table:
 
 ```markdown
 | Ability | Claim | Result | Evidence |
 |---|---|---|---|
-| myplugin/get-things | readonly=true | OK | no write patterns detected |
+| myplugin/get-things | readonly=true | OK | callback reads only |
 | myplugin/get-things-with-counts | readonly=true | FAIL | `src/Abilities/Things.php:142`: `$wpdb->update( $table, ... )` |
-| myplugin/submit-thing | destructive=false | OK | no destructive patterns detected |
+| myplugin/submit-thing | destructive=false | OK | no destructive patterns |
 | myplugin/submit-thing | idempotent=false | N/A | not claimed idempotent |
 ```
 
-The evidence column MUST cite the file + line number of the offending
-pattern, so a reviewer can jump straight to the lie and either fix the
-code or add a suppression.
-
-## Why grep and not a full PHP parser
-
-A full AST parser (`nikic/php-parser`) would catch more edge cases —
-method-chain writes via variable indirection, for instance. But:
-
-1. It requires Composer + a PHP environment just to run the static check.
-2. It slows down the check from <1s to tens of seconds on a large plugin.
-3. It adds a dependency verify has to maintain.
-
-Grep catches 90%+ of real violations with no dependencies. The 10% that
-slip through surface in runtime mode via the twin-invocation diff or via
-code review. A future contribution can add an opt-in AST-based variant if
-we hit enough false-negatives to justify the complexity.
-
-## Escalation
-
-If verify trips a false positive on a pattern that's genuinely common
-across plugins (not a plugin-specific quirk), add it to the "File-level
-allow-list" above in a focused PR. Include the rationale. Don't loosen
-the regex patterns — narrower with an explicit allow-list is easier to
-audit than broader regexes.
+The evidence column MUST cite file + line so a reviewer can jump
+straight to the issue.

--- a/skills/wp-abilities-verify/references/annotation-correctness.md
+++ b/skills/wp-abilities-verify/references/annotation-correctness.md
@@ -1,0 +1,304 @@
+# Annotation Correctness
+
+The adversarial core of this skill. This is what makes `wp-abilities-verify`
+a distinct skill rather than a thin wrapper around "run the tests".
+
+## Why this matters
+
+Agents plan actions on the basis of the annotations they introspect. If an
+ability is annotated `readonly: true`, an orchestrator will confidently
+invoke it in a dry-run, speculative exploration, or multi-agent fan-out
+without thinking twice — because `readonly` means "can't break anything".
+
+A `readonly: true` ability that actually writes is therefore:
+
+1. **A security hazard** — agents will invoke it in contexts where side
+   effects are forbidden.
+2. **A UX disaster** — the agent's mental model of what happened diverges
+   silently from reality. The human operator can't reason about what
+   state the system is in.
+3. **Undetectable at the annotation-layer** — the annotation says
+   `readonly: true`; nothing in the registration forces it to be true.
+
+Unit tests won't catch this class of bug because the mock the test
+constructs looks just like the real writer. What catches it is reading the
+execute callback body and comparing what it does against what the
+annotation says it does. That's this file.
+
+The same logic applies to `destructive: false` ("won't delete anything")
+and `idempotent: true` ("same input, same result, same effect").
+
+## The three claims
+
+| Annotation | What it promises | What to check |
+|---|---|---|
+| `readonly: true` | No writes. GET-style side-effect-free. | No `wpdb->insert/update/delete`, `update_option`, `wp_insert_*`, non-GET delegates, etc. |
+| `destructive: false` | Won't irreversibly destroy data or forfeit money. | No `wp_delete_*`, `wp_trash_post`, `->refund`, `->cancel`, `->close_dispute`. |
+| `idempotent: true` | Same input always produces same effect. | No `rand()`, nonce generation, sequence increments, timestamps-in-response. Runtime: twin invocations byte-identical. |
+
+These overlap but are not redundant: `readonly` is the strictest,
+`destructive: false` is weaker (updates that don't destroy are OK), and
+`idempotent` is orthogonal (a POST that writes the same row twice is both
+"writes" and "idempotent").
+
+## Static adversarial checks
+
+These grep-based checks run against the plugin checkout with no env.
+They're the heart of the skill.
+
+### Step 1 — locate the execute callback body
+
+For each ability in the static inventory, resolve its `execute_callback`:
+
+```bash
+# 1. Find the ability registration.
+grep -rn "wp_register_ability( *'<plugin>/<ability-name>'" <plugin-root>/
+
+# 2. Find the execute_callback => key in the same array literal.
+#    Usually a few lines below the name.
+
+# 3. The callback value is either:
+#    a) [ ClassName::class, 'method' ] — look in ClassName for `public function method` or `public static function method`.
+#    b) [ $this, 'method' ] — look in the current class.
+#    c) 'function_name' — look for `function function_name` top-level.
+#    d) An anonymous function — the body is literally there.
+```
+
+Record the file + starting line + ending line of the callback. All
+subsequent greps target that byte range.
+
+### Step 2 — readonly-but-writes check
+
+Against callbacks annotated `readonly: true`, run these patterns. ANY hit
+means the annotation is a lie and the ability FAILs the adversarial check.
+
+```bash
+# Direct $wpdb writes.
+grep -nE '\$wpdb->(update|insert|delete|replace)\b' <file> | awk -v s=<start> -v e=<end> '$1 >= s && $1 <= e'
+
+# Raw SQL with write verbs.
+grep -nE '\$wpdb->query\s*\([^)]*(UPDATE|INSERT|DELETE|REPLACE|TRUNCATE|ALTER)' <file>
+
+# Options API writes.
+grep -nE '\b(update_option|add_option|delete_option|update_site_option|add_site_option|delete_site_option)\s*\(' <file>
+
+# Post and post-meta writes.
+grep -nE '\bwp_(insert|update|delete|trash)_post\s*\(' <file>
+grep -nE '\b(update|add|delete)_post_meta\s*\(' <file>
+
+# User writes.
+grep -nE '\bwp_(insert|update|delete)_user\s*\(' <file>
+grep -nE '\b(update|add|delete)_user_meta\s*\(' <file>
+
+# Term writes.
+grep -nE '\bwp_(insert|update|delete)_term\s*\(' <file>
+grep -nE '\b(update|add|delete)_term_meta\s*\(' <file>
+
+# Comment writes.
+grep -nE '\bwp_(insert|update|delete|trash|spam)_comment\s*\(' <file>
+
+# Method-name write-verb patterns on controllers / services.
+grep -nE '->(create|insert|update|delete|remove|save|store|write|destroy|purge|archive|restore|disable|enable|activate|deactivate|revoke|grant)_' <file>
+
+# Non-GET HTTP delegations.
+grep -nE '\bwp_remote_(post|request|delete)\b' <file>
+grep -nE "delegate_to_rest_controller\s*\([^)]*(POST|PUT|DELETE|PATCH)" <file>
+
+# Inline non-GET WP_REST_Request construction (without the delegate helper).
+grep -nE "new\s+\\\\?WP_REST_Request\s*\(\s*['\"](POST|PUT|DELETE|PATCH)" <file>
+
+# Filesystem writes — durable state changes that tools/list cannot describe.
+grep -nE '\b(file_put_contents|wp_upload_bits|fwrite|fputs|unlink|rename|mkdir|rmdir|copy|move_uploaded_file)\s*\(' <file>
+grep -nE 'WP_Filesystem(_Direct)?\s*->\s*(put_contents|delete|move|copy|mkdir|rmdir)' <file>
+
+# Cron and scheduler writes — mutate the cron options table even on "readonly" abilities.
+grep -nE '\bwp_(schedule_event|schedule_single_event|reschedule_event|unschedule_event|clear_scheduled_hook)\s*\(' <file>
+
+# Transients — may be legitimate read-path caching; flag as WARN not FAIL.
+# See "False-positive allow-list" below.
+grep -nE '\b(set_transient|delete_transient|set_site_transient|delete_site_transient)\s*\(' <file>
+```
+
+### Step 3 — destructive-but-says-false check
+
+Against callbacks annotated `destructive: false`:
+
+```bash
+# Deletion verbs.
+grep -nE '\bwp_(delete|trash)_(post|user|term|comment|attachment)\s*\(' <file>
+grep -nE '->(delete|destroy|purge|revoke|forfeit|cancel|refund|chargeback|close_dispute|void|terminate)_' <file>
+
+# Payment-system destructive verbs.
+grep -nE '->(refund|cancel|void|dispute|chargeback)\s*\(' <file>
+
+# Data-removal verbs.
+grep -nE '\bwp_delete_user\s*\(' <file>
+```
+
+### Step 4 — idempotent-but-nondeterministic check
+
+Against callbacks annotated `idempotent: true`:
+
+```bash
+# Randomness.
+grep -nE '\b(rand|mt_rand|random_int|random_bytes|wp_rand)\s*\(' <file>
+grep -nE '\bwp_generate_(uuid4|password|auth_cookie)\s*\(' <file>
+
+# Nonce generation (per-call, non-deterministic by design).
+grep -nE '\bwp_create_nonce\s*\(' <file>
+
+# Time-based payloads — time() in the response means twin calls differ.
+# Flag as WARN, not FAIL: many legitimate read callbacks include a
+# `generated_at` field. Runtime byte-comparison catches the real violations.
+grep -nE '\b(time|microtime|current_time|date|wp_date)\s*\(' <file>
+
+# Sequence increments.
+grep -nE '\+\+\s*;|\$[a-z_]+\s*\+=\s*1\b' <file>
+```
+
+## Precedence and severity
+
+Not every hit is equal weight.
+
+| Pattern | Severity on `readonly: true` | Severity on `destructive: false` |
+|---|---|---|
+| `wpdb->update/insert/delete` | FAIL | FAIL (delete) / WARN (update) |
+| `update_option` / `update_post_meta` | FAIL | WARN |
+| `wp_insert_*` / `wp_update_*` | FAIL | WARN (unless delete) |
+| `wp_delete_*` / `wp_trash_*` | FAIL | FAIL |
+| `->refund`, `->cancel`, `->close_dispute` | FAIL | FAIL |
+| Non-GET `delegate_to_rest_controller` | FAIL | depends on method |
+| Inline `new WP_REST_Request('POST', ...)` | FAIL | depends on method |
+| `wp_remote_post` / `wp_remote_delete` | FAIL | WARN |
+| `file_put_contents`, `wp_upload_bits`, `WP_Filesystem->put_contents`, `unlink`, `rename` | FAIL | FAIL (delete) / WARN (write) |
+| `wp_schedule_event` / `wp_schedule_single_event` / `wp_clear_scheduled_hook` | FAIL | WARN |
+| `set_transient` / `delete_transient` | WARN (caching is ambiguous) | OK |
+| `rand()` / `wp_create_nonce` | N/A | N/A |
+| `time()` in response | N/A | N/A |
+
+Severity is deliberately sharp on the patterns that matter (deletion,
+money-moving verbs, non-GET delegates) and soft on ambiguous patterns
+(transients, time-in-response) to preserve signal quality.
+
+## Known blind spots
+
+Grep cannot reach every write. Static-mode PASS is "no obvious-shape
+violations," not "verified write-free." When verifying a high-stakes
+ability, run runtime mode and inspect the callback by hand for these
+patterns:
+
+| Blind spot | Why grep misses it | Mitigation |
+|---|---|---|
+| **Indirected service writes** — `$repo->persist()`, `$service->commit()`, `$model->flush()`, `->markAsPaid()` (camelCase), `->set()` (Doctrine), `->put()` (key-value), `->push()` (queue), `->dispatch_job()` | The verb list is finite and excludes domain-specific or framework-specific mutating verbs. | Inspect the callback when the ability touches any custom service/repository. Add the verb to the regex if it's recurring. |
+| **`do_action()` whose listeners write** | The ability itself emits an event; the write happens in a registered listener. Provenance ambiguity: the readonly-by-design ability is conceptually clean but the system mutates state. | Audit registered listeners on the action. If any write, downgrade the ability to `readonly: false` or split the event-emission out of the read path. |
+| **Variable-built or default HTTP method on `delegate_to_rest_controller`** — `$method = $is_write ? 'POST' : 'GET'; delegate_to_rest_controller(..., $method);` | The regex matches a literal token, not a variable. | When the helper signature defaults `$http_method` to anything other than `'GET'`, treat all callers as suspect. |
+| **WP-CLI invocations from inside an ability** — `WP_CLI::runcommand('option update foo bar')` | Not in any pattern list. | Rare in production; if present, treat as a destructive escape hatch and require explicit annotation. |
+| **Tautological capability gates** — `permission_callback` whose body returns `current_user_can('read')` (a cap every logged-in user holds) | Static mode records cap as `read`; subscribers pass. Runtime catches it because subscriber assertions fail. | Cross-reference the permission roundtrip step; flag any cap that all logged-in users hold. |
+
+The blind-spot list is the reason the skill lists `readonly: true` as
+the *strongest* claim and `destructive: false` as a *weaker* one. A
+plugin that registers everything as `destructive: true` and
+`idempotent: false` and lets `readonly` be the only annotated promise
+gets the most value out of the static checks.
+
+## False-positive allow-list
+
+Some legitimate patterns trip these checks. Two suppression mechanisms:
+
+### Inline suppression — per-line
+
+Add a comment immediately before or on the offending line:
+
+```php
+// verify-ignore: readonly -- writes to read-through cache; semantically a read.
+set_transient( $cache_key, $data, HOUR_IN_SECONDS );
+```
+
+Suppression format: `// verify-ignore: <annotation-name> -- <one-line reason>`.
+
+Legal annotation names: `readonly`, `destructive`, `idempotent`, `all`.
+
+The grep-scanner skips any line with a matching `verify-ignore` comment.
+`// verify-ignore: all` suppresses every check on that line; narrower is
+better.
+
+### File-level allow-list — in this reference
+
+Patterns that recur across many plugins get listed here so agents don't
+re-invent the suppression rationale:
+
+| Pattern | Why it's legitimate on a readonly ability | Caveat |
+|---|---|---|
+| `set_transient($cache_key, $data, ...)` after a cache-miss | Read-through cache populating on fetch. Side-effect, but not a semantic write. Suppress with `// verify-ignore: readonly`. | Don't allow when the transient is a rate-limit counter or a write-counter — that's a real state mutation. Reviewers should check what's actually being cached before rubber-stamping the suppression. |
+| `update_user_meta( $user_id, 'last_read_at', time() )` | Tracking that the user read something. Arguably a write, but doesn't change the data the ability returns. WARN, not FAIL. | — |
+| `do_action( 'my_plugin_after_read', ... )` with no known write-listener | Emitting an event. If no registered listener writes, the ability stays clean. | Check listeners. If any listener writes, the ability is no longer cleanly readonly; either downgrade the annotation or move the action emission outside the read path. |
+| `$logger->info(...)` or similar logging | Diagnostic, not a semantic write. OK. | — |
+
+Anything not in this list should be reviewed case-by-case. Don't add
+entries speculatively — only add one after hitting a real false positive
+in a real audit.
+
+## Runtime check complement
+
+When runtime mode is on, add one more check that static cannot do:
+**twin-invocation diff for `idempotent: true` abilities**.
+
+```bash
+# Via wp-cli (substitute the plugin's env-up + wp-cli invocation per AGENTS.md).
+<env-cli> wp --user=admin eval '
+$a = wp_get_ability( "<plugin>/<ability>" );
+$r1 = $a->execute( [ <same-input> ] );
+$r2 = $a->execute( [ <same-input> ] );
+echo var_export( $r1 === $r2, true ) . PHP_EOL;  // should print "true"
+echo md5( serialize( $r1 ) ) . PHP_EOL;
+echo md5( serialize( $r2 ) ) . PHP_EOL;
+'
+```
+
+Expected output: `true` followed by two identical hashes. Differ → FAIL
+with the two serialized payloads as evidence.
+
+Note: `idempotent: true` abilities that legitimately embed a timestamp
+(e.g. `generated_at` in the response) will fail this strict check. Either
+remove the timestamp (preferred — it's never load-bearing for the agent)
+or loosen the annotation to `idempotent: false`.
+
+## Report format
+
+Each adversarial check finding gets one row in the run's
+"Annotation correctness" table:
+
+```markdown
+| Ability | Claim | Result | Evidence |
+|---|---|---|---|
+| myplugin/get-things | readonly=true | OK | no write patterns detected |
+| myplugin/get-things-with-counts | readonly=true | FAIL | `src/Abilities/Things.php:142`: `$wpdb->update( $table, ... )` |
+| myplugin/submit-thing | destructive=false | OK | no destructive patterns detected |
+| myplugin/submit-thing | idempotent=false | N/A | not claimed idempotent |
+```
+
+The evidence column MUST cite the file + line number of the offending
+pattern, so a reviewer can jump straight to the lie and either fix the
+code or add a suppression.
+
+## Why grep and not a full PHP parser
+
+A full AST parser (`nikic/php-parser`) would catch more edge cases —
+method-chain writes via variable indirection, for instance. But:
+
+1. It requires Composer + a PHP environment just to run the static check.
+2. It slows down the check from <1s to tens of seconds on a large plugin.
+3. It adds a dependency verify has to maintain.
+
+Grep catches 90%+ of real violations with no dependencies. The 10% that
+slip through surface in runtime mode via the twin-invocation diff or via
+code review. A future contribution can add an opt-in AST-based variant if
+we hit enough false-negatives to justify the complexity.
+
+## Escalation
+
+If verify trips a false positive on a pattern that's genuinely common
+across plugins (not a plugin-specific quirk), add it to the "File-level
+allow-list" above in a focused PR. Include the rationale. Don't loosen
+the regex patterns — narrower with an explicit allow-list is easier to
+audit than broader regexes.

--- a/skills/wp-abilities-verify/references/annotation-correctness.md
+++ b/skills/wp-abilities-verify/references/annotation-correctness.md
@@ -31,9 +31,16 @@ annotation says it does.
 
 | Annotation | What it promises (from core) |
 |---|---|
-| `readonly: true` | No writes. GET-style side-effect-free. |
+| `readonly: true` | No durable writes to user / business state. GET-style side-effect-free. |
 | `destructive: false` | Won't irreversibly destroy data or forfeit money. |
 | `idempotent: true` | Repeated calls with the same arguments produce no additional effect on the environment (per the `idempotent` annotation's docblock in `class-wp-ability.php`). |
+
+`readonly: true` prohibits durable writes to user or business state.
+Read-through cache writes (e.g. `set_transient`) and observability
+timestamps (e.g. `last_read_at`) are acceptable when explicitly
+annotated with `verify-ignore` — see the "Suppressing legitimate
+exceptions" section below. The static check treats unannotated writes
+as FAILs; annotated ones pass with the reason recorded as evidence.
 
 These overlap but are not redundant: `readonly` is the strictest;
 `destructive: false` is weaker (updates that don't destroy are OK);
@@ -138,7 +145,7 @@ Each finding gets one row in the run's "Annotation correctness" table:
 | myplugin/get-things | readonly=true | OK | callback reads only |
 | myplugin/get-things-with-counts | readonly=true | FAIL | `src/Abilities/Things.php:142`: `$wpdb->update( $table, ... )` |
 | myplugin/submit-thing | destructive=false | OK | no destructive patterns |
-| myplugin/submit-thing | idempotent=false | N/A | not claimed idempotent |
+| myplugin/submit-thing | idempotent=false | OK | check only applies when idempotent=true; false annotation acknowledged |
 ```
 
 The evidence column MUST cite file + line so a reviewer can jump

--- a/skills/wp-abilities-verify/references/audit-schema-validation.md
+++ b/skills/wp-abilities-verify/references/audit-schema-validation.md
@@ -1,0 +1,131 @@
+# Audit Schema Validation
+
+How `wp-abilities-verify` validates an audit document produced by
+`wp-abilities-audit`. The canonical schema (field tables, types,
+invariants, known limitations) lives in
+`../../wp-abilities-audit/references/audit-schema.md` — this reference
+covers only the validation procedure: how to extract the YAML, what
+checks to run in what order, and how to report results.
+
+If a field type or shape question is not answered here, look in the
+canonical schema. Do NOT duplicate field tables in this file — the
+canonical is the single source of truth.
+
+## Why verify owns the validator
+
+Verify fails fast on a malformed audit so the rest of its procedure can
+assume well-formed input. Audit produces; verify validates the
+production. Co-locating the validator with verify keeps the
+"validate audit" step in the same procedure as "validate registered
+abilities" and lets a single run produce one consolidated report.
+
+## Step 1 — extract the YAML
+
+The audit doc is a markdown file with a single fenced ` ```yaml ` block
+containing the structured fields:
+
+```bash
+# Scan for the ```yaml fence and capture until the closing ``` fence.
+awk '/^```yaml$/{f=1;next} /^```$/{f=0} f' <audit-doc.md> > /tmp/audit.yaml
+```
+
+If the audit has multiple YAML blocks (it shouldn't, but defensively),
+take the first one with `proposed_abilities` as a top-level key.
+
+Parse with any YAML library — `js-yaml` from Node, `yaml` (Python), or
+`yq` from the command line. None of the canonical fields require
+non-standard YAML features (no anchors, no aliases), so a plain
+`yaml.load` is sufficient.
+
+## Step 2 — validate against the canonical schema
+
+Apply the field-shape rules defined in
+`../../wp-abilities-audit/references/audit-schema.md`. Specifically:
+
+1. Every required top-level field is present and non-empty (see
+   "Top-level fields" in the canonical).
+2. `capability_gate` matches one of the legal shapes (single string,
+   `{read, write}` object, or — with WARN per the canonical's "Known
+   limitations" — the legacy slash-separated string).
+3. Every entry in `proposed_abilities` has every required per-ability
+   field with the right type (see "`proposed_abilities`" in the
+   canonical).
+4. Each ability's `annotations` block has all three booleans
+   (`readonly`, `destructive`, `idempotent`) as actual booleans —
+   string `"true"` / `"false"` is FAIL (indicates a quoting bug).
+5. Each ability's `backing` is either an object with the canonical
+   fields or `null`; `null` is WARN, not FAIL (it's intentional gap
+   output).
+
+Missing required field → FAIL. Wrong type → FAIL. Legacy
+`capability_gate` slash-string → WARN.
+
+## Step 3 — whole-audit invariants
+
+Run these after per-field validation passes:
+
+### Exactly 0 or 1 abilities with `reference_ability: true`
+
+Count abilities where `reference_ability` is `true`. More than 1 → FAIL
+(the schema permits at most one reference; multiple are ambiguous for
+implementers picking a starting point).
+
+```js
+const refCount = audit.proposed_abilities.filter(a => a.reference_ability === true).length;
+if (refCount > 1) fail("multiple abilities claim reference_ability: true");
+```
+
+### Every `backing: null` ability appears in `surfaced_gaps`
+
+Per the canonical's "Known limitations": a `null` backing is intentional
+gap output and MUST be paired with a matching `surfaced_gaps` entry.
+
+```js
+const gapNames = new Set((audit.surfaced_gaps || []).map(g => g.name));
+for (const ability of audit.proposed_abilities) {
+  if (ability.backing === null && !gapNames.has(ability.name)) {
+    fail(`ability ${ability.name} has backing: null but is missing from surfaced_gaps`);
+  }
+}
+```
+
+### `excluded_from_mvp` and `surfaced_gaps` may be empty
+
+Both are optional; empty arrays are legal. Missing entirely → WARN
+(schema expects them, even if empty).
+
+## Step 4 — emit the report section
+
+Each check goes into the "Audit doc validation" section of the run's
+final report:
+
+```markdown
+## Audit doc validation
+
+| Check | Result | Detail |
+|---|---|---|
+| Top-level required fields | OK | All 7 required fields present |
+| `capability_gate` shape | OK | string (single-cap) |
+| Per-ability fields | WARN | 1 ability has `backing: null` (intentional) |
+| `reference_ability` uniqueness | OK | 1 ability marked |
+| `surfaced_gaps` consistency | OK | all `backing: null` entries present |
+```
+
+A single FAIL in this section makes the whole run FAIL; verify cannot
+meaningfully continue without a trustworthy audit. WARN entries don't
+block the rest of the procedure.
+
+The procedure is manual-but-deterministic: follow the steps above in
+order, emit the report section, and fail fast on any missing required
+field. A future contribution may add a deterministic CLI helper that
+extracts the YAML fence and applies the rules end-to-end; until that
+exists, the steps above are the contract.
+
+## Escalation
+
+If the validator rejects an audit that's actually well-formed, the
+canonical schema in
+`../../wp-abilities-audit/references/audit-schema.md` has evolved.
+Update this file's procedure to match (likely adding a new invariant
+or relaxing a field rule). Don't loosen the validation in isolation —
+the canonical schema is the contract; this file is the enforcer.

--- a/skills/wp-abilities-verify/references/permission-roundtrip.md
+++ b/skills/wp-abilities-verify/references/permission-roundtrip.md
@@ -99,6 +99,14 @@ foreach ( $results as $context => $result ) {
     }
     echo $context . "=" . $printable . PHP_EOL;
 }
+
+// Cleanup the test subscriber so repeated harness runs don't accumulate users
+// on shared dev environments. Already running as admin (line above), so the
+// caller has the delete_users capability.
+if ( isset( $sub_id ) && ! is_wp_error( $sub_id ) ) {
+    require_once ABSPATH . "wp-admin/includes/user.php";
+    wp_delete_user( $sub_id );
+}
 '
 ```
 

--- a/skills/wp-abilities-verify/references/permission-roundtrip.md
+++ b/skills/wp-abilities-verify/references/permission-roundtrip.md
@@ -9,8 +9,8 @@ unauthenticated, subscriber, and admin contexts.
 
 When an ability is invoked, the registered `permission_callback` is
 called through `WP_Ability::check_permissions( $input )`, which
-dispatches to `WP_Ability::invoke_callback( $callback, $input )`
-(`class-wp-ability.php` lines 541-551 and 507-526 in WordPress core).
+dispatches to `WP_Ability::invoke_callback( $callback, $input )` (both
+defined in `class-wp-ability.php` in WordPress core).
 
 `invoke_callback`'s contract:
 

--- a/skills/wp-abilities-verify/references/permission-roundtrip.md
+++ b/skills/wp-abilities-verify/references/permission-roundtrip.md
@@ -1,0 +1,300 @@
+# Permission Roundtrip
+
+Verify that the registered `permission_callback` on every ability actually
+gates on a real capability — statically (by source inspection) and, in
+runtime mode, by exercising the gate against unauthenticated, subscriber,
+and admin contexts.
+
+## Background — what `permission_callback` actually receives
+
+When an ability is invoked, the registered `permission_callback` is called
+through `WP_Ability::check_permissions( $input )`, which dispatches to
+`WP_Ability::invoke_callback( $callback, $input )` (`class-wp-ability.php`
+lines 541–551 and 507–526 in WordPress core).
+
+`invoke_callback`'s contract:
+
+- If the ability declares a non-empty `input_schema`, the callback is
+  invoked with one positional argument: the validated `$input` value
+  (whatever the schema's root type produced — array, string, integer,
+  boolean, etc.).
+- If `input_schema` is empty or absent, the callback is invoked **with
+  no arguments**.
+
+In particular, the callback **never receives a `WP_REST_Request`**, even
+when the ability is reached via the REST bridge. The bridge unwraps the
+request, runs schema validation, and passes the validated value down.
+
+This matters because permission callbacks built around `WP_REST_Request`
+patterns (e.g. `$request->get_method()`) cannot work as-is when copied from
+a REST controller to an ability registration. Static checks below catch
+this misshape.
+
+## Static check
+
+Every ability registration includes a `permission_callback`:
+
+```php
+wp_register_ability(
+    'myplugin/get-things',
+    array(
+        'permission_callback' => array( self::class, 'check_permission' ),
+        // ...
+    )
+);
+```
+
+Inspect the callback's body. Classify each into one of these shapes.
+
+### Shape A — direct `current_user_can(...)` check (preferred)
+
+```php
+public static function check_permission() {
+    return current_user_can( 'manage_options' );
+}
+```
+
+→ OK. Record the resolved capability.
+
+The callback takes no arguments because the ability has no `input_schema`,
+or because the cap doesn't depend on input. Either way, this is the
+default and most-secure shape: a single capability check that resolves
+deterministically per user.
+
+### Shape B — input-shape branch (use sparingly; prefer splitting)
+
+If a single ability genuinely needs different caps for different input
+shapes, the callback may branch on `$input`:
+
+```php
+public static function check_permission( $input = null ) {
+    $is_destructive = is_array( $input ) && ! empty( $input['delete'] );
+    if ( $is_destructive ) {
+        return current_user_can( 'delete_posts' );
+    }
+    return current_user_can( 'edit_posts' );
+}
+```
+
+→ OK on a case-by-case basis, but smell. If you're tempted to write
+Shape B, the operation almost always belongs as **two abilities** —
+one for the read/edit path and one for the destructive path — each
+with its own clean Shape A callback. The use-case-contract framing in
+`../../wp-abilities-api/references/domain-vs-projection.md` argues for
+splitting whenever two distinct user actions are being represented.
+
+A common antipattern that LOOKS like Shape B but won't work:
+
+```php
+// WRONG — callback never sees a WP_REST_Request.
+public static function check_permission( $request ) {
+    if ( 'GET' === $request->get_method() ) { /* ... */ }
+}
+```
+
+→ FAIL. The argument is the validated input value, not a `WP_REST_Request`.
+Branching on `$request->get_method()` is a static-analysis red flag —
+the callback would either crash on a non-object input or always take the
+fall-through path. If you find this, the callback was almost certainly
+copied from a REST controller without translation.
+
+### Shape C — `'__return_true'` (deliberate public ability)
+
+```php
+'permission_callback' => '__return_true',
+```
+
+→ WARN. Most abilities should gate; a public ability is rare and needs
+explicit justification in the registration (code comment) or the audit
+doc's `risks` array.
+
+### Shape D — delegated to a helper that resolves to `current_user_can(...)`
+
+```php
+public static function check_permission() {
+    return self::user_is_authorized();
+}
+
+private static function user_is_authorized() {
+    return current_user_can( 'manage_options' );
+}
+```
+
+→ OK, but trace the helper to confirm it resolves to a `current_user_can`
+call. If the helper returns `true` unconditionally (functionally
+equivalent to `'__return_true'`), treat as Shape C.
+
+### Shape E — `return true;` or similar unconditional literal
+
+```php
+public static function check_permission() {
+    return true;  // functionally __return_true but harder to grep for
+}
+```
+
+→ FAIL. This is worse than Shape C because it hides the public-access
+pattern from a casual grep. Change to `'__return_true'` (explicit) or
+add a real capability check.
+
+### Shape F — `is_user_logged_in()` only
+
+```php
+public static function check_permission() {
+    return is_user_logged_in();
+}
+```
+
+→ WARN. This lets any authenticated user — including subscribers — call
+the ability. Rarely what's intended. If deliberate, document in code
+comment; otherwise tighten.
+
+## Static grep patterns
+
+Locate the permission callback for each ability:
+
+```bash
+# 1. Find the permission_callback => value in the registration array.
+grep -rn --include='*.php' -A 40 "wp_register_ability\s*(\s*'<plugin>/<ability>'" <plugin-root>/ \
+    | grep -E "'permission_callback'\s*=>"
+
+# 2. Resolve the callback reference (same pattern as execute_callback — see static-enumeration.md).
+
+# 3. Inspect the callback body for the shapes above.
+grep -nE "current_user_can\s*\(\s*['\"]([^'\"]+)['\"]|__return_true|return\s+true\s*;|is_user_logged_in\s*\(" <callback-file>
+
+# 4. Red flag — callbacks built around WP_REST_Request (Shape B antipattern).
+grep -nE '\$request->get_method|\$request->get_param|WP_REST_Request' <callback-file>
+```
+
+Classify each ability by shape A–F and record the resolved capability
+(or `__return_true`, or `<unresolvable>`). Any `WP_REST_Request` usage in a
+permission callback is a FAIL — flag for rewrite.
+
+## Runtime check
+
+With the env running, exercise the gate against three user contexts using
+`WP_Ability::check_permissions()` (the public method that wraps the
+registered callback):
+
+```bash
+<env-cli> wp --user=admin eval '
+$ability = wp_get_ability( "<plugin>/<ability-name>" );
+if ( ! $ability ) {
+    echo "ability not registered" . PHP_EOL;
+    exit( 1 );
+}
+
+$results = array();
+
+// Unauthenticated.
+wp_set_current_user( 0 );
+$results["anon"] = $ability->check_permissions();
+
+// Subscriber (create a fresh user; ignore if already exists).
+$sub_login = "verify_sub_" . time();
+$sub_id    = wp_create_user( $sub_login, "x", $sub_login . "@example.com" );
+if ( ! is_wp_error( $sub_id ) ) {
+    $sub_user = get_user_by( "id", $sub_id );
+    $sub_user->set_role( "subscriber" );
+    wp_set_current_user( $sub_id );
+    $results["subscriber"] = $ability->check_permissions();
+}
+
+// Admin.
+wp_set_current_user( 1 );
+$results["admin"] = $ability->check_permissions();
+
+foreach ( $results as $context => $result ) {
+    if ( true === $result ) {
+        $printable = "true";
+    } elseif ( is_wp_error( $result ) ) {
+        $printable = "WP_Error(" . $result->get_error_code() . ")";
+    } else {
+        $printable = var_export( $result, true );
+    }
+    echo $context . "=" . $printable . PHP_EOL;
+}
+'
+```
+
+Notes on interpretation:
+
+- `check_permissions()` returns `bool|WP_Error`. Treat `true` as
+  *allowed*; treat `false` or any `WP_Error` as *denied*.
+- A `WP_Error` with code `ability_invalid_permission_callback` means
+  the registration didn't supply a valid callable — a hard FAIL.
+- A `WP_Error` with code `ability_callback_exception` means the
+  callback threw — also a hard FAIL; capture the underlying message.
+
+Expected for a standard (non-public) ability:
+
+```
+anon=false
+subscriber=false
+admin=true
+```
+
+Expected for a deliberate public ability (Shape C):
+
+```
+anon=true
+subscriber=true
+admin=true
+```
+
+Any deviation → FAIL. Common causes:
+
+- `admin=WP_Error(...)` — bug in the callback or a missing dependency
+  the callback transitively requires.
+- `admin=false` — the capability check references a cap admin doesn't
+  have, or the callback has a bug.
+- `subscriber=true` on a non-public ability — permission callback is
+  too permissive (Shape E or F, not Shape A).
+- `anon=true` on a non-public ability — same, with worse exposure.
+
+## Audit cross-check
+
+If an audit doc was provided, the audit's `capability_gate` field (or each
+ability's `permission.resolves_to`) declares what the gate should be.
+Compare the registered capability against the audit's declared one:
+
+- Audit says `manage_options`, registration resolves to
+  `manage_options` → OK.
+- Audit says `manage_options`, registration resolves to
+  `edit_posts` → FAIL. Either the audit is wrong or the registration
+  drifted.
+- Audit is a compound `{read, write}` gate and the registration uses
+  Shape B with both caps → OK.
+- Audit is a compound gate but the registration uses Shape A (single
+  cap only) → FAIL. Write-path abilities would inherit the read gate
+  and under-authorize writes (or vice versa).
+
+Cross-reference
+`../../wp-abilities-audit/references/capability-gate-tracing.md` for the
+tracing mechanics — this skill's validator re-derives the same trace and
+compares.
+
+## Output format
+
+```markdown
+## Permission gates
+
+| Ability | Shape | Resolved cap(s) | anon | subscriber | admin | Audit match |
+|---|---|---|---|---|---|---|
+| <ability> | A | manage_options | false | false | true | OK |
+| <ability> | B | edit_posts (read), delete_posts (destructive) | false | false | true | OK |
+| <ability> | C | __return_true (public) | true | true | true | WARN |
+| <ability> | E | (literal true) | true | true | true | FAIL |
+```
+
+## Static-only mode caveats
+
+Without runtime mode, only the source-inspection columns are populated.
+The table becomes:
+
+| Ability | Shape | Resolved cap(s) | Audit match |
+|---|---|---|---|
+
+The roundtrip columns are omitted rather than guessed. Static-mode
+reports should make this explicit in the section header:
+`Permission gates (static inspection only)`.

--- a/skills/wp-abilities-verify/references/permission-roundtrip.md
+++ b/skills/wp-abilities-verify/references/permission-roundtrip.md
@@ -1,16 +1,16 @@
 # Permission Roundtrip
 
-Verify that the registered `permission_callback` on every ability actually
-gates on a real capability — statically (by source inspection) and, in
-runtime mode, by exercising the gate against unauthenticated, subscriber,
-and admin contexts.
+Verify that the registered `permission_callback` on every ability
+actually gates on a real capability — statically (by source
+inspection) and, in runtime mode, by exercising the gate against
+unauthenticated, subscriber, and admin contexts.
 
 ## Background — what `permission_callback` actually receives
 
-When an ability is invoked, the registered `permission_callback` is called
-through `WP_Ability::check_permissions( $input )`, which dispatches to
-`WP_Ability::invoke_callback( $callback, $input )` (`class-wp-ability.php`
-lines 541–551 and 507–526 in WordPress core).
+When an ability is invoked, the registered `permission_callback` is
+called through `WP_Ability::check_permissions( $input )`, which
+dispatches to `WP_Ability::invoke_callback( $callback, $input )`
+(`class-wp-ability.php` lines 541-551 and 507-526 in WordPress core).
 
 `invoke_callback`'s contract:
 
@@ -21,160 +21,34 @@ lines 541–551 and 507–526 in WordPress core).
 - If `input_schema` is empty or absent, the callback is invoked **with
   no arguments**.
 
-In particular, the callback **never receives a `WP_REST_Request`**, even
-when the ability is reached via the REST bridge. The bridge unwraps the
-request, runs schema validation, and passes the validated value down.
+In particular, the callback **never receives a `WP_REST_Request`**,
+even when the ability is reached via the REST bridge. The bridge
+unwraps the request, runs schema validation, and passes the validated
+value down. Permission callbacks built around `WP_REST_Request`
+patterns (e.g. `$request->get_method()`) cannot work as-is when copied
+from a REST controller — flag any such usage as a static FAIL.
 
-This matters because permission callbacks built around `WP_REST_Request`
-patterns (e.g. `$request->get_method()`) cannot work as-is when copied from
-a REST controller to an ability registration. Static checks below catch
-this misshape.
+## Static check — classify each callback's shape
 
-## Static check
+Read each ability's `permission_callback` body and classify:
 
-Every ability registration includes a `permission_callback`:
+| Shape | Body | Result | Notes |
+|---|---|---|---|
+| A | `return current_user_can( 'cap' );` | OK | Preferred. Record the resolved capability. |
+| B | Branches on `$input` — different cap for different shapes | OK with smell | Two distinct user actions usually want two abilities, each with its own Shape A. See `../../wp-abilities-api/references/domain-vs-projection.md`. |
+| B-bad | Branches on `$request->get_method()` or other `WP_REST_Request` calls | FAIL | The argument is the validated input value, not a request object. Almost always a copy from a REST controller without translation. |
+| C | `'__return_true'` | WARN | Deliberate public ability. Document the reason in code or in the audit doc's `risks` array. |
+| D | Delegates to a helper that resolves to `current_user_can(...)` | OK | Trace the helper. If it returns `true` unconditionally, treat as Shape C. |
+| E | `return true;` (literal) | FAIL | Functionally Shape C but harder to grep for. Change to `'__return_true'` or add a real cap check. |
+| F | `return is_user_logged_in();` | WARN | Lets any authenticated user — including subscribers — call. Rarely intended. Document or tighten. |
 
-```php
-wp_register_ability(
-    'myplugin/get-things',
-    array(
-        'permission_callback' => array( self::class, 'check_permission' ),
-        // ...
-    )
-);
-```
-
-Inspect the callback's body. Classify each into one of these shapes.
-
-### Shape A — direct `current_user_can(...)` check (preferred)
-
-```php
-public static function check_permission() {
-    return current_user_can( 'manage_options' );
-}
-```
-
-→ OK. Record the resolved capability.
-
-The callback takes no arguments because the ability has no `input_schema`,
-or because the cap doesn't depend on input. Either way, this is the
-default and most-secure shape: a single capability check that resolves
-deterministically per user.
-
-### Shape B — input-shape branch (use sparingly; prefer splitting)
-
-If a single ability genuinely needs different caps for different input
-shapes, the callback may branch on `$input`:
-
-```php
-public static function check_permission( $input = null ) {
-    $is_destructive = is_array( $input ) && ! empty( $input['delete'] );
-    if ( $is_destructive ) {
-        return current_user_can( 'delete_posts' );
-    }
-    return current_user_can( 'edit_posts' );
-}
-```
-
-→ OK on a case-by-case basis, but smell. If you're tempted to write
-Shape B, the operation almost always belongs as **two abilities** —
-one for the read/edit path and one for the destructive path — each
-with its own clean Shape A callback. The use-case-contract framing in
-`../../wp-abilities-api/references/domain-vs-projection.md` argues for
-splitting whenever two distinct user actions are being represented.
-
-A common antipattern that LOOKS like Shape B but won't work:
-
-```php
-// WRONG — callback never sees a WP_REST_Request.
-public static function check_permission( $request ) {
-    if ( 'GET' === $request->get_method() ) { /* ... */ }
-}
-```
-
-→ FAIL. The argument is the validated input value, not a `WP_REST_Request`.
-Branching on `$request->get_method()` is a static-analysis red flag —
-the callback would either crash on a non-object input or always take the
-fall-through path. If you find this, the callback was almost certainly
-copied from a REST controller without translation.
-
-### Shape C — `'__return_true'` (deliberate public ability)
-
-```php
-'permission_callback' => '__return_true',
-```
-
-→ WARN. Most abilities should gate; a public ability is rare and needs
-explicit justification in the registration (code comment) or the audit
-doc's `risks` array.
-
-### Shape D — delegated to a helper that resolves to `current_user_can(...)`
-
-```php
-public static function check_permission() {
-    return self::user_is_authorized();
-}
-
-private static function user_is_authorized() {
-    return current_user_can( 'manage_options' );
-}
-```
-
-→ OK, but trace the helper to confirm it resolves to a `current_user_can`
-call. If the helper returns `true` unconditionally (functionally
-equivalent to `'__return_true'`), treat as Shape C.
-
-### Shape E — `return true;` or similar unconditional literal
-
-```php
-public static function check_permission() {
-    return true;  // functionally __return_true but harder to grep for
-}
-```
-
-→ FAIL. This is worse than Shape C because it hides the public-access
-pattern from a casual grep. Change to `'__return_true'` (explicit) or
-add a real capability check.
-
-### Shape F — `is_user_logged_in()` only
-
-```php
-public static function check_permission() {
-    return is_user_logged_in();
-}
-```
-
-→ WARN. This lets any authenticated user — including subscribers — call
-the ability. Rarely what's intended. If deliberate, document in code
-comment; otherwise tighten.
-
-## Static grep patterns
-
-Locate the permission callback for each ability:
-
-```bash
-# 1. Find the permission_callback => value in the registration array.
-grep -rn --include='*.php' -A 40 "wp_register_ability\s*(\s*'<plugin>/<ability>'" <plugin-root>/ \
-    | grep -E "'permission_callback'\s*=>"
-
-# 2. Resolve the callback reference (same pattern as execute_callback — see static-enumeration.md).
-
-# 3. Inspect the callback body for the shapes above.
-grep -nE "current_user_can\s*\(\s*['\"]([^'\"]+)['\"]|__return_true|return\s+true\s*;|is_user_logged_in\s*\(" <callback-file>
-
-# 4. Red flag — callbacks built around WP_REST_Request (Shape B antipattern).
-grep -nE '\$request->get_method|\$request->get_param|WP_REST_Request' <callback-file>
-```
-
-Classify each ability by shape A–F and record the resolved capability
-(or `__return_true`, or `<unresolvable>`). Any `WP_REST_Request` usage in a
-permission callback is a FAIL — flag for rewrite.
+Record per ability: `(shape, resolved_cap)`. Any Shape B-bad or
+Shape E → static FAIL. Shapes C and F → WARN. Shapes A, B, D → OK.
 
 ## Runtime check
 
-With the env running, exercise the gate against three user contexts using
-`WP_Ability::check_permissions()` (the public method that wraps the
-registered callback):
+Exercise the gate against three user contexts using
+`WP_Ability::check_permissions()`:
 
 ```bash
 <env-cli> wp --user=admin eval '
@@ -190,7 +64,7 @@ $results = array();
 wp_set_current_user( 0 );
 $results["anon"] = $ability->check_permissions();
 
-// Subscriber (create a fresh user; ignore if already exists).
+// Subscriber (create a fresh user).
 $sub_login = "verify_sub_" . time();
 $sub_id    = wp_create_user( $sub_login, "x", $sub_login . "@example.com" );
 if ( ! is_wp_error( $sub_id ) ) {
@@ -222,9 +96,9 @@ Notes on interpretation:
 - `check_permissions()` returns `bool|WP_Error`. Treat `true` as
   *allowed*; treat `false` or any `WP_Error` as *denied*.
 - A `WP_Error` with code `ability_invalid_permission_callback` means
-  the registration didn't supply a valid callable — a hard FAIL.
+  the registration didn't supply a valid callable — hard FAIL.
 - A `WP_Error` with code `ability_callback_exception` means the
-  callback threw — also a hard FAIL; capture the underlying message.
+  callback threw — hard FAIL; capture the underlying message.
 
 Expected for a standard (non-public) ability:
 
@@ -242,37 +116,28 @@ subscriber=true
 admin=true
 ```
 
-Any deviation → FAIL. Common causes:
-
-- `admin=WP_Error(...)` — bug in the callback or a missing dependency
-  the callback transitively requires.
-- `admin=false` — the capability check references a cap admin doesn't
-  have, or the callback has a bug.
-- `subscriber=true` on a non-public ability — permission callback is
-  too permissive (Shape E or F, not Shape A).
-- `anon=true` on a non-public ability — same, with worse exposure.
+Any deviation → FAIL. Common causes: cap reference an admin doesn't
+hold, callback bug, or permission too permissive (Shape E or F when it
+should have been Shape A).
 
 ## Audit cross-check
 
-If an audit doc was provided, the audit's `capability_gate` field (or each
+If an audit doc was provided, the audit's `capability_gate` (or each
 ability's `permission.resolves_to`) declares what the gate should be.
-Compare the registered capability against the audit's declared one:
+Compare:
 
-- Audit says `manage_options`, registration resolves to
-  `manage_options` → OK.
-- Audit says `manage_options`, registration resolves to
-  `edit_posts` → FAIL. Either the audit is wrong or the registration
-  drifted.
-- Audit is a compound `{read, write}` gate and the registration uses
+- Audit and registration resolve to the same cap → OK.
+- Audit and registration disagree → FAIL. Either the audit is wrong or
+  the registration drifted.
+- Audit declares a compound `{read, write}` gate, registration uses
   Shape B with both caps → OK.
-- Audit is a compound gate but the registration uses Shape A (single
-  cap only) → FAIL. Write-path abilities would inherit the read gate
-  and under-authorize writes (or vice versa).
+- Audit declares a compound gate, registration uses Shape A (single
+  cap) → FAIL. Write paths would inherit the read gate (or vice
+  versa), under- or over-authorizing.
 
-Cross-reference
-`../../wp-abilities-audit/references/capability-gate-tracing.md` for the
-tracing mechanics — this skill's validator re-derives the same trace and
-compares.
+See `../../wp-abilities-audit/references/capability-gate-tracing.md`
+for the tracing mechanics; this skill re-derives the same trace and
+diffs.
 
 ## Output format
 
@@ -289,12 +154,11 @@ compares.
 
 ## Static-only mode caveats
 
-Without runtime mode, only the source-inspection columns are populated.
-The table becomes:
+Without runtime mode, only the source-inspection columns are
+populated:
 
 | Ability | Shape | Resolved cap(s) | Audit match |
 |---|---|---|---|
 
-The roundtrip columns are omitted rather than guessed. Static-mode
-reports should make this explicit in the section header:
-`Permission gates (static inspection only)`.
+Roundtrip columns are omitted rather than guessed. Flag in the section
+header: `Permission gates (static inspection only)`.

--- a/skills/wp-abilities-verify/references/permission-roundtrip.md
+++ b/skills/wp-abilities-verify/references/permission-roundtrip.md
@@ -102,10 +102,17 @@ foreach ( $results as $context => $result ) {
 
 // Cleanup the test subscriber so repeated harness runs don't accumulate users
 // on shared dev environments. Already running as admin (line above), so the
-// caller has the delete_users capability.
+// caller has the delete_users capability. On multisite, wp_delete_user() only
+// removes the user from the current site's membership — wpmu_delete_user() in
+// wp-admin/includes/ms.php is the network-wide delete.
 if ( isset( $sub_id ) && ! is_wp_error( $sub_id ) ) {
-    require_once ABSPATH . "wp-admin/includes/user.php";
-    wp_delete_user( $sub_id );
+    if ( is_multisite() ) {
+        require_once ABSPATH . "wp-admin/includes/ms.php";
+        wpmu_delete_user( $sub_id );
+    } else {
+        require_once ABSPATH . "wp-admin/includes/user.php";
+        wp_delete_user( $sub_id );
+    }
 }
 '
 ```

--- a/skills/wp-abilities-verify/references/permission-roundtrip.md
+++ b/skills/wp-abilities-verify/references/permission-roundtrip.md
@@ -48,7 +48,17 @@ Shape E → static FAIL. Shapes C and F → WARN. Shapes A, B, D → OK.
 ## Runtime check
 
 Exercise the gate against three user contexts using
-`WP_Ability::check_permissions()`:
+`WP_Ability::check_permissions( $input )`.
+
+`check_permissions()` accepts an optional input value and passes it
+through to the registered `permission_callback`. Shape A callbacks
+(`return current_user_can('cap')`) don't read it. Shape B callbacks
+that branch on `$input` (the smell the static check flags) need a
+representative value to exercise the real gate; otherwise they
+receive `null` and the roundtrip result is misleading. The snippet
+below passes `array()` — the minimal safe input for object-typed
+schemas. For abilities with a non-object root schema, substitute a
+representative value of the declared root type.
 
 ```bash
 <env-cli> wp --user=admin eval '
@@ -58,11 +68,12 @@ if ( ! $ability ) {
     exit( 1 );
 }
 
+$input   = array(); // representative input; substitute for non-object root schemas.
 $results = array();
 
 // Unauthenticated.
 wp_set_current_user( 0 );
-$results["anon"] = $ability->check_permissions();
+$results["anon"] = $ability->check_permissions( $input );
 
 // Subscriber (create a fresh user).
 $sub_login = "verify_sub_" . time();
@@ -71,12 +82,12 @@ if ( ! is_wp_error( $sub_id ) ) {
     $sub_user = get_user_by( "id", $sub_id );
     $sub_user->set_role( "subscriber" );
     wp_set_current_user( $sub_id );
-    $results["subscriber"] = $ability->check_permissions();
+    $results["subscriber"] = $ability->check_permissions( $input );
 }
 
 // Admin.
 wp_set_current_user( 1 );
-$results["admin"] = $ability->check_permissions();
+$results["admin"] = $ability->check_permissions( $input );
 
 foreach ( $results as $context => $result ) {
     if ( true === $result ) {

--- a/skills/wp-abilities-verify/references/runtime-harness.md
+++ b/skills/wp-abilities-verify/references/runtime-harness.md
@@ -252,15 +252,17 @@ means the registration didn't supply a valid callable — a hard FAIL. A
 `WP_Error` with code `ability_callback_exception` means the callback
 threw — also a hard FAIL.
 
-## Check 6 — idempotent reads return byte-for-byte identical results on twin invocations
+## Check 6 — twin-invocation heuristic for idempotent abilities
 
 Only apply this to abilities annotated `idempotent: true` whose `execute()`
-returned without error in Check 3. Per
-`annotation-correctness.md` step "Runtime check complement":
+returned without error in Check 3. Per `annotation-correctness.md` step
+"Runtime check complement", this is a *heuristic*: idempotent in core
+means "no additional effect on the environment" (`class-wp-ability.php`
+lines 47-48), not "byte-identical return values."
 
 ```bash
 <env-cli> wp --user=admin eval '
-$a  = wp_get_ability( "<plugin>/<idempotent-read-ability>" );
+$a  = wp_get_ability( "<plugin>/<idempotent-ability>" );
 $r1 = $a->execute();
 $r2 = $a->execute();
 
@@ -278,18 +280,23 @@ if ( is_wp_error( $r1 ) || is_wp_error( $r2 ) ) {
 '
 ```
 
-Expected (when both invocations succeeded): `match=true` and two
-identical hashes.
+Interpretation:
 
-Twin-invocation differ on an `idempotent: true` ability → FAIL. Common
-causes:
+- `match=true` → cheap PASS. Same input produced the same response, and
+  any environmental writes (write abilities) were the same on both calls.
+- `match=false` → inspect what changed before deciding:
+  - Response embeds a per-call timestamp, nonce, or random ID →
+    environment unchanged. Still idempotent under core's reading.
+    Optionally remove the field if the agent doesn't need it; the
+    annotation stays `idempotent: true`.
+  - Response reflects a counter or sequence that grew between calls →
+    real environmental change. FAIL: drop the `idempotent: true`
+    annotation or fix the underlying write to be input-determined.
 
-- Response embeds `time()` or `current_time()`.
-- Response embeds a nonce.
-- Response embeds a non-deterministic queue state.
-
-Either remove the nondeterministic field (preferred) or change the
-annotation to `idempotent: false`. Don't loosen the check.
+For ambiguous cases (response varies but no obvious counter), supplement
+with a state diff: snapshot a representative table or option before call
+1, snapshot after call 2, diff. If state changed by more than the input
+writes would explain, the ability is non-idempotent.
 
 ## Output format
 

--- a/skills/wp-abilities-verify/references/runtime-harness.md
+++ b/skills/wp-abilities-verify/references/runtime-harness.md
@@ -231,6 +231,15 @@ foreach ( array( "admin" => $admin_result, "subscriber" => $sub_result ) as $con
     }
     echo $context . ": " . $printable . PHP_EOL;
 }
+
+// Cleanup the test subscriber so repeated harness runs don't accumulate users
+// on shared dev environments. Switch back to admin first since we last ran as
+// the subscriber and that role doesn't hold delete_users.
+if ( isset( $sub_id ) && ! is_wp_error( $sub_id ) ) {
+    wp_set_current_user( 1 );
+    require_once ABSPATH . "wp-admin/includes/user.php";
+    wp_delete_user( $sub_id );
+}
 '
 ```
 

--- a/skills/wp-abilities-verify/references/runtime-harness.md
+++ b/skills/wp-abilities-verify/references/runtime-harness.md
@@ -234,11 +234,18 @@ foreach ( array( "admin" => $admin_result, "subscriber" => $sub_result ) as $con
 
 // Cleanup the test subscriber so repeated harness runs don't accumulate users
 // on shared dev environments. Switch back to admin first since we last ran as
-// the subscriber and that role doesn't hold delete_users.
+// the subscriber and that role doesn't hold delete_users. On multisite,
+// wp_delete_user() only removes the user from the current site's membership —
+// wpmu_delete_user() in wp-admin/includes/ms.php is the network-wide delete.
 if ( isset( $sub_id ) && ! is_wp_error( $sub_id ) ) {
     wp_set_current_user( 1 );
-    require_once ABSPATH . "wp-admin/includes/user.php";
-    wp_delete_user( $sub_id );
+    if ( is_multisite() ) {
+        require_once ABSPATH . "wp-admin/includes/ms.php";
+        wpmu_delete_user( $sub_id );
+    } else {
+        require_once ABSPATH . "wp-admin/includes/user.php";
+        wp_delete_user( $sub_id );
+    }
 }
 '
 ```

--- a/skills/wp-abilities-verify/references/runtime-harness.md
+++ b/skills/wp-abilities-verify/references/runtime-harness.md
@@ -124,7 +124,18 @@ This check complements the static adversarial check from
 behavior; runtime checks what the registration hook resolved to at boot
 time. Both must agree for the annotations to be trustworthy.
 
-## Check 3 — each read ability's `execute()` returns OK or a standard-vocabulary WP_Error
+## Check 3 — each read ability's `execute()` behaves as the contract claims
+
+Two verification levels. The smoke level catches bootstrap and gross-error
+regressions; the high-confidence level is the one that actually exercises
+the ability against the data shape it will see in production. Run both
+when the audit doc provides `seed_data_needs`; run the smoke level alone
+when it doesn't.
+
+### Level 1 — smoke execution (synthetic inputs)
+
+Confirm each read returns `OK` or a vocabulary `WP_Error`. Catches PHP
+fatals, un-bootstrapped services, registration failures.
 
 ```bash
 <env-cli> wp --user=admin eval '
@@ -169,7 +180,78 @@ echo "<ability>: " . ( is_wp_error( $r ) ? "WP_Error(" . $r->get_error_code() . 
 
 A synthetic ID on a fresh install typically triggers
 `<plugin>_<resource>_data_unavailable` or an upstream-equivalent code.
-Both are acceptable.
+Both are acceptable for Level 1 — they mean "ability dispatched cleanly,
+the backing reported no data," which is the smoke signal.
+
+### Level 2 — high-confidence verification (representative seeded data)
+
+Synthetic inputs catch fatals and gross errors. They do NOT catch wrong
+IDs returning the wrong record, cached sentinel values being served
+instead of fresh data, permission gates appearing correct against a
+synthetic ID but not against a real one, filtered labels diverging from
+the unfiltered claim, missing capabilities surfacing only when a real
+record is in scope, or curated output drift (a new field added to the
+controller that the ability inherits and now leaks). These are the
+failure modes that matter and they only fall out when the ability runs
+against the data shape it will see in production.
+
+For each ability whose audit entry declares a non-null `seed_data_needs`,
+seed the environment per that field, then call the ability with
+representative inputs (a real id, a real slug — not a synthetic
+placeholder), and assert the output shape AND the privacy contract:
+
+```bash
+<env-cli> wp --user=admin eval '
+// Seed once at the top of the harness run, per the audit doc:
+// e.g. wp post create, wp user create, wp option update, factory helpers.
+
+$ability = wp_get_ability( "<plugin>/<read-ability>" );
+$result  = $ability->execute( array( "<field>" => "<real-id-from-the-seeded-data>" ) );
+
+if ( is_wp_error( $result ) ) {
+    echo "FAIL: " . $result->get_error_code() . PHP_EOL;
+    exit;
+}
+
+// Assert the documented output shape — keys present, types correct.
+$expected_keys = array( "id", "label", "status" );  // from the ability schema or audit return_type
+foreach ( $expected_keys as $k ) {
+    if ( ! array_key_exists( $k, (array) $result ) ) {
+        echo "FAIL: missing output key " . $k . PHP_EOL;
+        exit;
+    }
+}
+
+// Assert the privacy contract: sensitive fields the contract does NOT
+// promise must not appear (e.g. full PAN, full bank account, raw token,
+// internal-only debug fields).
+$forbidden_keys = array( "full_pan", "card_number", "bank_account_number", "iban" );
+foreach ( $forbidden_keys as $k ) {
+    if ( array_key_exists( $k, (array) $result ) ) {
+        echo "FAIL: privacy leak — " . $k . " present in output." . PHP_EOL;
+        exit;
+    }
+}
+
+echo "PASS: shape OK, privacy OK." . PHP_EOL;
+'
+```
+
+Adapt `$expected_keys` and `$forbidden_keys` to each ability. The audit
+doc's `return_type` field hints at the shape; the privacy keys depend on
+the plugin's domain. For payments-family plugins, full PANs / bank
+numbers / raw tokens are the canonical forbidden set; other families
+substitute appropriately. The plugin's in-tree contract tests (the
+overlay's `test-the-public-contract.md` for WooCommerce extensions) are
+the durable home for these assertions on every CI run — this Level 2
+check is the one-off harness run that produces the PR artifact.
+
+When the audit doc declares `seed_data_needs: null`, Level 2 is not yet
+runnable: the auditor has not identified the seed shape. The harness
+reports `LEVEL 2: pending (seed_data_needs is null — ask the
+implementer)` and proceeds. When `seed_data_needs` is a string, the
+harness operator seeds per that description before running the
+representative-input block above.
 
 ## Check 4 — each write ability's missing-input returns `ability_invalid_input` or `<plugin>_missing_<field>`
 

--- a/skills/wp-abilities-verify/references/runtime-harness.md
+++ b/skills/wp-abilities-verify/references/runtime-harness.md
@@ -1,0 +1,353 @@
+# Runtime Harness
+
+The runtime-mode procedure. Everything static-mode does, plus six canonical
+checks that need a live `wp_get_abilities()` call.
+
+Static mode catches structural problems (annotation lies, schema lint
+failures, audit mismatches). Runtime mode catches the class of bug that
+only surfaces against a booted WordPress: missing constructor arguments,
+bootstrap-ordering issues, schema-validator paths, capability-roundtrip
+failures, and idempotency violations at the response-byte level.
+
+## Harness rule: stop on first fatal
+
+If any step below produces a PHP fatal, STOP. Later steps won't produce
+meaningful output. Capture the failure, escalate to the plugin's
+implementer to fix, then re-run from step 1.
+
+A `WP_Error` return is acceptable — any `<plugin>_*` or upstream-prefixed
+error means the execute callback handled the error path gracefully. Only
+PHP fatals block.
+
+## Step 0 — identify the env-up command
+
+Read the plugin's `AGENTS.md` for the canonical env bring-up command. Do
+NOT assume `npm run wp-env start` works for every plugin. Common patterns
+seen in real plugin trees:
+
+- `npm run wp-env start` — projects using `@wordpress/env` with a checked-in
+  `.wp-env.json` (typical for many WooCommerce-family plugins).
+- `npx wp-env start` — projects using `@wordpress/env` without a custom
+  npm script wrapper.
+- `jetpack docker up` — Jetpack-family monorepo packages.
+- `composer install && composer test-php --setup-only` — package-local
+  test bootstraps that don't run a full WordPress install.
+- `docker-compose up -d` — plugin-specific dev Docker stacks.
+
+If `AGENTS.md` doesn't document it, ask the user rather than guessing.
+Record the env-up command + the corresponding wp-cli invocation (e.g.
+`npx wp-env run cli wp`, `jetpack docker cli wp`) and use them uniformly
+for the rest of the harness.
+
+In this file, `<env-cli>` is shorthand for whatever wp-cli invocation the
+plugin uses.
+
+## Step 1 — bring up the env and sanity-check
+
+```bash
+<env-up-command>
+<env-cli> wp core version
+<env-cli> wp plugin list --status=active
+<env-cli> wp eval 'var_export( function_exists( "wp_get_abilities" ) );'
+```
+
+Confirm:
+
+- WordPress version >= 6.9 (Abilities API available in core).
+- The plugin being verified is active.
+- `wp_get_abilities` exists (true if WP >= 6.9, else the Abilities API
+  feature plugin/package must be active).
+
+Any "no" answer halts the harness.
+
+## Check 1 — ability names match source-expected list
+
+Enumerate runtime abilities and diff against the static inventory from
+`static-enumeration.md`:
+
+```bash
+<env-cli> wp --user=admin eval '
+$names = array_filter(
+    array_keys( (array) wp_get_abilities() ),
+    function ( $n ) {
+        return strpos( $n, "<plugin-slug>/" ) === 0;
+    }
+);
+sort( $names );
+echo "count=" . count( $names ) . PHP_EOL;
+echo implode( PHP_EOL, $names ) . PHP_EOL;
+'
+```
+
+Compare against the static inventory:
+
+- Source contains ability, runtime missing → FAIL. Registration hook
+  isn't firing; check init hook timing and plugin activation.
+- Runtime contains ability, source missing → WARN. Dynamic registration
+  path the enumerator couldn't follow. Document but don't block.
+- Counts match → OK.
+
+## Check 2 — annotations read back as declared
+
+```bash
+<env-cli> wp --user=admin eval '
+$names = array_filter(
+    array_keys( (array) wp_get_abilities() ),
+    function ( $n ) {
+        return strpos( $n, "<plugin-slug>/" ) === 0;
+    }
+);
+sort( $names );
+foreach ( $names as $name ) {
+    $a = wp_get_ability( $name );
+    $m = $a->get_meta();
+    printf(
+        "%s | readonly=%s | destructive=%s | idempotent=%s | category=%s" . PHP_EOL,
+        $name,
+        var_export( $m["annotations"]["readonly"], true ),
+        var_export( $m["annotations"]["destructive"], true ),
+        var_export( $m["annotations"]["idempotent"], true ),
+        $a->get_category()
+    );
+}
+'
+```
+
+Cross-reference each annotation against the audit's declared value (if an
+audit was provided) AND against the static inventory's declared value.
+Mismatch on either axis → FAIL.
+
+This check complements the static adversarial check from
+`annotation-correctness.md`: static checks the callback's actual
+behavior; runtime checks what the registration hook resolved to at boot
+time. Both must agree for the annotations to be trustworthy.
+
+## Check 3 — each read ability's `execute()` returns OK or a standard-vocabulary WP_Error
+
+```bash
+<env-cli> wp --user=admin eval '
+$reads = array(
+    "<plugin-slug>/<read-ability-1>",
+    "<plugin-slug>/<read-ability-2>",
+    // ...
+);
+foreach ( $reads as $name ) {
+    $r = wp_get_ability( $name )->execute();
+    echo $name . ": " . ( is_wp_error( $r ) ? "WP_Error(" . $r->get_error_code() . ")" : "OK" ) . PHP_EOL;
+}
+'
+```
+
+Acceptable outcomes:
+
+- `OK` — the ability returned without error.
+- `WP_Error(<plugin>_not_initialized)` — bootstrap guard fired (e.g.
+  un-bootstrapped service). Happy error path.
+- `WP_Error(<plugin>_<resource>_data_unavailable)` — transient backend
+  error. Acceptable.
+- `WP_Error(<upstream_code>)` — upstream third-party error bubbled
+  through. Document, don't block.
+
+Unacceptable:
+
+- PHP fatal → stop the harness.
+- `WP_Error` with a non-vocabulary code → WARN. Cross-reference
+  `../../wp-abilities-api/references/error-code-vocabulary.md`.
+
+Abilities with required input get invoked separately with a
+synthetic-but-plausible value:
+
+```bash
+<env-cli> wp --user=admin eval '
+$r = wp_get_ability( "<plugin>/<ability-with-required-input>" )
+    ->execute( array( "<field>" => "<synthetic-id>" ) );
+echo "<ability>: " . ( is_wp_error( $r ) ? "WP_Error(" . $r->get_error_code() . ")" : "OK" ) . PHP_EOL;
+'
+```
+
+A synthetic ID on a fresh install typically triggers
+`<plugin>_<resource>_data_unavailable` or an upstream-equivalent code.
+Both are acceptable.
+
+## Check 4 — each write ability's missing-input returns `ability_invalid_input` or `<plugin>_missing_<field>`
+
+```bash
+<env-cli> wp --user=admin eval '
+$a = wp_get_ability( "<plugin>/<write-ability>" );
+
+$r1 = $a->execute( array() );
+echo "missing: " . ( is_wp_error( $r1 ) ? "WP_Error(" . $r1->get_error_code() . ")" : "UNEXPECTED_OK" ) . PHP_EOL;
+
+$r2 = $a->execute( array( "<required_field>" => 123 ) );
+echo "non-string: " . ( is_wp_error( $r2 ) ? "WP_Error(" . $r2->get_error_code() . ")" : "UNEXPECTED_OK" ) . PHP_EOL;
+'
+```
+
+Acceptable codes, per
+`../../wp-abilities-api/references/error-code-vocabulary.md`:
+
+- `ability_invalid_input` — the Abilities API's schema validator fired
+  first (normal REST-bridge path; emitted by
+  `WP_Ability::validate_input()` in core).
+- `<plugin>_missing_<field>` — the execute callback's own guard fired
+  (direct-invocation path).
+- `<plugin>_invalid_<field>` — same, for the wrong-type case.
+
+`UNEXPECTED_OK` → FAIL. Validation is missing; the ability accepted
+no-input and proceeded to do something it shouldn't have.
+
+## Check 5 — permission gate denies subscriber, allows admin
+
+```bash
+<env-cli> wp --user=admin eval '
+$ability = wp_get_ability( "<plugin>/<any-ability>" );
+
+// Admin path.
+wp_set_current_user( 1 );
+$admin_result = $ability->check_permissions();
+
+// Subscriber path.
+$sub_login = "verify_sub_" . time();
+$sub_id    = wp_create_user( $sub_login, "x", $sub_login . "@example.com" );
+if ( ! is_wp_error( $sub_id ) ) {
+    $user = get_user_by( "id", $sub_id );
+    $user->set_role( "subscriber" );
+    wp_set_current_user( $sub_id );
+    $sub_result = $ability->check_permissions();
+} else {
+    $sub_result = $sub_id; // surface the create_user error in the report
+}
+
+foreach ( array( "admin" => $admin_result, "subscriber" => $sub_result ) as $context => $r ) {
+    if ( true === $r ) {
+        $printable = "true";
+    } elseif ( is_wp_error( $r ) ) {
+        $printable = "WP_Error(" . $r->get_error_code() . ")";
+    } else {
+        $printable = var_export( $r, true );
+    }
+    echo $context . ": " . $printable . PHP_EOL;
+}
+'
+```
+
+Expected:
+
+```
+admin: true
+subscriber: false
+```
+
+Any inversion is a bug in the registered `permission_callback`. See
+`permission-roundtrip.md` for the deeper cross-checks (audit's declared
+capability → registered callback → resolved `current_user_can(...)`).
+
+Public abilities (deliberately ungated) expect `subscriber: true` AND
+`admin: true`. Verify that the ability's `permission_callback` is
+`'__return_true'` in source before accepting this outcome.
+
+`check_permissions()` returns `bool|WP_Error` per `WP_Ability::check_permissions()`
+in WordPress core. A `WP_Error` with code `ability_invalid_permission_callback`
+means the registration didn't supply a valid callable — a hard FAIL. A
+`WP_Error` with code `ability_callback_exception` means the callback
+threw — also a hard FAIL.
+
+## Check 6 — idempotent reads return byte-for-byte identical results on twin invocations
+
+Only apply this to abilities annotated `idempotent: true` whose `execute()`
+returned without error in Check 3. Per
+`annotation-correctness.md` step "Runtime check complement":
+
+```bash
+<env-cli> wp --user=admin eval '
+$a  = wp_get_ability( "<plugin>/<idempotent-read-ability>" );
+$r1 = $a->execute();
+$r2 = $a->execute();
+
+if ( is_wp_error( $r1 ) || is_wp_error( $r2 ) ) {
+    echo "skipped: one or both invocations returned WP_Error" . PHP_EOL;
+    if ( is_wp_error( $r1 ) ) { echo "r1=" . $r1->get_error_code() . PHP_EOL; }
+    if ( is_wp_error( $r2 ) ) { echo "r2=" . $r2->get_error_code() . PHP_EOL; }
+} else {
+    $h1 = md5( serialize( $r1 ) );
+    $h2 = md5( serialize( $r2 ) );
+    echo "match=" . var_export( $h1 === $h2, true ) . PHP_EOL;
+    echo "h1=" . $h1 . PHP_EOL;
+    echo "h2=" . $h2 . PHP_EOL;
+}
+'
+```
+
+Expected (when both invocations succeeded): `match=true` and two
+identical hashes.
+
+Twin-invocation differ on an `idempotent: true` ability → FAIL. Common
+causes:
+
+- Response embeds `time()` or `current_time()`.
+- Response embeds a nonce.
+- Response embeds a non-deterministic queue state.
+
+Either remove the nondeterministic field (preferred) or change the
+annotation to `idempotent: false`. Don't loosen the check.
+
+## Output format
+
+The runtime harness writes a dedicated section in the run report:
+
+```markdown
+## Runtime harness
+
+**Env:** wp-env (Docker), WordPress 6.9, <plugin> <version>
+**Captured:** <YYYY-MM-DD HH:MM>
+
+### Check 1 — enumeration
+
+count=7 (expected 7 from static inventory)
+<sorted list>
+
+### Check 2 — annotations
+
+| Ability | readonly | destructive | idempotent | Matches source? |
+|---|---|---|---|---|
+
+### Check 3 — read execution
+
+| Ability | Result |
+|---|---|
+
+### Check 4 — write input validation
+
+| Ability | Missing-input code | Wrong-type code |
+|---|---|---|
+
+### Check 5 — permission gate
+
+| Ability | admin | subscriber | Expected |
+|---|---|---|---|
+
+### Check 6 — idempotency
+
+| Ability | match | h1 | h2 |
+|---|---|---|---|
+
+### Notes / surprises
+
+<Anything unexpected that didn't block.>
+```
+
+## When the harness catches a bug
+
+Observed pattern:
+
+1. Harness surfaces a PHP fatal (e.g. `ArgumentCountError: Too few
+   arguments to function <controller>::__construct`).
+2. Implementer fixes the bug in a focused commit.
+3. Harness re-runs; write the post-fix output as the headline status.
+4. Preserve the pre-fix trace in the report under a "Pre-fix status"
+   section so reviewers can see what verify caught.
+
+This is the highest-leverage signal the runtime harness produces:
+bootstrap-ordering and missing-dependency bugs that pass static review
+because the source declares the right shape — they only manifest when
+the registration runs against a booted WordPress.

--- a/skills/wp-abilities-verify/references/runtime-harness.md
+++ b/skills/wp-abilities-verify/references/runtime-harness.md
@@ -26,18 +26,20 @@ NOT assume `npm run wp-env start` works for every plugin. Common patterns
 seen in real plugin trees:
 
 - `npm run wp-env start` — projects using `@wordpress/env` with a checked-in
-  `.wp-env.json` (typical for many WooCommerce-family plugins).
+  `.wp-env.json`.
 - `npx wp-env start` — projects using `@wordpress/env` without a custom
   npm script wrapper.
-- `jetpack docker up` — Jetpack-family monorepo packages.
 - `composer install && composer test-php --setup-only` — package-local
   test bootstraps that don't run a full WordPress install.
 - `docker-compose up -d` — plugin-specific dev Docker stacks.
 
+Plugin families with their own dev tooling will have their own bring-up
+command in `AGENTS.md`; follow it as documented.
+
 If `AGENTS.md` doesn't document it, ask the user rather than guessing.
 Record the env-up command + the corresponding wp-cli invocation (e.g.
-`npx wp-env run cli wp`, `jetpack docker cli wp`) and use them uniformly
-for the rest of the harness.
+`npx wp-env run cli wp`) and use them uniformly for the rest of the
+harness.
 
 In this file, `<env-cli>` is shorthand for whatever wp-cli invocation the
 plugin uses.

--- a/skills/wp-abilities-verify/references/runtime-harness.md
+++ b/skills/wp-abilities-verify/references/runtime-harness.md
@@ -203,10 +203,11 @@ no-input and proceeded to do something it shouldn't have.
 ```bash
 <env-cli> wp --user=admin eval '
 $ability = wp_get_ability( "<plugin>/<any-ability>" );
+$input   = array(); // representative input; substitute for non-object root schemas.
 
 // Admin path.
 wp_set_current_user( 1 );
-$admin_result = $ability->check_permissions();
+$admin_result = $ability->check_permissions( $input );
 
 // Subscriber path.
 $sub_login = "verify_sub_" . time();
@@ -215,7 +216,7 @@ if ( ! is_wp_error( $sub_id ) ) {
     $user = get_user_by( "id", $sub_id );
     $user->set_role( "subscriber" );
     wp_set_current_user( $sub_id );
-    $sub_result = $ability->check_permissions();
+    $sub_result = $ability->check_permissions( $input );
 } else {
     $sub_result = $sub_id; // surface the create_user error in the report
 }

--- a/skills/wp-abilities-verify/references/runtime-harness.md
+++ b/skills/wp-abilities-verify/references/runtime-harness.md
@@ -257,8 +257,9 @@ threw — also a hard FAIL.
 Only apply this to abilities annotated `idempotent: true` whose `execute()`
 returned without error in Check 3. Per `annotation-correctness.md` step
 "Runtime check complement", this is a *heuristic*: idempotent in core
-means "no additional effect on the environment" (`class-wp-ability.php`
-lines 47-48), not "byte-identical return values."
+means "no additional effect on the environment" (per the `idempotent`
+annotation's docblock in `class-wp-ability.php`), not "byte-identical
+return values."
 
 ```bash
 <env-cli> wp --user=admin eval '

--- a/skills/wp-abilities-verify/references/schema-lints.md
+++ b/skills/wp-abilities-verify/references/schema-lints.md
@@ -1,0 +1,239 @@
+# Schema Lints
+
+Static lints against an ability's `input_schema` (and to a lesser extent,
+output schema when one is declared). Complements the adversarial
+annotation checks: schema hygiene is about agent legibility, not
+correctness-versus-behavior.
+
+The target audience is orchestrating agents: they read the schema to
+figure out how to call the ability. A schema that's hard to parse,
+ambiguous, or misleading wastes agent turns even when the ability
+itself works perfectly.
+
+## The lints
+
+### Lint 1 — `additionalProperties: false` for object schemas, unless deliberately accepting extras
+
+```php
+'input_schema' => [
+    'type'       => 'object',
+    'properties' => [ /* ... */ ],
+    'additionalProperties' => false,  // <-- preferred when the input is object-typed
+],
+```
+
+**Scope:** this lint only applies when the top-level schema has
+`'type' => 'object'`. Non-object schemas (e.g. a string with an enum,
+an integer with min/max) are not subject to this check —
+`additionalProperties` is meaningless on those types.
+
+**Why:** for object-typed input, an agent passing typos (e.g.
+`par_page` instead of `per_page`) gets accepted silently when
+`additionalProperties` is not declared (JSON Schema's default is
+`true`). The backing controller ignores the typo key and the behavior
+differs from what the agent expected. Fail fast on unknown keys.
+
+**Grep:**
+
+```bash
+# Find input_schema blocks.
+grep -rn --include='*.php' -A 30 "'input_schema'\s*=>\s*\[" <plugin-root>/ \
+    | grep -E "'additionalProperties'\s*=>\s*(true|false)"
+```
+
+**Result (object-typed schemas only):**
+
+- `additionalProperties: false` declared → OK.
+- `additionalProperties: true` declared → WARN. Inspect: is this a
+  deliberate pass-through (e.g. user-controlled metadata fields)?
+  Document in a comment; otherwise tighten.
+- Not declared at all on an object schema → WARN, recommend declaring
+  explicitly. Not a hard FAIL — the input still validates against the
+  declared `properties`; the risk is silent typo acceptance, which is
+  bounded.
+
+**Deliberate-extras exemption:** some plugins pass through user-controlled
+metadata fields (e.g. payment-system custom metadata, form-field
+free-text). A pattern like:
+
+```php
+'metadata' => [
+    'type'        => 'object',
+    'additionalProperties' => true,  // user-controlled metadata
+    'description' => __( 'Free-form key/value metadata.', '<text-domain>' ),
+],
+```
+
+is legitimate at the property level. Top-level
+`additionalProperties: false` should still apply — the object as a
+whole has a finite key set, even if one of those keys is itself a
+bag-of-attributes.
+
+**Non-object input schemas:** the Abilities API accepts schemas of any
+JSON Schema type at the root, not just objects. For example, an ability
+that takes a single status string can declare:
+
+```php
+'input_schema' => array(
+    'type'        => 'string',
+    'enum'        => array( 'pending', 'active', 'cancelled' ),
+    'description' => __( 'The desired status.', '<text-domain>' ),
+),
+```
+
+Lint 1 is a no-op on schemas like this — there are no properties for
+typos to slip into.
+
+### Lint 2 — every required field has a description
+
+```php
+'properties' => [
+    'order_id' => [
+        'type'        => 'string',
+        'description' => __( 'The order ID to fetch.', '<text-domain>' ),  // <-- required
+    ],
+],
+'required' => [ 'order_id' ],
+```
+
+**Why:** required fields are where agents most need guidance. Missing
+descriptions push the agent into guessing from the field name alone,
+which fails on any non-obvious case (date formats, ID conventions,
+enum semantics).
+
+**Check:**
+
+For each key in `required`, its entry in `properties` must have a
+non-empty `description`. Empty or missing → FAIL (required field is
+opaque).
+
+Optional fields may also benefit from descriptions but their absence is
+a WARN, not a FAIL.
+
+### Lint 3 — enums are non-empty
+
+```php
+'status' => [
+    'type' => 'string',
+    'enum' => [ 'pending', 'active', 'cancelled' ],  // <-- at least one value
+],
+```
+
+**Why:** an empty `enum` accepts no values, effectively rejecting every
+input. Almost always a bug.
+
+**Check:** any `'enum' => []` → FAIL.
+
+A single-value enum is legal but unusual; WARN and prompt for review —
+often an artifact of a copy-paste that lost the other values.
+
+### Lint 4 — no `$ref`
+
+```php
+// WRONG — don't do this in ability schemas.
+'input_schema' => [
+    'type' => 'object',
+    'properties' => [
+        'address' => [ '$ref' => '#/definitions/Address' ],
+    ],
+],
+```
+
+**Why:** agents read the schema via the REST introspection endpoint. A
+`$ref` forces the agent to follow a reference to see what `address`
+looks like — wastes a turn and often breaks because the referenced
+schema isn't in the same document. Inline the shape instead.
+
+**Check:** any `'$ref'` in an `input_schema` → FAIL.
+
+### Lint 5 — default values are primitive or `null`
+
+```php
+// OK — primitive defaults.
+'per_page' => [ 'type' => 'integer', 'default' => 25 ],
+'submit'   => [ 'type' => 'boolean', 'default' => false ],
+'status'   => [ 'type' => 'string',  'default' => 'pending' ],
+'metadata' => [ 'type' => 'object',  'default' => null ],
+
+// WRONG — complex expression as default.
+'created_at' => [ 'type' => 'string', 'default' => gmdate( 'c' ) ],
+```
+
+**Why:** a default that evaluates per-call is both non-deterministic
+(twin invocations can differ, violating `idempotent: true`) and
+surprising to agents that expect defaults to be static values.
+
+**Check:** each `'default'` value must be a scalar literal (`true`,
+`false`, integer, float, quoted string, `null`) or an empty array
+literal. A function call, variable reference, or computed expression →
+FAIL.
+
+### Lint 6 — `reference_ability: true` implies no required inputs
+
+From `../../wp-abilities-audit/references/audit-schema.md`:
+
+> Exactly zero or one ability per audit may set `reference_ability: true`.
+
+The reference ability is the first one an implementer lands — typically
+the smallest, safest, highest-leverage read. It gets invoked as a
+bootstrap call to confirm the abilities registration works end-to-end,
+so it must work without input:
+
+**Check:** if an audit doc is provided and an ability has
+`reference_ability: true`, its `input_schema.required` array must be
+empty or absent. Required inputs on the reference ability → FAIL.
+
+If no audit is provided, this lint is skipped (no reference ability
+declared).
+
+## Cross-reference: the three runtime gotchas
+
+Static lints can't catch runtime gotchas. Cross-reference
+`../../wp-abilities-api/references/input-schema-gotchas.md` for the three
+patterns that need defensive code in the execute callback:
+
+1. **Schema `default` values are NOT injected into callback input** —
+   the callback must re-apply defaults via `array_key_exists` + null
+   checks.
+2. **Pagination parameter-name drift** — if the backing reads `pagesize`
+   but the schema exposes `per_page`, the callback must translate before
+   delegating.
+3. **ID validation must not use `empty()`** — `empty( "0" )` is true,
+   but `"0"` is a legal ID. Use `isset + is_string + '' === ...`
+   instead.
+
+Static mode can only detect the schema-declaration side of these:
+
+- Gotcha 1: the lint catches missing `default` values that are obviously
+  expected (e.g. a boolean with `required: false` but no default).
+  Flag as WARN.
+- Gotcha 2: grep the callback body for the `per_page`/`pagesize`
+  translation helper; if the schema exposes `per_page` and the backing
+  reads `pagesize`, the helper should be present. Absence → FAIL.
+- Gotcha 3: grep the callback body for `empty( $input[ <required_key> ] )`
+  on required string IDs. Hit → FAIL (use `isset + is_string + ''`).
+
+Runtime mode confirms these patterns via actual invocation — the
+harness's "missing-input code" and "wrong-type code" checks from
+`runtime-harness.md` step 4.
+
+## Output format
+
+Report schema lints in the run report under a "Schema lints" section:
+
+```markdown
+## Schema lints
+
+| Ability | Lint | Result | Detail |
+|---|---|---|---|
+| <ability> | additionalProperties (object schemas) | WARN | not declared on object schema |
+| <ability> | required-field descriptions | OK | 3/3 required fields documented |
+| <ability> | enum non-empty | OK | no enums |
+| <ability> | no $ref | OK | inline |
+| <ability> | primitive defaults | FAIL | `created_at` uses `gmdate('c')` |
+| <ability> | reference_ability implies no required | N/A | not reference ability |
+```
+
+A single FAIL lint on any ability feeds into the run's top-line status
+per the main SKILL.md "Verification" section. WARN-only lints don't
+flip the top-line status but are surfaced for the reviewer.

--- a/skills/wp-abilities-verify/references/schema-lints.md
+++ b/skills/wp-abilities-verify/references/schema-lints.md
@@ -1,250 +1,98 @@
 # Schema Lints
 
-Static lints against an ability's `input_schema` (and to a lesser extent,
-output schema when one is declared). Complements the adversarial
-annotation checks: schema hygiene is about agent legibility, not
-correctness-versus-behavior.
-
-The target audience is orchestrating agents: they read the schema to
+Static lints against an ability's `input_schema`. Schema hygiene is
+about *agent legibility*: orchestrating agents read the schema to
 figure out how to call the ability. A schema that's hard to parse,
-ambiguous, or misleading wastes agent turns even when the ability
-itself works perfectly.
+ambiguous, or misleading wastes turns even when the ability itself
+works.
 
-## The lints
+These lints are six small principles. Apply them by reading the
+schema, not by mechanically grepping — most plugins use enough
+formatting variety that grep recipes drift.
 
-### Lint 1 — `additionalProperties: false` for object schemas, unless deliberately accepting extras
+## Lint 1 — `additionalProperties: false` for object schemas
 
-```php
-'input_schema' => [
-    'type'       => 'object',
-    'properties' => [ /* ... */ ],
-    'additionalProperties' => false,  // <-- preferred when the input is object-typed
-],
-```
-
-**Scope:** this lint only applies when the top-level schema has
-`'type' => 'object'`. Non-object schemas (e.g. a string with an enum,
-an integer with min/max) are not subject to this check —
-`additionalProperties` is meaningless on those types.
-
-**Why:** for object-typed input, an agent passing typos (e.g.
-`par_page` instead of `per_page`) gets accepted silently when
-`additionalProperties` is not declared (JSON Schema's default is
-`true`). The backing controller ignores the typo key and the behavior
-differs from what the agent expected. Fail fast on unknown keys.
-
-**Grep:**
-
-```bash
-# Find input_schema blocks.
-grep -rn --include='*.php' -A 30 "'input_schema'\s*=>\s*\[" <plugin-root>/ \
-    | grep -E "'additionalProperties'\s*=>\s*(true|false)"
-```
-
-**Result (object-typed schemas only):**
+For top-level `'type' => 'object'` schemas, declare
+`'additionalProperties' => false` unless you deliberately accept
+extras. Without this, an agent passing a typo (`par_page` instead of
+`per_page`) gets accepted silently and falls through to the backing,
+which ignores the unknown key.
 
 - `additionalProperties: false` declared → OK.
-- `additionalProperties: true` declared → WARN. Inspect: is this a
-  deliberate pass-through (e.g. user-controlled metadata fields)?
-  Document in a comment; otherwise tighten.
-- Not declared at all on an object schema → WARN, recommend declaring
-  explicitly. Not a hard FAIL — the input still validates against the
-  declared `properties`; the risk is silent typo acceptance, which is
-  bounded.
+- `additionalProperties: true` declared → WARN, unless the schema is
+  for genuinely free-form metadata (payment custom fields, form
+  free-text); document the reason inline.
+- Not declared on an object schema → WARN.
+- Non-object root (string with enum, integer, etc.) → N/A. The lint
+  applies only to objects.
 
-**Deliberate-extras exemption:** some plugins pass through user-controlled
-metadata fields (e.g. payment-system custom metadata, form-field
-free-text). A pattern like:
+## Lint 2 — every required field has a non-empty description
 
-```php
-'metadata' => [
-    'type'        => 'object',
-    'additionalProperties' => true,  // user-controlled metadata
-    'description' => __( 'Free-form key/value metadata.', '<text-domain>' ),
-],
-```
+For each entry in `required`, the matching `properties` entry must
+declare a non-empty `description`. Required fields are where agents
+most need guidance; an opaque required key forces the agent to guess
+from the field name alone. Empty / missing → FAIL.
 
-is legitimate at the property level. Top-level
-`additionalProperties: false` should still apply — the object as a
-whole has a finite key set, even if one of those keys is itself a
-bag-of-attributes.
+Optional-field descriptions are nice-to-have — absence is WARN.
 
-**Non-object input schemas:** the Abilities API accepts schemas of any
-JSON Schema type at the root, not just objects. For example, an ability
-that takes a single status string can declare:
+## Lint 3 — enums are non-empty
 
-```php
-'input_schema' => array(
-    'type'        => 'string',
-    'enum'        => array( 'pending', 'active', 'cancelled' ),
-    'description' => __( 'The desired status.', '<text-domain>' ),
-),
-```
+`'enum' => []` accepts no values, rejecting every input. Almost always
+a bug. → FAIL.
 
-Lint 1 is a no-op on schemas like this — there are no properties for
-typos to slip into.
+A single-value enum (`'enum' => [ 'pending' ]`) is legal but unusual;
+WARN and prompt for review — often a copy-paste that lost the other
+values.
 
-### Lint 2 — every required field has a description
+## Lint 4 — no `$ref`
 
-```php
-'properties' => [
-    'order_id' => [
-        'type'        => 'string',
-        'description' => __( 'The order ID to fetch.', '<text-domain>' ),  // <-- required
-    ],
-],
-'required' => [ 'order_id' ],
-```
+Agents read the schema via REST introspection. A `$ref` forces the
+agent to follow a reference to see the field shape — wastes a turn and
+often breaks because the referenced schema isn't in the same document.
+Inline the shape instead.
 
-**Why:** required fields are where agents most need guidance. Missing
-descriptions push the agent into guessing from the field name alone,
-which fails on any non-obvious case (date formats, ID conventions,
-enum semantics).
+Any `'$ref'` in the schema → FAIL.
 
-**Check:**
+## Lint 5 — defaults are statically constant
 
-For each key in `required`, its entry in `properties` must have a
-non-empty `description`. Empty or missing → FAIL (required field is
-opaque).
+Each `'default'` value must evaluate to the same shape on every call:
 
-Optional fields may also benefit from descriptions but their absence is
-a WARN, not a FAIL.
+- Scalar literals — `true`, `false`, integer, float, quoted string,
+  `null` → OK.
+- Empty or all-literal arrays — `[]`, `array()`, `[ 'a', 'b' ]` → OK.
+- Literal cast to an empty object — `(object) array()`, `(object) []`
+  → OK. This is the recommended top-level default for zero-arg-allowed
+  abilities; see
+  `../../wp-abilities-api/references/input-schema-gotchas.md` §4.
+- `new stdClass()` with no arguments → OK.
+- A function call (`gmdate('c')`, `wp_generate_uuid4()`, `time()`),
+  variable reference, or other computed expression → FAIL.
 
-### Lint 3 — enums are non-empty
+The principle: defaults that vary per call are both non-deterministic
+and surprising to agents that expect defaults to be static.
 
-```php
-'status' => [
-    'type' => 'string',
-    'enum' => [ 'pending', 'active', 'cancelled' ],  // <-- at least one value
-],
-```
+## Lint 6 — `reference_ability: true` implies no required inputs
 
-**Why:** an empty `enum` accepts no values, effectively rejecting every
-input. Almost always a bug.
-
-**Check:** any `'enum' => []` → FAIL.
-
-A single-value enum is legal but unusual; WARN and prompt for review —
-often an artifact of a copy-paste that lost the other values.
-
-### Lint 4 — no `$ref`
-
-```php
-// WRONG — don't do this in ability schemas.
-'input_schema' => [
-    'type' => 'object',
-    'properties' => [
-        'address' => [ '$ref' => '#/definitions/Address' ],
-    ],
-],
-```
-
-**Why:** agents read the schema via the REST introspection endpoint. A
-`$ref` forces the agent to follow a reference to see what `address`
-looks like — wastes a turn and often breaks because the referenced
-schema isn't in the same document. Inline the shape instead.
-
-**Check:** any `'$ref'` in an `input_schema` → FAIL.
-
-### Lint 5 — default values are statically constant
-
-```php
-// OK — primitive defaults.
-'per_page' => [ 'type' => 'integer', 'default' => 25 ],
-'submit'   => [ 'type' => 'boolean', 'default' => false ],
-'status'   => [ 'type' => 'string',  'default' => 'pending' ],
-'metadata' => [ 'type' => 'object',  'default' => null ],
-
-// OK — literal empty object/array. The cast and `new stdClass()` always
-// produce the same shape on every call. `(object) array()` is the
-// recommended top-level default for zero-arg-allowed abilities — see
-// `../../wp-abilities-api/references/input-schema-gotchas.md` §4.
-'input_schema' => [
-    'type'    => 'object',
-    'default' => (object) array(),
-    // ...
-],
-'tags' => [ 'type' => 'array', 'default' => [] ],
-
-// WRONG — expression that evaluates differently per call.
-'created_at' => [ 'type' => 'string', 'default' => gmdate( 'c' ) ],
-'token'      => [ 'type' => 'string', 'default' => wp_generate_uuid4() ],
-```
-
-**Why:** a default that evaluates differently per call is both
-non-deterministic and surprising to agents that expect defaults to be
-static values. A type-cast of a literal (`(object) array()`,
-`(object) []`) or a `new stdClass()` always produces the same shape, so
-they're constant for this lint's purposes even though they're not
-scalar literals.
-
-**Check:** each `'default'` value must be one of:
-
-- A scalar literal (`true`, `false`, integer, float, quoted string, `null`).
-- An empty or all-literal array (`[]`, `array()`, `[ 'a', 'b' ]`).
-- A literal cast to an empty object (`(object) array()`, `(object) []`).
-- `new stdClass()` with no arguments.
-
-A function call (`gmdate(...)`, `wp_generate_*(...)`, `time()`),
-variable reference, or other computed expression → FAIL.
-
-Note: this lint deliberately accepts the `(object) array()` form so it
-agrees with the recommended fix in `input-schema-gotchas.md` for
-top-level schema defaults on zero-arg-allowed abilities. Flagging it
-here would create a contradiction across sister skills.
-
-### Lint 6 — `reference_ability: true` implies no required inputs
-
-From `../../wp-abilities-audit/references/audit-schema.md`:
-
-> Exactly zero or one ability per audit may set `reference_ability: true`.
-
-The reference ability is the first one an implementer lands — typically
-the smallest, safest, highest-leverage read. It gets invoked as a
-bootstrap call to confirm the abilities registration works end-to-end,
-so it must work without input:
-
-**Check:** if an audit doc is provided and an ability has
+If an audit doc is provided and an ability has
 `reference_ability: true`, its `input_schema.required` array must be
-empty or absent. Required inputs on the reference ability → FAIL.
+empty or absent. The reference ability is the smallest, safest
+bootstrap call an implementer lands first; it must work with
+`execute([])`. Required inputs on the reference ability → FAIL.
 
-If no audit is provided, this lint is skipped (no reference ability
-declared).
+(No audit provided → this lint is skipped — no reference ability is
+declared.)
 
-## Cross-reference: the three runtime gotchas
+## Cross-reference: the four runtime gotchas
 
-Static lints can't catch runtime gotchas. Cross-reference
-`../../wp-abilities-api/references/input-schema-gotchas.md` for the three
-patterns that need defensive code in the execute callback:
-
-1. **Schema `default` values are NOT injected into callback input** —
-   the callback must re-apply defaults via `array_key_exists` + null
-   checks.
-2. **Pagination parameter-name drift** — if the backing reads `pagesize`
-   but the schema exposes `per_page`, the callback must translate before
-   delegating.
-3. **ID validation must not use `empty()`** — `empty( "0" )` is true,
-   but `"0"` is a legal ID. Use `isset + is_string + '' === ...`
-   instead.
-
-Static mode can only detect the schema-declaration side of these:
-
-- Gotcha 1: the lint catches missing `default` values that are obviously
-  expected (e.g. a boolean with `required: false` but no default).
-  Flag as WARN.
-- Gotcha 2: grep the callback body for the `per_page`/`pagesize`
-  translation helper; if the schema exposes `per_page` and the backing
-  reads `pagesize`, the helper should be present. Absence → FAIL.
-- Gotcha 3: grep the callback body for `empty( $input[ <required_key> ] )`
-  on required string IDs. Hit → FAIL (use `isset + is_string + ''`).
-
-Runtime mode confirms these patterns via actual invocation — the
-harness's "missing-input code" and "wrong-type code" checks from
-`runtime-harness.md` step 4.
+Static lints catch shape; the three runtime gotchas in
+`../../wp-abilities-api/references/input-schema-gotchas.md` need
+defensive code in the execute callback (`array_key_exists` instead of
+`isset`-only for property defaults, pagination key translation, ID
+validation that accepts `"0"`). Gotcha #4 — the direct vs indirect
+invocation strictness — is what motivates the `(object) array()`
+top-level default that Lint 5 explicitly accepts.
 
 ## Output format
-
-Report schema lints in the run report under a "Schema lints" section:
 
 ```markdown
 ## Schema lints
@@ -255,10 +103,9 @@ Report schema lints in the run report under a "Schema lints" section:
 | <ability> | required-field descriptions | OK | 3/3 required fields documented |
 | <ability> | enum non-empty | OK | no enums |
 | <ability> | no $ref | OK | inline |
-| <ability> | primitive defaults | FAIL | `created_at` uses `gmdate('c')` |
+| <ability> | static defaults | FAIL | `created_at` uses `gmdate('c')` |
 | <ability> | reference_ability implies no required | N/A | not reference ability |
 ```
 
-A single FAIL lint on any ability feeds into the run's top-line status
-per the main SKILL.md "Verification" section. WARN-only lints don't
-flip the top-line status but are surfaced for the reviewer.
+A FAIL on any lint flips that ability to FAIL in the run summary.
+WARNs surface but don't block.

--- a/skills/wp-abilities-verify/references/schema-lints.md
+++ b/skills/wp-abilities-verify/references/schema-lints.md
@@ -82,15 +82,22 @@ bootstrap call an implementer lands first; it must work with
 (No audit provided → this lint is skipped — no reference ability is
 declared.)
 
-## Cross-reference: the four runtime gotchas
+## Cross-reference: gotchas 1-3 (callback hardening) and gotcha 4 (structural default)
 
-Static lints catch shape; the three runtime gotchas in
-`../../wp-abilities-api/references/input-schema-gotchas.md` need
-defensive code in the execute callback (`array_key_exists` instead of
-`isset`-only for property defaults, pagination key translation, ID
-validation that accepts `"0"`). Gotcha #4 — the direct vs indirect
-invocation strictness — is what motivates the `(object) array()`
-top-level default that Lint 5 explicitly accepts.
+Static lints catch shape; the four runtime gotchas in
+`../../wp-abilities-api/references/input-schema-gotchas.md` split into
+two kinds.
+
+Gotchas 1-3 need defensive code in the execute callback —
+`array_key_exists` instead of `isset`-only for property defaults,
+pagination key translation, ID validation that accepts `"0"`. These
+are runtime behaviors the callback itself must handle; static schema
+lints can't enforce them.
+
+Gotcha 4 — the direct vs indirect invocation strictness — is what
+motivates the `(object) array()` top-level default that Lint 5
+explicitly accepts. This one IS structural and Lint 5 carries the
+enforcement.
 
 ## Output format
 

--- a/skills/wp-abilities-verify/references/schema-lints.md
+++ b/skills/wp-abilities-verify/references/schema-lints.md
@@ -146,7 +146,7 @@ schema isn't in the same document. Inline the shape instead.
 
 **Check:** any `'$ref'` in an `input_schema` → FAIL.
 
-### Lint 5 — default values are primitive or `null`
+### Lint 5 — default values are statically constant
 
 ```php
 // OK — primitive defaults.
@@ -155,18 +155,43 @@ schema isn't in the same document. Inline the shape instead.
 'status'   => [ 'type' => 'string',  'default' => 'pending' ],
 'metadata' => [ 'type' => 'object',  'default' => null ],
 
-// WRONG — complex expression as default.
+// OK — literal empty object/array. The cast and `new stdClass()` always
+// produce the same shape on every call. `(object) array()` is the
+// recommended top-level default for zero-arg-allowed abilities — see
+// `../../wp-abilities-api/references/input-schema-gotchas.md` §4.
+'input_schema' => [
+    'type'    => 'object',
+    'default' => (object) array(),
+    // ...
+],
+'tags' => [ 'type' => 'array', 'default' => [] ],
+
+// WRONG — expression that evaluates differently per call.
 'created_at' => [ 'type' => 'string', 'default' => gmdate( 'c' ) ],
+'token'      => [ 'type' => 'string', 'default' => wp_generate_uuid4() ],
 ```
 
-**Why:** a default that evaluates per-call is both non-deterministic
-(twin invocations can differ, violating `idempotent: true`) and
-surprising to agents that expect defaults to be static values.
+**Why:** a default that evaluates differently per call is both
+non-deterministic and surprising to agents that expect defaults to be
+static values. A type-cast of a literal (`(object) array()`,
+`(object) []`) or a `new stdClass()` always produces the same shape, so
+they're constant for this lint's purposes even though they're not
+scalar literals.
 
-**Check:** each `'default'` value must be a scalar literal (`true`,
-`false`, integer, float, quoted string, `null`) or an empty array
-literal. A function call, variable reference, or computed expression →
-FAIL.
+**Check:** each `'default'` value must be one of:
+
+- A scalar literal (`true`, `false`, integer, float, quoted string, `null`).
+- An empty or all-literal array (`[]`, `array()`, `[ 'a', 'b' ]`).
+- A literal cast to an empty object (`(object) array()`, `(object) []`).
+- `new stdClass()` with no arguments.
+
+A function call (`gmdate(...)`, `wp_generate_*(...)`, `time()`),
+variable reference, or other computed expression → FAIL.
+
+Note: this lint deliberately accepts the `(object) array()` form so it
+agrees with the recommended fix in `input-schema-gotchas.md` for
+top-level schema defaults on zero-arg-allowed abilities. Flagging it
+here would create a contradiction across sister skills.
 
 ### Lint 6 — `reference_ability: true` implies no required inputs
 

--- a/skills/wp-abilities-verify/references/static-enumeration.md
+++ b/skills/wp-abilities-verify/references/static-enumeration.md
@@ -1,0 +1,262 @@
+# Static Enumeration
+
+Enumerate a plugin's abilities from source, with no running environment.
+This is the first step of every static-mode run and the cross-check for
+every runtime-mode run.
+
+Static enumeration is necessarily best-effort — PHP's dynamism (variable
+indirection, runtime-conditional registration) means a full inventory
+only comes from a live `wp_get_abilities()` call. When static and runtime
+inventories diverge, trust runtime; static drives the diff so the
+reviewer knows where to look.
+
+## Target: `wp_register_ability( '<name>', [ ... ] )` calls
+
+The canonical registration shape:
+
+```php
+wp_register_ability(
+    '<plugin-slug>/<ability-name>',
+    [
+        'label'           => __( '...', '<text-domain>' ),
+        'description'     => __( '...', '<text-domain>' ),
+        'category'        => '<category-slug>',
+        'input_schema'    => [ /* ... */ ],
+        'execute_callback' => [ self::class, 'execute_my_ability' ],
+        'permission_callback' => [ self::class, 'check_permission' ],
+        'meta'            => [
+            'annotations' => [
+                'readonly'    => true,
+                'destructive' => false,
+                'idempotent'  => true,
+            ],
+            'show_in_rest' => true,
+        ],
+    ]
+);
+```
+
+Find the calls, extract the names, and follow the callback references to
+locate the execute-callback body.
+
+## Step 1 — find every registration call
+
+```bash
+grep -rn --include='*.php' "wp_register_ability\s*(" <plugin-root>/
+```
+
+For each hit, capture the starting line. The next 40-100 lines are
+usually the array literal — the exact end-line is whatever line balances
+the opening `[` or `(`.
+
+If the plugin has zero hits, return a clear "no abilities registered"
+report per the main SKILL.md "Failure modes" section. Don't fabricate
+an empty inventory.
+
+## Step 2 — extract each ability name
+
+The first argument to `wp_register_ability` is the ability name. Usually
+a literal string:
+
+```bash
+# Greedy capture of single- or double-quoted first argument.
+grep -rn --include='*.php' -E "wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"]" <plugin-root>/ \
+    | sed -nE "s/.*wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"].*/\1/p"
+```
+
+If the first argument is a variable (`wp_register_ability( $ability_name, ... )`),
+trace the variable:
+
+- Recent assignment in the same function → resolve at audit time.
+- Constant (`MyPlugin\ABILITY_NAME`) → resolve via a follow-up grep.
+- Truly dynamic (computed from config or loops) → flag as a limitation
+  and recommend the caller use runtime mode for authoritative
+  enumeration.
+
+## Step 3 — extract the annotation block
+
+The annotations live at `meta.annotations.{readonly,destructive,idempotent}`.
+
+For each registration, read the array literal from the starting line
+forward until the matching close paren. Inside, find:
+
+```php
+'annotations' => [
+    'readonly'    => true,
+    'destructive' => false,
+    'idempotent'  => true,
+],
+```
+
+Patterns to handle:
+
+### 3.1 — short-form one-liner
+
+```php
+'annotations' => [ 'readonly' => true, 'destructive' => false, 'idempotent' => true ],
+```
+
+### 3.2 — multi-line (most common)
+
+Use a multi-line regex or read lines until the next `],`:
+
+```bash
+grep -nE "'(readonly|destructive|idempotent)'\s*=>\s*(true|false)" <file>
+```
+
+### 3.3 — values via variables
+
+```php
+'annotations' => self::annotations_for_read(),
+```
+
+Resolve the helper method. If it returns an array literal, treat as
+resolvable. If it builds the array dynamically, record the ability with
+`annotations: <unresolved>` and flag: the adversarial checks can still
+run against the execute callback, but the declared annotations can't be
+compared statically — runtime mode required for that comparison.
+
+### 3.4 — inherited / constant annotations
+
+```php
+'annotations' => self::READONLY_ANNOTATIONS,
+```
+
+Find the class constant; treat as resolvable.
+
+## Step 4 — follow the execute callback to its body
+
+`execute_callback` is one of:
+
+```php
+// Array form (most common with static class method).
+'execute_callback' => [ self::class, 'execute_get_things' ],
+'execute_callback' => [ My_Class::class, 'execute_get_things' ],
+'execute_callback' => [ $this, 'execute_get_things' ],
+
+// String form (top-level function).
+'execute_callback' => 'my_plugin_execute_get_things',
+
+// Closure.
+'execute_callback' => function( $input ) { /* ... */ },
+```
+
+For each form:
+
+- **Array form**: find `class <name>` in the plugin, then
+  `(public|protected|private)( static)?\s+function\s+<method>\s*\(` inside
+  that class. Record the file + start line + end line (find the matching
+  `}` — use the brace-matching heuristic).
+- **String form**: grep for `function <name>\s*\(`.
+- **Closure**: the body is literally inline in the registration; the
+  start line is the `function(` line, the end line is the matching `}`.
+
+Record per ability: `ability_name → (callback_file, callback_start_line, callback_end_line)`.
+The annotation-correctness checks grep inside this range.
+
+## Step 5 — handle fluent builder patterns
+
+Some plugins wrap registrations in helper functions:
+
+```php
+register_get_foo_ability();
+register_get_bar_ability();
+
+function register_get_foo_ability() {
+    wp_register_ability(
+        'myplugin/get-foo',
+        [ /* ... */ ]
+    );
+}
+```
+
+The `grep 'wp_register_ability'` still finds these — they're one level of
+indirection but still literal. No special handling needed.
+
+The trickier pattern:
+
+```php
+foreach ( [ 'foo', 'bar', 'baz' ] as $slug ) {
+    wp_register_ability( "myplugin/get-{$slug}", [ /* ... */ ] );
+}
+```
+
+Here the ability name is dynamic. Record each computed name as a
+limitation and recommend runtime enumeration.
+
+## Step 6 — handle `input_schema` via helper methods
+
+```php
+'input_schema' => self::input_schema_for_get_things(),
+```
+
+The schema lints in `schema-lints.md` need the actual schema. Resolve
+the helper; if it returns an array literal, use it. If the helper builds
+the schema conditionally, flag as unresolvable and skip the static schema
+lints for that ability (runtime mode via the `wp_get_ability(...)->get_input_schema()`
+API is authoritative).
+
+## Step 7 — handle heredoc callbacks (rare but real)
+
+A handful of plugins register abilities with inline heredoc SQL:
+
+```php
+'execute_callback' => function() {
+    global $wpdb;
+    return $wpdb->get_results( <<<SQL
+        SELECT ...
+    SQL );
+},
+```
+
+The grep patterns from `annotation-correctness.md` work on the PHP body,
+not the SQL inside the heredoc. A `SELECT` inside a heredoc is a read
+regardless; an `INSERT` or `UPDATE` inside a heredoc on a `readonly: true`
+ability is a lie. The regex in annotation-correctness catches
+`$wpdb->query(...UPDATE|INSERT|DELETE)` on a single line, but a heredoc
+spans lines. Use multi-line grep:
+
+```bash
+grep -PzoE '\$wpdb->query\s*\([^)]*<<<SQL[^S]*(UPDATE|INSERT|DELETE)' <file>
+```
+
+Document this as a known gap: single-line write patterns are reliably
+detected; multi-line heredoc writes require the multi-line grep variant
+above.
+
+## Limits of static enumeration
+
+Cases where static enumeration produces incomplete or ambiguous output:
+
+- Variable-indirected names (`foreach` over a slug list).
+- Variable-indirected annotations (annotations built from config).
+- Conditional registration (`if ( feature_enabled() ) wp_register_ability(...)`).
+- Variable-indirected callbacks (`[ $this, $callback_name ]`).
+
+Every case above gets recorded in the report's "Static enumeration
+limitations" section. When these occur, recommend the caller re-run in
+runtime mode to get the authoritative inventory from
+`wp_get_abilities()`.
+
+## Output format
+
+```markdown
+## Static inventory
+
+Found <N> ability registrations across <M> files:
+
+| Ability | Source file | Registration line | Callback file | Callback lines |
+|---|---|---|---|---|
+| myplugin/get-foo | src/Abilities.php | 42 | src/Abilities.php | 102-134 |
+| myplugin/submit-bar | src/Abilities.php | 68 | src/Services/Bar.php | 58-91 |
+
+### Limitations
+
+- <ability>: annotations built dynamically in `annotations_for_read()`;
+  recommend runtime mode for annotation cross-check.
+```
+
+This inventory is the input to the annotation-correctness, schema-lint,
+permission-roundtrip, and error-code-vocabulary checks. Each of those
+references operates on the `(callback_file, callback_start_line,
+callback_end_line)` byte range.

--- a/skills/wp-abilities-verify/references/static-enumeration.md
+++ b/skills/wp-abilities-verify/references/static-enumeration.md
@@ -55,14 +55,35 @@ an empty inventory.
 
 ## Step 2 — extract each ability name
 
-The first argument to `wp_register_ability` is the ability name. Usually
-a literal string:
+The first argument to `wp_register_ability` is the ability name —
+usually a literal string. Real-world formatting splits the call across
+lines (the canonical shape at the top of this file is itself
+multi-line), so a single-line regex misses common cases. Use a
+multi-line tool, or fall back to reading a small window after each
+call site.
 
 ```bash
-# Greedy capture of single- or double-quoted first argument.
-grep -rn --include='*.php' -E "wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"]" <plugin-root>/ \
-    | sed -nE "s/.*wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"].*/\1/p"
+# Preferred: ripgrep with multi-line + PCRE2 captures the name whether
+# it sits on the same line as `wp_register_ability(` or on the next
+# non-blank line.
+rg --multiline --pcre2 --type=php -n \
+   "wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"]" <plugin-root>/
+
+# Single-line grep also works for the inline form (name on the same
+# line as the call) but misses the multi-line canonical shape:
+grep -rn --include='*.php' -E \
+   "wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"]" <plugin-root>/
+
+# Fallback when only POSIX grep is available: locate the call sites,
+# then read the next 5-10 lines of each match and pick the first
+# quoted token. Either pcregrep -M or perl -0777 works:
+pcregrep -M -n --include='\.php$' -r \
+   "wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"]" <plugin-root>/
 ```
+
+If the regex still misses a registration (heredoc/HEREDOC name,
+deeply-conditional formatting), fall back to inspecting the call-site
+window by hand — record the line number, open the file, copy the name.
 
 If the first argument is a variable (`wp_register_ability( $ability_name, ... )`),
 trace the variable:

--- a/skills/wp-abilities-verify/references/static-enumeration.md
+++ b/skills/wp-abilities-verify/references/static-enumeration.md
@@ -7,7 +7,7 @@ means a complete inventory only comes from a live `wp_get_abilities()`
 call. When static and runtime inventories diverge, trust runtime;
 static drives the diff so the reviewer knows where to look.
 
-## Canonical registration shape
+## Typical registration shape
 
 ```php
 wp_register_ability(
@@ -43,8 +43,8 @@ SKILL.md "Failure modes." Don't fabricate an empty inventory.
 ## Step 2 — extract each ability name
 
 The first argument is the ability name — usually a literal string.
-Real-world formatting splits the call across lines (the canonical
-shape above is itself multi-line), so single-line regexes miss common
+Real-world formatting splits the call across lines (the example
+above is itself multi-line), so single-line regexes miss common
 cases. Use a multi-line tool:
 
 ```bash

--- a/skills/wp-abilities-verify/references/static-enumeration.md
+++ b/skills/wp-abilities-verify/references/static-enumeration.md
@@ -1,263 +1,111 @@
 # Static Enumeration
 
-Enumerate a plugin's abilities from source, with no running environment.
-This is the first step of every static-mode run and the cross-check for
-every runtime-mode run.
+Enumerate a plugin's abilities from source, with no running
+environment. Static enumeration is necessarily best-effort — PHP's
+dynamism (variable indirection, runtime-conditional registration)
+means a complete inventory only comes from a live `wp_get_abilities()`
+call. When static and runtime inventories diverge, trust runtime;
+static drives the diff so the reviewer knows where to look.
 
-Static enumeration is necessarily best-effort — PHP's dynamism (variable
-indirection, runtime-conditional registration) means a full inventory
-only comes from a live `wp_get_abilities()` call. When static and runtime
-inventories diverge, trust runtime; static drives the diff so the
-reviewer knows where to look.
-
-## Target: `wp_register_ability( '<name>', [ ... ] )` calls
-
-The canonical registration shape:
+## Canonical registration shape
 
 ```php
 wp_register_ability(
     '<plugin-slug>/<ability-name>',
-    [
-        'label'           => __( '...', '<text-domain>' ),
-        'description'     => __( '...', '<text-domain>' ),
-        'category'        => '<category-slug>',
-        'input_schema'    => [ /* ... */ ],
-        'execute_callback' => [ self::class, 'execute_my_ability' ],
-        'permission_callback' => [ self::class, 'check_permission' ],
-        'meta'            => [
-            'annotations' => [
+    array(
+        'label'               => __( '...', '<text-domain>' ),
+        'description'         => __( '...', '<text-domain>' ),
+        'category'            => '<category-slug>',
+        'input_schema'        => array( /* ... */ ),
+        'execute_callback'    => array( self::class, 'execute_my_ability' ),
+        'permission_callback' => array( self::class, 'check_permission' ),
+        'meta'                => array(
+            'annotations' => array(
                 'readonly'    => true,
                 'destructive' => false,
                 'idempotent'  => true,
-            ],
+            ),
             'show_in_rest' => true,
-        ],
-    ]
+        ),
+    )
 );
 ```
-
-Find the calls, extract the names, and follow the callback references to
-locate the execute-callback body.
 
 ## Step 1 — find every registration call
 
 ```bash
-grep -rn --include='*.php' "wp_register_ability\s*(" <plugin-root>/
+grep -rn --include='*.php' 'wp_register_ability\s*(' <plugin-root>/
 ```
 
-For each hit, capture the starting line. The next 40-100 lines are
-usually the array literal — the exact end-line is whatever line balances
-the opening `[` or `(`.
-
-If the plugin has zero hits, return a clear "no abilities registered"
-report per the main SKILL.md "Failure modes" section. Don't fabricate
-an empty inventory.
+Zero hits → return a clear "no abilities registered" report per
+SKILL.md "Failure modes." Don't fabricate an empty inventory.
 
 ## Step 2 — extract each ability name
 
-The first argument to `wp_register_ability` is the ability name —
-usually a literal string. Real-world formatting splits the call across
-lines (the canonical shape at the top of this file is itself
-multi-line), so a single-line regex misses common cases. Use a
-multi-line tool, or fall back to reading a small window after each
-call site.
+The first argument is the ability name — usually a literal string.
+Real-world formatting splits the call across lines (the canonical
+shape above is itself multi-line), so single-line regexes miss common
+cases. Use a multi-line tool:
 
 ```bash
-# Preferred: ripgrep with multi-line + PCRE2 captures the name whether
-# it sits on the same line as `wp_register_ability(` or on the next
-# non-blank line.
+# ripgrep with --multiline + PCRE2 captures the name regardless of line break:
 rg --multiline --pcre2 --type=php -n \
    "wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"]" <plugin-root>/
 
-# Single-line grep also works for the inline form (name on the same
-# line as the call) but misses the multi-line canonical shape:
-grep -rn --include='*.php' -E \
-   "wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"]" <plugin-root>/
-
-# Fallback when only POSIX grep is available: locate the call sites,
-# then read the next 5-10 lines of each match and pick the first
-# quoted token. Either pcregrep -M or perl -0777 works:
-pcregrep -M -n --include='\.php$' -r \
-   "wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"]" <plugin-root>/
+# Fallbacks: pcregrep -M, perl -0777.
 ```
 
-If the regex still misses a registration (heredoc/HEREDOC name,
-deeply-conditional formatting), fall back to inspecting the call-site
-window by hand — record the line number, open the file, copy the name.
-
-If the first argument is a variable (`wp_register_ability( $ability_name, ... )`),
-trace the variable:
-
-- Recent assignment in the same function → resolve at audit time.
-- Constant (`MyPlugin\ABILITY_NAME`) → resolve via a follow-up grep.
-- Truly dynamic (computed from config or loops) → flag as a limitation
-  and recommend the caller use runtime mode for authoritative
-  enumeration.
+If the first argument is a variable or constant
+(`wp_register_ability( $name, ... )`,
+`wp_register_ability( MyPlugin\NAME, ... )`), trace it: a recent
+assignment in the same function or a class constant usually resolves;
+a name computed in a loop won't, in which case flag the limitation and
+recommend runtime mode for authoritative enumeration.
 
 ## Step 3 — extract the annotation block
 
-The annotations live at `meta.annotations.{readonly,destructive,idempotent}`.
+Annotations live at `meta.annotations.{readonly,destructive,idempotent}`.
+For each registration, read the array literal forward until the
+matching close. Common shapes:
 
-For each registration, read the array literal from the starting line
-forward until the matching close paren. Inside, find:
+- Multi-line literal (most common).
+- Short-form one-liner.
+- Helper method (`'annotations' => self::annotations_for_read()`) —
+  resolve the helper if it returns a literal; otherwise mark
+  `<unresolved>` and run the adversarial check against the callback
+  alone.
+- Class constant (`'annotations' => self::READONLY_ANNOTATIONS`) —
+  resolve the constant.
 
-```php
-'annotations' => [
-    'readonly'    => true,
-    'destructive' => false,
-    'idempotent'  => true,
-],
-```
+Record `ability_name → declared_annotations`.
 
-Patterns to handle:
-
-### 3.1 — short-form one-liner
-
-```php
-'annotations' => [ 'readonly' => true, 'destructive' => false, 'idempotent' => true ],
-```
-
-### 3.2 — multi-line (most common)
-
-Use a multi-line regex or read lines until the next `],`:
-
-```bash
-grep -nE "'(readonly|destructive|idempotent)'\s*=>\s*(true|false)" <file>
-```
-
-### 3.3 — values via variables
-
-```php
-'annotations' => self::annotations_for_read(),
-```
-
-Resolve the helper method. If it returns an array literal, treat as
-resolvable. If it builds the array dynamically, record the ability with
-`annotations: <unresolved>` and flag: the adversarial checks can still
-run against the execute callback, but the declared annotations can't be
-compared statically — runtime mode required for that comparison.
-
-### 3.4 — inherited / constant annotations
-
-```php
-'annotations' => self::READONLY_ANNOTATIONS,
-```
-
-Find the class constant; treat as resolvable.
-
-## Step 4 — follow the execute callback to its body
+## Step 4 — follow `execute_callback` to its body
 
 `execute_callback` is one of:
 
 ```php
-// Array form (most common with static class method).
-'execute_callback' => [ self::class, 'execute_get_things' ],
-'execute_callback' => [ My_Class::class, 'execute_get_things' ],
-'execute_callback' => [ $this, 'execute_get_things' ],
-
-// String form (top-level function).
-'execute_callback' => 'my_plugin_execute_get_things',
-
-// Closure.
-'execute_callback' => function( $input ) { /* ... */ },
+'execute_callback' => array( self::class, 'execute_get_things' ),
+'execute_callback' => array( My_Class::class, 'execute_get_things' ),
+'execute_callback' => array( $this, 'execute_get_things' ),
+'execute_callback' => 'my_plugin_execute_get_things',  // top-level function
+'execute_callback' => function ( $input ) { /* ... */ },  // closure
 ```
 
-For each form:
-
-- **Array form**: find `class <name>` in the plugin, then
-  `(public|protected|private)( static)?\s+function\s+<method>\s*\(` inside
-  that class. Record the file + start line + end line (find the matching
-  `}` — use the brace-matching heuristic).
-- **String form**: grep for `function <name>\s*\(`.
-- **Closure**: the body is literally inline in the registration; the
-  start line is the `function(` line, the end line is the matching `}`.
-
-Record per ability: `ability_name → (callback_file, callback_start_line, callback_end_line)`.
-The annotation-correctness checks grep inside this range.
-
-## Step 5 — handle fluent builder patterns
-
-Some plugins wrap registrations in helper functions:
-
-```php
-register_get_foo_ability();
-register_get_bar_ability();
-
-function register_get_foo_ability() {
-    wp_register_ability(
-        'myplugin/get-foo',
-        [ /* ... */ ]
-    );
-}
-```
-
-The `grep 'wp_register_ability'` still finds these — they're one level of
-indirection but still literal. No special handling needed.
-
-The trickier pattern:
-
-```php
-foreach ( [ 'foo', 'bar', 'baz' ] as $slug ) {
-    wp_register_ability( "myplugin/get-{$slug}", [ /* ... */ ] );
-}
-```
-
-Here the ability name is dynamic. Record each computed name as a
-limitation and recommend runtime enumeration.
-
-## Step 6 — handle `input_schema` via helper methods
-
-```php
-'input_schema' => self::input_schema_for_get_things(),
-```
-
-The schema lints in `schema-lints.md` need the actual schema. Resolve
-the helper; if it returns an array literal, use it. If the helper builds
-the schema conditionally, flag as unresolvable and skip the static schema
-lints for that ability (runtime mode via the `wp_get_ability(...)->get_input_schema()`
-API is authoritative).
-
-## Step 7 — handle heredoc callbacks (rare but real)
-
-A handful of plugins register abilities with inline heredoc SQL:
-
-```php
-'execute_callback' => function() {
-    global $wpdb;
-    return $wpdb->get_results( <<<SQL
-        SELECT ...
-    SQL );
-},
-```
-
-The grep patterns from `annotation-correctness.md` work on the PHP body,
-not the SQL inside the heredoc. A `SELECT` inside a heredoc is a read
-regardless; an `INSERT` or `UPDATE` inside a heredoc on a `readonly: true`
-ability is a lie. The regex in annotation-correctness catches
-`$wpdb->query(...UPDATE|INSERT|DELETE)` on a single line, but a heredoc
-spans lines. Use multi-line grep:
-
-```bash
-grep -PzoE '\$wpdb->query\s*\([^)]*<<<SQL[^S]*(UPDATE|INSERT|DELETE)' <file>
-```
-
-Document this as a known gap: single-line write patterns are reliably
-detected; multi-line heredoc writes require the multi-line grep variant
-above.
+Resolve the reference to its source location: file + start line + end
+line. The annotation-correctness, schema-lint, and permission checks
+all operate on that byte range.
 
 ## Limits of static enumeration
 
-Cases where static enumeration produces incomplete or ambiguous output:
+Cases where the inventory is incomplete or ambiguous:
 
 - Variable-indirected names (`foreach` over a slug list).
-- Variable-indirected annotations (annotations built from config).
-- Conditional registration (`if ( feature_enabled() ) wp_register_ability(...)`).
-- Variable-indirected callbacks (`[ $this, $callback_name ]`).
+- Variable-indirected annotations (built from config).
+- Conditional registration (`if ( feature_enabled() )`).
+- Variable-indirected callbacks (`array( $this, $callback_name )`).
 
-Every case above gets recorded in the report's "Static enumeration
-limitations" section. When these occur, recommend the caller re-run in
-runtime mode to get the authoritative inventory from
-`wp_get_abilities()`.
+Record each in the report's "Static enumeration limitations" section
+and recommend a runtime-mode rerun for the authoritative inventory.
 
 ## Output format
 
@@ -276,8 +124,3 @@ Found <N> ability registrations across <M> files:
 - <ability>: annotations built dynamically in `annotations_for_read()`;
   recommend runtime mode for annotation cross-check.
 ```
-
-This inventory is the input to the annotation-correctness, schema-lint,
-permission-roundtrip, and error-code-vocabulary checks. Each of those
-references operates on the `(callback_file, callback_start_line,
-callback_end_line)` byte range.


### PR DESCRIPTION
Adds the `wp-abilities-verify` skill — checks a plugin's Abilities API registrations against the structural and behavioral promises they declare. The centerpiece is **adversarial annotation correctness**: a `readonly: true` ability whose execute callback actually writes (via `$wpdb->update`, `update_option`, `wp_insert_*`, a non-GET delegate, etc.) is the bug class that unit tests don't catch — the mock looks just like the real writer. Stacks on #46 (merged #44 is in `trunk` as `26aa4e8`).

## What lands

| File | Purpose |
|---|---|
| `skills/wp-abilities-verify/SKILL.md` | Two modes (static, runtime). Seven-step procedure: validate audit doc → enumerate statically → enumerate at runtime (runtime mode) → annotation correctness → permission roundtrip → schema lints → error-code vocabulary. Static-mode blind spots called out so a static PASS isn't read as "verified write-free." |
| `references/static-enumeration.md` | Find `wp_register_ability(` calls (multi-line via `rg --multiline --pcre2`), extract names + annotation blocks, follow `execute_callback` to its body. |
| `references/annotation-correctness.md` | The adversarial core. Three-claims table anchored in the `idempotent` annotation's docblock in `class-wp-ability.php` and `WP_REST_Abilities_V1_Run_Controller::validate_request_method()`. Common write patterns as a starting set; blind spots (indirected service writes, hooks-as-writes, variable-built HTTP methods, tautological caps); the `// verify-ignore` suppression mechanism. |
| `references/schema-lints.md` | Six lint principles applied to each ability's `input_schema`. |
| `references/permission-roundtrip.md` | What `permission_callback` actually receives (validated input value, never a `WP_REST_Request` — the antipattern ships in plugins copied from REST controllers without translation). Six callback shapes (A-F) classified OK / WARN / FAIL. Runnable wp-cli block exercising the gate against anon / subscriber / admin contexts. |
| `references/runtime-harness.md` | Six wp-cli checks against a booted WordPress: name match, annotation read-back, read execute (split into Level 1 smoke / Level 2 high-confidence using `seed_data_needs` from the audit), write input validation, permission gate, idempotency twin-invocation heuristic. All execute-checks go through `wp_get_ability( $name )->execute( ... )` — verification through the public boundary by design. |
| `references/audit-schema-validation.md` | Delegates to the canonical schema in `wp-abilities-audit/references/audit-schema.md`; picks up #46's three new required fields automatically post-rebase. |
| `eval/scenarios/wp-abilities-verify.json` | Scenario where one read ability accidentally calls `$wpdb->update`; success criteria require FAIL with file + line evidence. |

## Verification at tip

- WP core symbols (`WP_Ability::*`, `WP_REST_Abilities_V1_Run_Controller::validate_request_method`, `wp_register_ability`, `wp_get_ability`, `wp_get_abilities`, etc.) verified against `WordPress/wordpress-develop` trunk.
- PHP code blocks parse on PHP 7.2.
- `node eval/harness/run.mjs` passes.

## Status

Round 4 (current tip). Iteration:

- **Round 1** — original scope.
- **Round 2** (`c5f962a..d8ea032`) — five focused fixes against @nerrad's review: `idempotent` wording aligned to core's docblock; `(object) array()` accepted in Lint 5; mutator-verb regex broadened; multi-line `wp_register_ability` handled; README updated.
- **Round 3** (`dad0196..f0070f6`) — ~650 lines net cut per @nerrad's "ship lighter; iterate from real usage" guidance. References now read as principles + a few examples + agent-derived patterns rather than exhaustive catalogues. Runnable harnesses preserved as concrete runbooks.
- **Round 4** (`b6e1bb4`) — addresses @nerrad's `#discussion_r3277906278` on `runtime-harness.md:127`. Splits Check 3 into Level 1 — smoke execution (synthetic inputs, prior content kept verbatim) and Level 2 — high-confidence verification (representative seeded data using `seed_data_needs` from the audit; asserts output shape AND privacy contract). When `seed_data_needs: null`, Level 2 reports `pending (ask the implementer)` — dovetails with #46's WARN-not-FAIL posture. Threaded reply posted.

Post-rebase follow-up (when #46 lands): one count update in `audit-schema-validation.md` ("All 7 required fields present" → generic, since the schema now has 10).

Rebased after #44 merged on 2026-05-26; once #45 and #46 merge, this PR's diff narrows to just the 25 verify-skill commits.


