### PR TITLE
Add wp-ai-client, wp-ai-connectors, wp-ai-plugin (WP 7.0+ AI surfaces)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Agent Skills solve this by giving AI assistants **expert-level WordPress knowled
 | **wp-rest-api** | REST API routes/endpoints, schema, auth, and response shaping |
 | **wp-interactivity-api** | Frontend interactivity with `data-wp-*` directives and stores |
 | **wp-abilities-api** | Capability-based permissions and REST API authentication |
+| **wp-ai-client** | Build AI features on WP 7.0+ using `wp_ai_client_prompt()` and the in-core AI Client |
+| **wp-ai-connectors** | Register a new AI provider with the WP 7.0+ Connectors API (Settings → Connectors) |
+| **wp-ai-plugin** | Extend the canonical AI plugin (`WordPress/ai`) with Experiments, paired Abilities, and Guidelines |
 | **wp-wpcli-and-ops** | WP-CLI commands, automation, multisite, search-replace |
 | **wp-performance** | Profiling, caching, database optimization, Server-Timing |
 | **wp-phpstan** | PHPStan static analysis for WordPress projects (config, baselines, WP-specific typing) |

--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -4,10 +4,10 @@ This repo is an authoring workspace for WordPress-focused Agent Skills.
 
 ## Compatibility contract (v1)
 
-Skills in this repo target:
+Skills in this repo target one of two floors:
 
-- WordPress core **6.9+**
-- PHP **7.2.24+** (minimum supported by WordPress 6.9)
+- **Default floor** — WordPress core **6.9+** with PHP **7.2.24+** (minimum supported by WordPress 6.9). Use this for skills covering APIs available on 6.9.
+- **WP 7.0+ floor** — WordPress core **7.0+** with PHP **7.4+**. Use this only for skills covering features unavailable on 6.9 (e.g., the AI Client, the Connectors API, the client-side Abilities API).
 
 ## Authoring rules
 
@@ -15,4 +15,5 @@ Skills should:
 
 - Prefer stable WordPress APIs and best practices.
 - Prefer detection + guardrails (triage) over hard-coded assumptions.
-- If a task requires behavior that differs across core versions, ask for a target version (but default guidance should assume WP 6.9+).
+- If a task requires behavior that differs across core versions, ask for a target version (but default guidance should assume WP 6.9+ unless the skill is on the 7.0+ floor).
+- Skills targeting 7.0-only features should explicitly say so in the SKILL.md description and use the 7.0+ compatibility line.

--- a/docs/skill-set-v1.md
+++ b/docs/skill-set-v1.md
@@ -10,6 +10,9 @@ This repo currently includes:
 - `wp-rest-api`
 - `wp-interactivity-api`
 - `wp-abilities-api`
+- `wp-ai-client`
+- `wp-ai-connectors`
+- `wp-ai-plugin`
 - `wp-wpcli-and-ops`
 - `wp-performance`
 - `wp-phpstan`

--- a/eval/harness/run.mjs
+++ b/eval/harness/run.mjs
@@ -111,9 +111,13 @@ function main() {
       compatibility.length <= 500,
       `Compatibility too long in ${path.relative(repoRoot, skillPath)} (${compatibility.length} chars)`
     );
+    const matchesLegacyBaseline =
+      compatibility.includes("WordPress 6.9") && compatibility.includes("PHP 7.2.24");
+    const matchesAiEraBaseline =
+      compatibility.includes("WordPress 7.0") && compatibility.includes("PHP 7.4");
     assert(
-      compatibility.includes("WordPress 6.9") && compatibility.includes("PHP 7.2.24"),
-      `Compatibility contract mismatch in ${path.relative(repoRoot, skillPath)} (expected WP 6.9 + PHP 7.2.24+)`
+      matchesLegacyBaseline || matchesAiEraBaseline,
+      `Compatibility contract mismatch in ${path.relative(repoRoot, skillPath)} (expected WP 6.9 + PHP 7.2.24+ or WP 7.0 + PHP 7.4+)`
     );
   }
 

--- a/eval/scenarios/abilities-mcp-expose.json
+++ b/eval/scenarios/abilities-mcp-expose.json
@@ -1,0 +1,25 @@
+{
+  "name": "Expose existing plugin abilities to Claude Desktop via MCP",
+  "skills": ["wordpress-router", "wp-project-triage", "wp-abilities-api"],
+  "query": "My plugin already registers a few abilities via wp_register_ability — things like 'list pending comments', 'approve comment', 'mark as spam'. I want to expose them to Claude Desktop so I can moderate comments by talking to Claude. The site is on WordPress 7.0. What do I install, and what do I need to change about my abilities to make this work cleanly?",
+  "expected_behavior": [
+    "Step 1: Run wordpress-router to classify repo kind",
+    "Step 2: Run wp-project-triage to detect plugin structure",
+    "Step 3: Route to wp-abilities-api skill (point at references/mcp-exposure.md)",
+    "Step 4: Recommend installing the MCP Adapter via Composer (composer require wordpress/mcp-adapter); use Jetpack Autoloader if multiple plugins on the site depend on it",
+    "Step 5: Note that the default server (mcp-adapter-default-server) exposes everything; for production with mixed-trust abilities, register a custom server via the mcp_adapter_init action",
+    "Step 6: Audit existing abilities for proper meta.annotations: 'list pending comments' should be readonly:true, 'approve' should NOT be readonly (it mutates), 'mark as spam' should be destructive:true",
+    "Step 7: Ensure every ability has a permission_callback (especially destructive ones); MCP clients act as authenticated users",
+    "Step 8: Set up an Application Password for the Claude Desktop user; explain Settings → Permalinks must NOT be Plain",
+    "Step 9: Verify by hitting /wp-json/ for the namespace and connecting Claude Desktop to confirm tools appear"
+  ],
+  "success_criteria": [
+    "Routes to wp-abilities-api with mcp-exposure.md reference",
+    "Recommends Composer installation of wordpress/mcp-adapter (not the standalone plugin zip for production)",
+    "Mentions Jetpack Autoloader for multi-plugin scenarios",
+    "Audits annotations: readonly for read operations, destructive for spam/delete",
+    "Confirms permission_callback on all abilities (especially destructive ones)",
+    "Surfaces the Plain permalinks gotcha",
+    "Mentions Application Passwords as the practical local-dev auth method"
+  ]
+}

--- a/eval/scenarios/ai-client-add-feature-endpoint.json
+++ b/eval/scenarios/ai-client-add-feature-endpoint.json
@@ -1,0 +1,27 @@
+{
+  "name": "Add an AI summarize-paragraph feature using WP 7.0 AI Client",
+  "skills": ["wordpress-router", "wp-project-triage", "wp-ai-client"],
+  "query": "I'm building a WordPress plugin that targets WordPress 7.0. I want to add a 'rewrite this paragraph in plain English' button to the block editor sidebar. It should use whatever AI provider the site owner has configured (not bundle our own API key). Editors and authors should be able to use it on posts they can edit. What's the right way to wire this up?",
+  "expected_behavior": [
+    "Step 1: Run wordpress-router to classify repo kind",
+    "Step 2: Run wp-project-triage to detect plugin structure",
+    "Step 3: Route to wp-ai-client skill",
+    "Step 4: Confirm WP 7.0+ via detect_ai_client.mjs (or note the requirement)",
+    "Step 5: Recommend a per-feature REST endpoint with permission_callback gating on edit_post (NOT the client-side prompt API which requires manage_options)",
+    "Step 6: Show wp_ai_client_prompt() with using_system_instruction() and an explicit user content payload via with_text()",
+    "Step 7: Use generate_text_result() and return via rest_ensure_response()",
+    "Step 8: Show conditional UI gating with is_supported_for_text_generation() before enqueueing scripts",
+    "Step 9: Document that credentials are handled by the Connectors API; do not handle API keys",
+    "Step 10: Mention using_abilities() as the function-calling tie-in if the feature would benefit from the model invoking registered abilities (links to wp-abilities-api)"
+  ],
+  "success_criteria": [
+    "Routes to wp-ai-client skill",
+    "Uses wp_ai_client_prompt() (not direct provider SDKs)",
+    "Recommends per-feature REST endpoint, not the client-side prompt API",
+    "Permission callback uses edit_post (or similar editor-level capability), not manage_options",
+    "Includes is_supported_for_text_generation() gate before showing UI",
+    "Returns the result via rest_ensure_response (handles WP_Error path)",
+    "Does not handle API keys; defers to Connectors API",
+    "Method names match the verified wp-ai-client/php-ai-client source: using_temperature/with_text/using_system_instruction/generate_text_result/is_supported_for_text_generation, and the wp_ai_client_prevent_prompt filter receives a clone of the builder (read-only)"
+  ]
+}

--- a/eval/scenarios/ai-connectors-register-provider.json
+++ b/eval/scenarios/ai-connectors-register-provider.json
@@ -1,0 +1,28 @@
+{
+  "name": "Build a Mistral provider plugin that registers with the AI Client",
+  "skills": ["wordpress-router", "wp-project-triage", "wp-ai-connectors"],
+  "query": "I want to build a WordPress plugin called 'AI Provider for Mistral' that adds Mistral as an option in the Settings → Connectors screen on WordPress 7.0. Site owners should set their Mistral API key like they would for the official Anthropic/Google/OpenAI providers. What do I need to register, and where?",
+  "expected_behavior": [
+    "Step 1: Run wordpress-router to classify repo kind",
+    "Step 2: Run wp-project-triage to detect plugin structure",
+    "Step 3: Route to wp-ai-connectors skill (not wp-ai-client — this is provider-side)",
+    "Step 4: Set the plugin header — Requires at least: 7.0 (or 6.9 with bundled wordpress/php-ai-client like the official plugins do), Requires PHP: 7.4",
+    "Step 5: Register via AiClient::defaultRegistry()->registerProvider( MistralProvider::class ) — class name string, NOT an instance, and the method is registerProvider() not register()",
+    "Step 6: Wrap registration in class_exists( AiClient::class ) and hasProvider() guards (verbatim pattern from ai-provider-for-anthropic/plugin.php)",
+    "Step 7: Hook on init priority 5 so registration runs BEFORE _wp_connectors_init at priority 10",
+    "Step 8: Note that the Connectors API auto-discovers the provider; do NOT manually call WP_Connector_Registry::register() for the new provider — that's only for overrides via wp_connectors_init",
+    "Step 9: Document the API key naming convention: setting connectors_ai_mistral_api_key, env/constant MISTRAL_API_KEY",
+    "Step 10: Mention that Settings → Connectors only renders ai_provider type connectors with api_key/none auth in WP 7.0",
+    "Step 11: Point at the three flagship provider plugins (Anthropic/Google/OpenAI) as canonical bootstrap implementations"
+  ],
+  "success_criteria": [
+    "Routes to wp-ai-connectors skill",
+    "Uses AiClient::defaultRegistry()->registerProvider() (not ->register(); not on WP_Connector_Registry)",
+    "Passes a class name string (MistralProvider::class), not an instance (new MistralProvider())",
+    "Includes class_exists( AiClient::class ) and hasProvider() guards",
+    "Hooks on init at priority < 10 (canonical: priority 5)",
+    "Does not manually call WP_Connector_Registry::register() for the new provider (auto-discovery)",
+    "Documents the connectors_ai_{id}_api_key naming convention and the env/constant/database priority order",
+    "References the official provider plugins (especially ai-provider-for-anthropic/plugin.php) as the canonical bootstrap"
+  ]
+}

--- a/eval/scenarios/ai-plugin-register-experiment.json
+++ b/eval/scenarios/ai-plugin-register-experiment.json
@@ -1,0 +1,33 @@
+{
+  "name": "Add an internal-link suggestion Experiment to the canonical AI plugin",
+  "skills": ["wordpress-router", "wp-project-triage", "wp-ai-plugin", "wp-abilities-api"],
+  "query": "I want to add an Experiment to the canonical WordPress AI plugin (the one at github.com/WordPress/ai, version 0.8.0) that suggests internal links for a post based on its content. It should appear in Settings → AI like the other Experiments, register an Ability so it's also reachable via REST and MCP, and respect the site's Guidelines if they're configured. Walk me through the structure.",
+  "expected_behavior": [
+    "Step 1: Run wordpress-router to classify repo kind",
+    "Step 2: Run wp-project-triage to detect that this is the AI plugin source (or a downstream plugin extending it)",
+    "Step 3: Route to wp-ai-plugin skill (with wp-abilities-api as a secondary reference for the Ability registration step)",
+    "Step 4: Open the canonical example: includes/Experiments/Example_Experiment/Example_Experiment.php — copy its shape",
+    "Step 5: Gate downstream code on function_exists('wp_supports_ai') && wp_supports_ai()",
+    "Step 6: Subclass WordPress\\AI\\Abstracts\\Abstract_Feature (NOT WP\\AI\\Features\\Abstract_Feature — that namespace is wrong)",
+    "Step 7: Implement the three abstract methods: public static get_id(), protected load_metadata() returning [label, description, category, optional stability], public register()",
+    "Step 8: Use Experiment_Category::EDITOR (since post-editor surface) for the category",
+    "Step 9: Register the Experiment via the wpai_default_feature_classes filter (preferred) OR wpai_register_features action — both documented in includes/Features/Loader.php",
+    "Step 10: Inside the Experiment's register() method, hook wp_abilities_api_init to call wp_register_ability('ai/internal-links', [label, description, ability_class => Internal_Links_Ability::class])",
+    "Step 11: Create a paired Internal_Links_Ability extending WordPress\\AI\\Abstracts\\Abstract_Ability with input_schema, output_schema, execute_callback, permission_callback, meta",
+    "Step 12: Override guideline_categories() on the Ability to return ['site', 'copy'] — Abstract_Ability handles the Guidelines integration automatically via load_system_instruction_from_file()",
+    "Step 13: Test: Settings → AI shows the Experiment; toggle persists; with AI plugin disabled, downstream code no-ops cleanly"
+  ],
+  "success_criteria": [
+    "Routes to wp-ai-plugin (and wp-abilities-api for the Ability step)",
+    "Uses the correct namespace WordPress\\AI\\Abstracts\\Abstract_Feature (NOT WP\\AI\\Features\\Abstract_Feature)",
+    "References Example_Experiment.php as the canonical 'copy this' starting point",
+    "Includes function_exists('wp_supports_ai') && wp_supports_ai() gate",
+    "Implements the three abstract methods with correct signatures (get_id static, load_metadata protected returning array with label+description+category, register public)",
+    "Uses Experiment_Category constants (EDITOR or ADMIN), not raw strings",
+    "Registers via wpai_default_feature_classes filter or wpai_register_features action (NOT a fabricated 'wp_ai_register_features' action or singleton like Registry::instance())",
+    "Pairs with an Abstract_Ability subclass — does not put prompt logic in the Experiment class itself",
+    "Sets guideline_categories() on the Ability (NOT a fabricated procedural call like wp_ai_guidelines_get_for_context())",
+    "Knows the WPAI_* constant names: WPAI_VERSION, WPAI_PLUGIN_FILE, WPAI_PLUGIN_DIR, WPAI_PLUGIN_URL (NOT WPAI_FILE/WPAI_PATH/WPAI_URL — those are wrong)",
+    "Acknowledges that there is no AI-plugin-specific dashboard widgets framework — uses standard wp_add_dashboard_widget() if needed"
+  ]
+}

--- a/skills/wordpress-router/references/decision-tree.md
+++ b/skills/wordpress-router/references/decision-tree.md
@@ -23,8 +23,16 @@ Route by intent even if repo kind is broad (like `wp-site`):
 
 - **Interactivity API / data-wp-* directives / @wordpress/interactivity / viewScriptModule**
   - Route → `wp-interactivity-api`.
-- **Abilities API / wp_register_ability / wp-abilities/v1 / @wordpress/abilities**
+- **AI Client / wp_ai_client_prompt / WP_AI_Client_Prompt_Builder / generate_text_result / using_model_preference / WP 7.0 AI**
+  - Route → `wp-ai-client`.
+- **AI provider plugin / Connectors API / Settings → Connectors / wp_connectors_init / WP_Connector_Registry / wp_get_connector / connectors_ai_*_api_key / `_ai_` prefix**
+  - Route → `wp-ai-connectors`.
+- **AI plugin (canonical) / WordPress/ai / Abstract_Feature / Experiments framework / WPAI_* / wp_supports_ai / Refine from Notes / dashboard AI widgets / Guidelines integration / ai-wp-admin**
+  - Route → `wp-ai-plugin`.
+- **Abilities API / wp_register_ability / wp-abilities/v1 / @wordpress/abilities / @wordpress/core-abilities / executeAbility / core/abilities store**
   - Route → `wp-abilities-api`.
+- **MCP Adapter / mcp_adapter_init / mcp-adapter-default-server / expose abilities to Claude Desktop / Cursor / ChatGPT via MCP**
+  - Route → `wp-abilities-api` (see `references/mcp-exposure.md`).
 - **Playground / run-blueprint / build-snapshot / @wp-playground/cli / playground.wordpress.net**
   - Route → `wp-playground`.
 - **Blocks / block.json / registerBlockType / attributes / save serialization**

--- a/skills/wp-abilities-api/SKILL.md
+++ b/skills/wp-abilities-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wp-abilities-api
-description: "Use when working with the WordPress Abilities API (wp_register_ability, wp_register_ability_category, /wp-json/wp-abilities/v1/*, @wordpress/abilities) including defining abilities, categories, meta, REST exposure, and permissions checks for clients."
+description: "Use when working with the WordPress Abilities API (wp_register_ability, wp_register_ability_category, /wp-json/wp-abilities/v1/*, @wordpress/abilities, @wordpress/core-abilities) including defining abilities, categories, meta, REST exposure, permissions checks for clients, the WP 7.0+ client-side JS API (registerAbility, executeAbility, the core/abilities store), and exposing abilities to external AI agents via the MCP Adapter (Claude Desktop, Cursor, ChatGPT)."
 compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Filesystem-based agent with bash + node. Some workflows require WP-CLI."
 ---
 
@@ -65,8 +65,14 @@ Use the documented init hooks for Abilities API registration so they load at the
 
 ### 6) Consume from JS (if needed)
 
-- Prefer `@wordpress/abilities` APIs for client-side access and checks.
-- Ensure build tooling includes the dependency and the project’s build pipeline bundles it.
+- For the WP 7.0+ client-side surface (registering abilities in JS, the `core/abilities` store, `executeAbility`, and how annotations affect the HTTP method used to dispatch server abilities), see `references/client-side.md`.
+- Two packages: `@wordpress/abilities` (pure store, registration, execution) and `@wordpress/core-abilities` (auto-loads server-registered abilities into the client store). Enqueue via `wp_enqueue_script_module()`.
+- WordPress core enqueues `@wordpress/core-abilities` on all admin pages, so server abilities are available there by default.
+- For older clients or non-WP 7.0 contexts, prefer `@wordpress/abilities` APIs for client-side access and checks; ensure the build pipeline bundles the dependency.
+
+### 7) Expose via MCP for external AI agents (optional)
+
+If external agents (Claude Desktop, Cursor, ChatGPT) should be able to discover and invoke your abilities, install the MCP Adapter (`composer require wordpress/mcp-adapter`). The adapter reads everything registered with `wp_register_ability()`, respects `permission_callback`, and maps `meta.annotations` (`readonly`, `destructive`, `idempotent`) to the corresponding MCP tool annotations. The default server (`mcp-adapter-default-server`) exposes everything; register a custom server via the `mcp_adapter_init` action when you need an allow-list. See `references/mcp-exposure.md`.
 
 ## Verification
 
@@ -93,3 +99,5 @@ Use the documented init hooks for Abilities API registration so they load at the
 - For canonical details, consult:
   - `references/rest-api.md`
   - `references/php-registration.md`
+  - `references/client-side.md` (WP 7.0+ JavaScript API)
+  - `references/mcp-exposure.md` (MCP Adapter integration)

--- a/skills/wp-abilities-api/references/client-side.md
+++ b/skills/wp-abilities-api/references/client-side.md
@@ -1,0 +1,254 @@
+# Client-side Abilities API (WP 7.0+)
+
+WordPress 6.9 introduced the server-side Abilities API. WordPress 7.0 added the JavaScript counterpart, letting plugins register and execute abilities entirely on the client (e.g., navigating, inserting blocks) and consume server-registered abilities from JS.
+
+## Two packages, one store
+
+- **`@wordpress/abilities`** — pure state management, no server dependencies. Provides the store, registration, querying, and execution. Use when you only need the store; works in non-WordPress contexts too.
+- **`@wordpress/core-abilities`** — the WordPress integration layer. When loaded, it auto-fetches all server-registered abilities and categories via `/wp-abilities/v1/` and registers them in the `@wordpress/abilities` store with execution callbacks. Use this for the common case.
+
+## Enqueuing
+
+### Server abilities + client UI (most common)
+
+```php
+add_action( 'admin_enqueue_scripts', function () {
+    wp_enqueue_script_module( '@wordpress/core-abilities' );
+} );
+```
+
+This loads `@wordpress/core-abilities` plus its dependency `@wordpress/abilities`, and the server abilities show up in the store automatically. WordPress core enqueues `@wordpress/core-abilities` on all admin pages, so server abilities are available in the admin by default — you don't need to re-enqueue unless you're outside admin.
+
+### Client-only abilities on a specific page
+
+```php
+add_action( 'admin_enqueue_scripts', function ( $hook_suffix ) {
+    if ( 'my-plugin-page' !== $hook_suffix ) {
+        return;
+    }
+    wp_enqueue_script_module( '@wordpress/abilities' );
+} );
+```
+
+Skips the server fetch overhead when you only need client-registered abilities on one screen.
+
+## Importing in JS
+
+Dynamic import:
+
+```js
+const {
+    registerAbility,
+    registerAbilityCategory,
+    getAbilities,
+    executeAbility,
+} = await import( '@wordpress/abilities' );
+```
+
+Or, if your code is a script module compiled with `@wordpress/scripts`, a normal static import works:
+
+```js
+import {
+    registerAbility,
+    registerAbilityCategory,
+    getAbilities,
+    executeAbility,
+} from '@wordpress/abilities';
+```
+
+## Registering a category
+
+Categories must exist before abilities reference them. Server categories load automatically with `@wordpress/core-abilities`. Register client categories explicitly:
+
+```js
+const { registerAbilityCategory } = await import( '@wordpress/abilities' );
+
+registerAbilityCategory( 'my-plugin-actions', {
+    label: 'My Plugin Actions',
+    description: 'Actions provided by My Plugin',
+} );
+```
+
+Slug rules: lowercase alphanumeric with dashes only (e.g., `data-retrieval`, `user-management`). No underscores, no caps.
+
+## Registering an ability
+
+```js
+const { registerAbility } = await import( '@wordpress/abilities' );
+
+registerAbility( {
+    name: 'my-plugin/navigate-to-settings',
+    label: 'Navigate to Settings',
+    description: 'Navigates to the plugin settings page',
+    category: 'my-plugin-actions',
+    callback: async () => {
+        window.location.href = '/wp-admin/options-general.php?page=my-plugin';
+        return { success: true };
+    },
+} );
+```
+
+### Input/output schemas (recommended)
+
+JSON Schema (draft-04). Inputs are validated before `callback` runs; outputs are validated after. Validation failures throw `ability_invalid_input` or `ability_invalid_output`.
+
+```js
+registerAbility( {
+    name: 'my-plugin/create-item',
+    label: 'Create Item',
+    description: 'Creates a new item with the given title and content',
+    category: 'my-plugin-actions',
+    input_schema: {
+        type: 'object',
+        properties: {
+            title: { type: 'string', minLength: 1 },
+            content: { type: 'string' },
+            status: { type: 'string', enum: [ 'draft', 'publish' ] },
+        },
+        required: [ 'title' ],
+    },
+    output_schema: {
+        type: 'object',
+        properties: {
+            id: { type: 'number' },
+            title: { type: 'string' },
+        },
+        required: [ 'id' ],
+    },
+    callback: async ( { title, content, status = 'draft' } ) => {
+        // Implementation...
+        return { id: 123, title };
+    },
+} );
+```
+
+### Permission callback
+
+```js
+registerAbility( {
+    name: 'my-plugin/admin-action',
+    label: 'Admin Action',
+    description: 'An action only available to administrators',
+    category: 'my-plugin-actions',
+    permissionCallback: () => currentUserCan( 'manage_options' ),
+    callback: async () => ({ success: true }),
+} );
+```
+
+Returns false → throws `ability_permission_denied`.
+
+## Annotations
+
+Behavioral hints used by the runtime and (importantly) by the MCP Adapter when exposing the ability over MCP:
+
+| Annotation | Type | Description |
+| --- | --- | --- |
+| `readonly` | boolean | Reads only, no state change |
+| `destructive` | boolean | Performs destructive operations |
+| `idempotent` | boolean | Same result if called multiple times with same input |
+
+```js
+registerAbility( {
+    name: 'my-plugin/get-stats',
+    label: 'Get Stats',
+    description: 'Returns plugin statistics',
+    category: 'my-plugin-actions',
+    callback: async () => ({ views: 100 }),
+    meta: { annotations: { readonly: true } },
+} );
+```
+
+The MCP Adapter maps these to MCP tool annotations: `readonly` → `readOnlyHint`, `destructive` → `destructiveHint`, `idempotent` → `idempotentHint`. So getting these right pays off for both the local execution surface and any MCP-exposed external surface.
+
+## HTTP method routing for server abilities
+
+When `executeAbility` calls a server-registered ability through the REST API, the HTTP method is chosen from the ability's annotations:
+
+- `readonly: true` → `GET`
+- `destructive: true` + `idempotent: true` → `DELETE`
+- All other cases → `POST`
+
+This matters for caching, logging, and CSRF posture. A read-only ability should always be marked `readonly` so it gets `GET` and benefits from any HTTP caching layer.
+
+## Querying
+
+```js
+const {
+    getAbilities,
+    getAbility,
+    getAbilityCategories,
+    getAbilityCategory,
+} = await import( '@wordpress/abilities' );
+
+const all      = getAbilities();
+const filtered = getAbilities( { category: 'data-retrieval' } );
+const one      = getAbility( 'my-plugin/create-item' );
+const cats     = getAbilityCategories();
+const cat      = getAbilityCategory( 'data-retrieval' );
+```
+
+### Reactive queries with `@wordpress/data`
+
+The store registers via `@wordpress/data` and integrates with `useSelect`. Use `useSelect` for reactive queries in React:
+
+```jsx
+import { useSelect } from '@wordpress/data';
+import { store as abilitiesStore } from '@wordpress/abilities';
+
+function AbilitiesList() {
+    const abilities = useSelect(
+        ( select ) => select( abilitiesStore ).getAbilities(),
+        []
+    );
+    const dataAbilities = useSelect(
+        ( select ) => select( abilitiesStore ).getAbilities( { category: 'data-retrieval' } ),
+        []
+    );
+    // Updates automatically when the store changes.
+}
+```
+
+Use the imported `store` constant rather than referencing the store by string name. The string key differs by environment: the standalone `WordPress/abilities-api` plugin registers it as `'abilities-api/abilities'`; the WP 7.0 dev note documents it as `'core/abilities'`. Importing `store` sidesteps the discrepancy.
+
+## Executing
+
+```js
+import { executeAbility } from '@wordpress/abilities';
+
+try {
+    const result = await executeAbility( 'my-plugin/create-item', {
+        title: 'New Item',
+        content: 'Item content',
+        status: 'draft',
+    } );
+} catch ( error ) {
+    switch ( error.code ) {
+        case 'ability_permission_denied':
+        case 'ability_invalid_input':
+        case 'ability_invalid_output':
+            // Handle each appropriately.
+            break;
+        default:
+            console.error( 'Execution failed:', error.message );
+    }
+}
+```
+
+`executeAbility` works for both client- and server-registered abilities. For server abilities loaded via `@wordpress/core-abilities`, execution is dispatched over REST automatically using the method derived from annotations.
+
+## Unregistering
+
+```js
+const { unregisterAbility, unregisterAbilityCategory } = await import( '@wordpress/abilities' );
+
+unregisterAbility( 'my-plugin/navigate-to-settings' );
+unregisterAbilityCategory( 'my-plugin-actions' );
+```
+
+Only client-registered abilities and categories can be unregistered from the client. Server-registered ones are removed by unregistering on the server side.
+
+## Sources
+
+- Dev note: https://make.wordpress.org/core/2026/03/24/client-side-abilities-api-in-wordpress-7-0/
+- Server-side dev note (WP 6.9): https://make.wordpress.org/core/2025/11/10/abilities-api-in-wordpress-6-9/
+- WebMCP context (why this work matters for browser agents): https://github.com/WordPress/ai/pull/224

--- a/skills/wp-abilities-api/references/mcp-exposure.md
+++ b/skills/wp-abilities-api/references/mcp-exposure.md
@@ -1,0 +1,161 @@
+# Exposing abilities via the MCP Adapter
+
+The MCP Adapter (`WordPress/mcp-adapter`) bridges the Abilities API to the Model Context Protocol, letting external AI agents (Claude Desktop, Claude Code, Cursor, ChatGPT) discover and execute WordPress abilities as MCP tools, resources, and prompts.
+
+The adapter is a separate Composer package and plugin. WordPress 7.0 ships the Abilities API in core but does **not** ship the adapter. Install it explicitly when MCP exposure is required.
+
+## Installation
+
+The adapter is designed to be a Composer dependency, not a standalone plugin install for distributed use:
+
+```bash
+composer require wordpress/mcp-adapter
+```
+
+Then load it from your plugin's bootstrap. If multiple plugins on the same site depend on the adapter (likely as the ecosystem grows), use the Jetpack Autoloader to avoid version conflicts:
+
+```php
+require_once plugin_dir_path( __FILE__ ) . 'vendor/autoloader.php'; // Jetpack Autoloader
+```
+
+For local exploration / smoke testing, the standalone plugin zip from the [adapter's Releases page](https://github.com/WordPress/mcp-adapter/releases) is fine. Don't ship that to production with multiple consumers — version conflicts will bite.
+
+## How abilities become MCP tools
+
+Once the adapter is loaded:
+
+1. It reads everything registered via `wp_register_ability()`.
+2. By default, abilities become MCP **tools** (callable functions). Read-only abilities can be configured as MCP **resources** (data the agent ingests as context). Abilities with structured prompt-like outputs can be configured as MCP **prompts**.
+3. The adapter respects the ability's `permission_callback` — agents can only invoke what the authenticated user is authorized to do.
+4. The ability's `input_schema` and `output_schema` translate directly into the MCP tool's input and output schemas.
+5. The ability's annotations map to MCP annotations: `readonly` → `readOnlyHint`, `destructive` → `destructiveHint`, `idempotent` → `idempotentHint`.
+
+So a well-shaped ability — namespaced ID, label, description, schemas, permission callback, accurate annotations — becomes a well-shaped MCP tool with no extra work.
+
+## Default server vs custom server
+
+On activation, the adapter registers a default MCP server (`mcp-adapter-default-server`) with three core abilities for inspection and execution:
+
+- `mcp-adapter/discover-abilities` — list all available abilities
+- `mcp-adapter/get-ability-info` — inspect a single ability's schema
+- `mcp-adapter/execute-ability` — run any ability
+
+(Ability names follow the `namespace/ability` convention — slash, not hyphen, between the two parts. They register inside the `mcp-adapter` ability namespace.)
+
+This is enough for most use cases — point an MCP client at the default server and it can discover and call every server-registered ability on the site.
+
+For finer control (exposing only a subset, separating tool/resource/prompt categorization, server-level metadata), register a custom server. **`create_server()` has 13 parameters in current source (v0.5.0+); the 7th is required and takes an array of transport class names, not a config array.** The signature and convention follow what `DefaultServerFactory::create()` does internally:
+
+```php
+use WP\MCP\Core\McpAdapter;
+use WP\MCP\Transport\Http\HttpTransport;
+use WP\MCP\Infrastructure\ErrorHandling\Implementations\ErrorLogMcpErrorHandler;
+use WP\MCP\Infrastructure\Observability\Implementations\NullMcpObservabilityHandler;
+
+add_action( 'mcp_adapter_init', function ( McpAdapter $adapter ) {
+    $adapter->create_server(
+        'my-plugin-server',                           // server_id
+        'my-plugin/v1',                               // server_route_namespace
+        'mcp',                                        // server_route
+        'My Plugin MCP Server',                       // server_name
+        'Tools for managing my plugin',               // server_description
+        '1.0.0',                                      // server_version
+        array( HttpTransport::class ),                // mcp_transports (required, array of class strings)
+        ErrorLogMcpErrorHandler::class,               // error_handler (class string or null)
+        NullMcpObservabilityHandler::class,           // observability_handler (optional, class string)
+        array(                                        // tools (ability names to expose)
+            'my-plugin/list-comments',
+            'my-plugin/approve-comment',
+            'my-plugin/mark-as-spam',
+        ),
+        array(),                                      // resources (ability names)
+        array(),                                      // prompts (ability names)
+        null                                          // transport_permission_callback (defaults to is_user_logged_in)
+    );
+} );
+```
+
+`create_server()` enforces that it can only be called inside the `mcp_adapter_init` action — calling it elsewhere triggers `_doing_it_wrong()`. The function returns either an `McpAdapter` instance or a `WP_Error`.
+
+Read the `create_server()` docblock in `includes/Core/McpAdapter.php` for the complete parameter documentation, and `includes/Servers/DefaultServerFactory.php` for the canonical "how to call it" example.
+
+## Customizing the default server (without replacing it)
+
+Two filters let you tune the default server without writing a custom one:
+
+- **`mcp_adapter_default_server_config`** — receives the default config array and lets you override any of: `server_id`, `server_route_namespace`, `server_route`, `server_name`, `server_description`, `server_version`, `mcp_transports`, `error_handler`, `observability_handler`, `tools`, `resources`, `prompts`. Useful for restricting which abilities the default server exposes.
+
+  ```php
+  add_filter( 'mcp_adapter_default_server_config', function ( array $config ): array {
+      // Allow-list which abilities the default server exposes.
+      $config['tools'] = array( 'core/get-site-info', 'core/get-user-info' );
+      return $config;
+  } );
+  ```
+
+- **`mcp_adapter_create_default_server`** — return `false` to skip default server creation entirely. Use when you want only your custom servers exposed.
+
+  ```php
+  add_filter( 'mcp_adapter_create_default_server', '__return_false' );
+  ```
+
+## Permalinks requirement
+
+The MCP Adapter's HTTP transport uses REST API endpoints. **Plain permalinks break the routing.** Site owners need to set permalinks to anything other than Plain (Post name is the typical recommendation). If your plugin requires the adapter, document this in your readme and consider a `wp_admin_notice` when Plain is detected:
+
+```php
+if ( '' === get_option( 'permalink_structure' ) ) {
+    add_action( 'admin_notices', function () {
+        echo '<div class="notice notice-warning"><p>';
+        esc_html_e( 'My Plugin: change Settings → Permalinks away from Plain to enable MCP.', 'my-plugin' );
+        echo '</p></div>';
+    } );
+}
+```
+
+## Authentication for HTTP transport
+
+External agents authenticate via WordPress's standard mechanisms. For Claude Desktop, Cursor, and similar local clients, **Application Passwords** are the practical default:
+
+1. Users → Profile → Application Passwords → create one for "My MCP Server".
+2. Copy the generated password (shown once).
+3. The MCP client uses it as basic auth or a bearer credential, depending on the client.
+
+For self-hosted scenarios with stricter requirements, the adapter supports JWT and OAuth in different deployments — but the canonical pattern documented in the WordPress.com MCP work is OAuth 2.1 with browser-based authorization. Production setups should use that rather than long-lived application passwords.
+
+## STDIO transport
+
+For local development and CLI integration, the adapter ships a STDIO transport. WP-CLI commands wrap it. This is the right transport for:
+
+- Local Claude Code / Claude Desktop integration via the standard MCP STDIO config
+- Testing abilities without setting up auth
+- Scripted agent runs against a local site
+
+HTTP transport is the right choice for production, remote sites, and any case where the AI client and the WordPress site aren't on the same machine.
+
+## Verifying the server
+
+A quick way to confirm the MCP server is registered: hit the WordPress REST API root (`/wp-json/`) and look for your server's namespace. If it shows up, the server registered. If it doesn't, the server creation hook didn't fire or the ID conflicted.
+
+For a more thorough check, connect an MCP client (Claude Desktop, MCP Inspector, or similar) and:
+
+1. Confirm the client lists your tools (your registered abilities).
+2. Inspect a tool's schema and confirm it matches your `input_schema` declaration.
+3. Execute a tool and confirm `permission_callback` enforcement.
+
+## Security posture
+
+MCP clients act as authenticated WordPress users. An overly permissive ability is the same risk as giving an external service the user's credentials.
+
+- **Default-deny.** Don't expose abilities you haven't reviewed for safety. Use a custom server with an explicit allow-list rather than the default server in production.
+- **Discipline `permission_callback`.** Every write or destructive ability needs one. Read-only abilities should still have one if they expose anything sensitive.
+- **Mark annotations honestly.** `readonly: true` on an ability that actually mutates state misleads both human reviewers and the MCP client's safety logic.
+- **Test with an unprivileged user.** If you've been testing as administrator, your permission callbacks are probably under-tested. Create an editor or author user, regenerate an Application Password for them, and verify the client only sees what they're allowed to do.
+
+## Sources
+
+- MCP Adapter repo: https://github.com/WordPress/mcp-adapter
+- Adapter releases: https://github.com/WordPress/mcp-adapter/releases
+- Developer Blog walkthrough: https://developer.wordpress.org/news/2026/02/from-abilities-to-ai-agents-introducing-the-wordpress-mcp-adapter/
+- Make/AI overview of MCP: https://make.wordpress.org/ai/2025/07/17/mcp-adapter/
+- Archived predecessor (do not use for new work): https://github.com/Automattic/wordpress-mcp

--- a/skills/wp-ai-client/SKILL.md
+++ b/skills/wp-ai-client/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: wp-ai-client
+description: "Use when building AI features in a WordPress plugin or theme on WordPress 7.0+ using the in-core AI Client (`wp_ai_client_prompt()`, `WP_AI_Client_Prompt_Builder`). Covers prompt construction, model preferences, REST endpoint patterns for exposing AI features to JS, error handling, and feature detection. Use this — not direct provider SDKs — when the user asks to add text/image/speech/video generation to a WordPress site."
+compatibility: "Targets WordPress 7.0+ (PHP 7.4+). Filesystem-based agent with bash + node. Some workflows require WP-CLI."
+---
+
+# WP AI Client
+
+## When to use
+
+Use this skill when the task involves:
+
+- adding an AI-powered feature (text, image, speech, video generation) to a plugin or theme on WP 7.0+,
+- replacing direct calls to OpenAI/Anthropic/Google SDKs with the provider-agnostic in-core API,
+- migrating from the standalone `wordpress/php-ai-client` or `wordpress/wp-ai-client` Composer packages now that 7.0 bundles them,
+- exposing an AI feature to the block editor or custom JS via a REST endpoint,
+- diagnosing "the model isn't responding" / "no provider configured" / "feature shows but never works".
+
+If the task is to write a *provider plugin* (e.g., adding a new AI service), route to `wp-ai-connectors` instead.
+
+## Inputs required
+
+- Repo root (run `wordpress-router` and `wp-project-triage` first).
+- Target WP version: this skill is **WP 7.0+ only**. If the project must support 6.x, see the migration section in `references/prompt-builder.md`.
+- Whether the feature runs server-side (PHP only), client-side (JS), or both.
+- Which modality is needed (text / image / speech / video).
+
+## Procedure
+
+### 0) Triage and confirm WP 7.0+
+
+1. Run triage: `node skills/wp-project-triage/scripts/detect_wp_project.mjs`
+2. Detect AI Client availability: `node skills/wp-ai-client/scripts/detect_ai_client.mjs`
+
+If the project's `Requires at least` is `< 7.0`, decide: bump the requirement (recommended), or use the conditional autoloader pattern in `references/prompt-builder.md#migration` to keep older versions working.
+
+### 1) Check feature support before showing UI
+
+Never assume an AI feature will work just because WP 7.0 is installed — site owners may have no provider configured, or their provider may not support every modality. Use `is_supported_for_*()` builder methods, which run synchronously and incur no API cost:
+
+```php
+$builder = wp_ai_client_prompt( 'test' )->using_temperature( 0.7 );
+if ( ! $builder->is_supported_for_text_generation() ) {
+    return; // Skip registering UI.
+}
+```
+
+Conditionally enqueue scripts, hide blocks, or render a notice based on this check. See `references/prompt-builder.md#feature-detection` for all support methods.
+
+### 2) Build the prompt with the fluent builder
+
+Entry point is `wp_ai_client_prompt( $optional_text )`, which returns a `WP_AI_Client_Prompt_Builder`. Chain configuration, then call a generator:
+
+```php
+$result = wp_ai_client_prompt( 'Summarize the following post.' )
+    ->using_system_instruction( 'You are a concise WordPress editor.' )
+    ->using_temperature( 0.3 )
+    ->using_model_preference( 'claude-sonnet-4-6', 'gpt-5.4', 'gemini-3.1-pro-preview' )
+    ->generate_text_result();
+```
+
+Model preferences are *preferences*, not requirements. The Client falls back to any compatible model. See `references/prompt-builder.md` for the full method list (with_text/with_file/with_history, using_max_tokens/top_p/top_k/stop_sequences, as_json_response, as_output_modalities).
+
+### 3) Expose to JS via a per-feature REST endpoint
+
+Do **not** use the client-side JS prompt API in distributed plugins — it requires `manage_options` and lets the caller send any prompt to any configured provider. Instead, register a REST endpoint scoped to your single feature, with a tight permission callback:
+
+```php
+register_rest_route( 'my-plugin/v1', '/summarize', array(
+    'methods'             => 'POST',
+    'permission_callback' => fn() => current_user_can( 'edit_posts' ),
+    'callback'            => 'my_plugin_rest_summarize',
+    'args'                => array(
+        'content' => array( 'required' => true, 'type' => 'string' ),
+    ),
+) );
+
+function my_plugin_rest_summarize( WP_REST_Request $request ) {
+    $result = wp_ai_client_prompt( 'Summarize: ' . $request->get_param( 'content' ) )
+        ->generate_text_result();
+    return rest_ensure_response( $result );
+}
+```
+
+`GenerativeAiResult` and `WP_Error` both serialize cleanly through `rest_ensure_response()`, with the right HTTP status code attached automatically on errors. See `references/rest-patterns.md`.
+
+### 4) Handle errors
+
+Generator methods return `WP_Error` on failure (no exceptions — the WordPress wrapper catches them). Always check:
+
+```php
+$result = wp_ai_client_prompt( $prompt )->generate_text_result();
+if ( is_wp_error( $result ) ) {
+    return $result; // Pass through to REST or log.
+}
+```
+
+The `wp_ai_client_prevent_prompt` filter lets you block specific prompts before they execute (useful for capability gating, content policies, dev-mode kill switches). See `references/error-handling.md`.
+
+### 5) Credentials are someone else's problem
+
+Do not handle API keys. The Connectors API (in core) reads keys from env var → PHP constant → database (in that order) and the **Settings → Connectors** screen surfaces them to admins. If you need to hint to site owners that no provider is set up, use feature detection (step 1) plus a link to `Settings → Connectors`.
+
+### 6) Function calling: `using_abilities()` is the bridge to the Abilities API
+
+If your feature needs the model to *call* something — read a post, update an attachment, classify content — pass registered ability IDs to `using_abilities()`. The AI Client converts them into function declarations the model can invoke; when the model calls one, execution routes back through the Abilities API's permission and execution machinery. This makes the AI Client agentic without writing function-calling boilerplate. Pair this with `wp-abilities-api` to define the abilities themselves.
+
+```php
+$result = wp_ai_client_prompt( 'Summarize the latest 5 posts.' )
+    ->using_abilities( 'core/get-posts', 'core/get-post' )
+    ->generate_text_result();
+```
+
+Abilities you pass must already be registered server-side via `wp_register_ability()`. Their `permission_callback` runs every time the model attempts to invoke them.
+
+## Verification
+
+- `is_supported_for_*()` returns `true` in your test environment with at least one configured provider.
+- Your REST endpoint returns the expected modality and a `GenerativeAiResult` payload (token usage, provider/model metadata visible).
+- With the provider's API key removed/invalidated, `is_supported_*()` returns `false` and your UI gracefully hides or shows a useful notice.
+- The `wp_ai_client_prevent_prompt` filter, if used, blocks calls without leaking the prompt content to logs.
+
+## Failure modes / debugging
+
+- **"AI feature shows but always errors"**: usually no provider configured. Confirm at least one provider plugin is active (`AI Provider for Anthropic|Google|OpenAI` or a community provider) and a key is set in Settings → Connectors.
+- **`call to undefined function wp_ai_client_prompt()`**: site is on WP < 7.0. Either bump the floor or use the conditional autoloader pattern.
+- **"Works for admin, fails for editors"**: the JS code is calling the high-privilege client-side prompt API instead of your scoped REST endpoint. Switch to a per-feature endpoint.
+- **`WP_Error` with HTTP 4xx but no useful detail**: the underlying provider returned a vague error. Pull `getProviderMetadata()` off the result for the actual upstream message.
+- **Different model than expected ran**: `using_model_preference()` is a preference. Inspect `getProviderMetadata()` / `getModelMetadata()` on the result to see what actually answered.
+
+## Escalation
+
+For canonical detail before inventing patterns:
+
+- AI Client dev note: https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/
+- PHP AI Client SDK source: https://github.com/WordPress/php-ai-client
+- WP AI Client (REST/JS package): https://github.com/WordPress/wp-ai-client
+- Trac ticket: https://core.trac.wordpress.org/ticket/64591
+
+References:
+- `references/prompt-builder.md`
+- `references/rest-patterns.md`
+- `references/error-handling.md`

--- a/skills/wp-ai-client/references/error-handling.md
+++ b/skills/wp-ai-client/references/error-handling.md
@@ -1,0 +1,85 @@
+# Error handling and prompt prevention
+
+The AI Client follows WordPress conventions: `WP_Error` on failure, semantic HTTP status codes when returned through REST, and a filter for blocking prompts before they execute.
+
+## Generators return `WP_Error`
+
+The wrapper catches exceptions from the underlying SDK and converts them. Never wrap calls in try/catch — check `is_wp_error()`:
+
+```php
+$result = wp_ai_client_prompt( 'Hello' )->generate_text_result();
+if ( is_wp_error( $result ) ) {
+    // Inspect ->get_error_code(), ->get_error_message(), ->get_error_data()
+    return $result;
+}
+```
+
+When passed to `rest_ensure_response()`, a `WP_Error` automatically receives a meaningful HTTP status code based on the underlying failure. You don't need to map status codes manually.
+
+## Common error categories
+
+Specific error codes depend on the provider plugin and the failure mode. General categories you should handle:
+
+- **No provider configured / no compatible model.** `is_supported_*()` would have returned `false` had you checked first. The error from a generator in this state is still meaningful, but the user-facing fix is "configure a provider in Settings → Connectors."
+- **Rate limited / quota exhausted.** Provider-specific. Usually `429`-class. Surface a generic "try again shortly" to the user; log the upstream message for ops.
+- **Validation error from the model.** Most common with `as_json_response()` if the schema is too strict or the prompt is ambiguous. Loosen the schema, lower temperature, or add an explicit example to the system instruction.
+- **Provider returned an opaque error.** Pull `getProviderMetadata()` off the result (when you used `*_result()`) for the actual upstream message — the wrapper sometimes loses detail in translation.
+
+## The `wp_ai_client_prevent_prompt` filter
+
+This filter runs before any AI call. Returning `true` blocks the prompt: no API call is made, `is_supported_*()` returns `false`, and generators return a `WP_Error`. Use it for capability gating, dev-mode kill switches, content policy enforcement, or per-environment restrictions.
+
+```php
+add_filter(
+    'wp_ai_client_prevent_prompt',
+    function ( bool $prevent, $builder ): bool {
+        // Block all prompts in staging unless explicitly opted in.
+        if ( defined( 'WP_ENVIRONMENT_TYPE' ) && 'staging' === wp_get_environment_type() ) {
+            return ! defined( 'MY_PLUGIN_AI_ENABLED_IN_STAGING' );
+        }
+        return $prevent;
+    },
+    10,
+    2
+);
+```
+
+The filter receives a **clone** of the builder, intended for read-only inspection — you can call query-style methods on it (e.g., to check what model preference or modality is configured), but mutations on the clone do not affect the actual builder. So you can inspect what's about to be sent — the system instruction, model preferences, modalities — and decide based on that. You can't (and shouldn't) read user prompt text out of the builder for content moderation; do moderation upstream of the builder, in your REST callback or business logic.
+
+### Combining with `is_supported_*()`
+
+When `wp_ai_client_prevent_prompt` returns `true`, the support checks return `false`. This is by design: your UI naturally hides itself when prompts are prevented. You don't need a separate check.
+
+## Surfacing errors in the editor
+
+If your feature runs in the block editor, return errors as a normal REST error and let `@wordpress/api-fetch` reject. Display via the `core/notices` store:
+
+```js
+import apiFetch from '@wordpress/api-fetch';
+import { dispatch } from '@wordpress/data';
+
+try {
+    const result = await apiFetch( {
+        path: '/my-plugin/v1/summarize-post',
+        method: 'POST',
+        data: { post_id: postId },
+    } );
+    // use result.text
+} catch ( error ) {
+    dispatch( 'core/notices' ).createErrorNotice(
+        error.message || 'AI request failed.',
+        { type: 'snackbar' }
+    );
+}
+```
+
+## Logging without leaking prompts
+
+Don't dump full prompts into PHP error logs — they may contain user content, PII, or trade secrets. Log:
+
+- error code,
+- HTTP status (from `$error->get_error_data()['status']` if present),
+- provider/model metadata if you have a `*_result()`,
+- a short hash of the prompt for correlation if you really need it.
+
+Keep the actual prompt text in your application's audit log, behind whatever access controls you already use for sensitive content.

--- a/skills/wp-ai-client/references/prompt-builder.md
+++ b/skills/wp-ai-client/references/prompt-builder.md
@@ -1,0 +1,203 @@
+# `WP_AI_Client_Prompt_Builder` reference
+
+Complete fluent API for the in-core AI Client (WP 7.0+).
+
+## Entry point
+
+```php
+$builder = wp_ai_client_prompt( $optional_text = null );
+```
+
+Returns a `WP_AI_Client_Prompt_Builder`. Chain configuration methods, then call a generator. Passing prompt text directly is a shortcut for `->with_text( $text )`.
+
+## Configuration methods
+
+| Configuration | Method |
+| --- | --- |
+| Prompt text | `with_text( string )` |
+| File input | `with_file( File )` |
+| Conversation history (multi-turn) | `with_history( array )` |
+| Function call response (multi-turn function calling) | `with_function_response( FunctionResponse )` |
+| Pre-built message parts | `with_message_parts( MessagePart ...)` |
+| System instruction | `using_system_instruction( string )` |
+| Temperature | `using_temperature( float )` |
+| Max tokens | `using_max_tokens( int )` |
+| Top-p / Top-k | `using_top_p( float )`, `using_top_k( int )` |
+| Stop sequences | `using_stop_sequences( array )` |
+| Candidate count | `using_candidate_count( int )` |
+| Model preference (ordered list) | `using_model_preference( ...$model_ids )` |
+| Force a specific model | `using_model( ModelInterface )` |
+| Force a specific provider | `using_provider( string $providerIdOrClassName )` |
+| Bind registered Abilities for function calling | `using_abilities( ...$ability_ids )` |
+| Function declarations (manual) | `using_function_declarations( FunctionDeclaration ...)` |
+| Web search configuration | `using_web_search( WebSearch )` |
+| Presence / frequency penalties | `using_presence_penalty( float )`, `using_frequency_penalty( float )` |
+| Request options (HTTP transport) | `using_request_options( RequestOptions )` |
+| Top log probabilities | `using_top_logprobs( ?int )` |
+| Output modalities | `as_output_modalities( ...$modality_enums )` |
+| Output file type (image/audio/video) | `as_output_file_type( FileTypeEnum )` |
+| Output media orientation | `as_output_media_orientation( MediaOrientationEnum )` |
+| Output MIME type | `as_output_mime_type( string )` |
+| Output schema (raw JSON Schema) | `as_output_schema( array )` |
+| Structured JSON response | `as_json_response( ?array $schema = null )` |
+
+The skill's main SKILL.md and the dev note focus on the most-used subset (the first ~12 rows). The advanced rows above are real but rarely needed — they're documented here for completeness, not for everyday use.
+
+### Function calling via the Abilities API
+
+`using_abilities()` is the integration point between the AI Client and the Abilities API. Pass registered ability IDs (server-side abilities, registered via `wp_register_ability()`); the AI Client converts them into function declarations the model can call. When the model invokes one, the AI Client routes the call back through the Abilities API's permission and execution machinery.
+
+```php
+$result = wp_ai_client_prompt( 'Add an alt text to image #123 if it doesn\'t have one yet.' )
+    ->using_abilities( 'core/get-attachment', 'core/update-attachment' )
+    ->generate_text_result();
+```
+
+This makes the AI Client agentic without you writing function-calling boilerplate. The abilities you pass must already be registered. See the `wp-abilities-api` skill for the registration side.
+
+## Generator methods
+
+Each modality has a "raw" generator (returns the content directly) and a `*_result()` generator (returns a `GenerativeAiResult` with metadata).
+
+### Text
+
+```php
+$text  = wp_ai_client_prompt( 'Write a haiku about WordPress.' )->generate_text();
+$texts = wp_ai_client_prompt( 'Write a tagline.' )->generate_texts( 4 );  // 4 variants
+$res   = wp_ai_client_prompt( $prompt )->generate_text_result();           // with metadata
+```
+
+### Image
+
+```php
+use WordPress\AiClient\Files\DTO\File;
+
+$image  = wp_ai_client_prompt( 'A neon WordPress logo' )->generate_image();
+$images = wp_ai_client_prompt( $prompt )->generate_images( 4 );
+$res    = wp_ai_client_prompt( $prompt )->generate_image_result();
+```
+
+`generate_image()` returns a `File` DTO. Read the data with `$image->getDataUri()` for inline embedding, or persist via the Media Library however your plugin already handles uploads.
+
+### Other modalities
+
+- `generate_speech()` / `generate_speech_result()`
+- `convert_text_to_speech()` / `convert_text_to_speech_result()`
+- `generate_video()` / `generate_video_result()`
+- `generate_result()` — multimodal, when `as_output_modalities()` includes more than one
+
+## Structured output
+
+Pass a JSON Schema and the model returns a JSON-encoded string matching it:
+
+```php
+$schema = array(
+    'type'  => 'array',
+    'items' => array(
+        'type'       => 'object',
+        'properties' => array(
+            'plugin_name' => array( 'type' => 'string' ),
+            'category'    => array( 'type' => 'string' ),
+        ),
+        'required' => array( 'plugin_name', 'category' ),
+    ),
+);
+
+$json = wp_ai_client_prompt( 'List 5 popular WordPress plugins.' )
+    ->as_json_response( $schema )
+    ->generate_text();
+
+$data = json_decode( $json, true );
+```
+
+## Multimodal output
+
+```php
+use WordPress\AiClient\Messages\Enums\ModalityEnum;
+
+$result = wp_ai_client_prompt( 'Recipe for chocolate cake with step photos.' )
+    ->as_output_modalities( ModalityEnum::text(), ModalityEnum::image() )
+    ->generate_result();
+
+foreach ( $result->toMessage()->getParts() as $part ) {
+    if ( $part->isText() ) {
+        echo wp_kses_post( $part->getText() );
+    } elseif ( $part->isFile() && $part->getFile()->isImage() ) {
+        echo '<img src="' . esc_url( $part->getFile()->getDataUri() ) . '">';
+    }
+}
+```
+
+## Feature detection
+
+These methods are synchronous, deterministic, and free — they match the builder's configuration against the available models, no API call. Use them before showing UI:
+
+- `is_supported_for_text_generation()`
+- `is_supported_for_image_generation()`
+- `is_supported_for_text_to_speech_conversion()`
+- `is_supported_for_speech_generation()`
+- `is_supported_for_video_generation()`
+- `is_supported_for_music_generation()`
+- `is_supported_for_embedding_generation()`
+- `is_supported( ?CapabilityEnum $capability = null )` — general form, takes any capability enum
+
+```php
+$builder = wp_ai_client_prompt( 'test' )->using_temperature( 0.7 );
+if ( ! $builder->is_supported_for_text_generation() ) {
+    return; // No suitable model available; skip UI.
+}
+```
+
+## `GenerativeAiResult`
+
+Returned by `generate_*_result()` methods. Useful methods:
+
+- `getTokenUsage()` — input/output (and optional thinking) token counts
+- `getProviderMetadata()` — which provider handled this request
+- `getModelMetadata()` — which model the provider routed to
+- `toMessage()` — raw `Message` for multimodal inspection
+
+The object is serializable; `rest_ensure_response( $result )` works directly in REST callbacks.
+
+## Architecture (worth knowing)
+
+The AI Client is two layers:
+
+1. **`wordpress/php-ai-client`** — the framework-agnostic PHP SDK, bundled into Core. camelCase methods, throws exceptions.
+2. **`WP_AI_Client_Prompt_Builder`** — Core's WordPress wrapper. snake_case methods, returns `WP_Error`, integrates with WordPress HTTP, the Connectors API, and the hooks system.
+
+`wp_ai_client_prompt()` is the recommended entry point. It returns the wrapper, which catches SDK exceptions and converts them to `WP_Error` for you.
+
+### A class-name nuance worth knowing
+
+The dev note documents the Core 7.0 wrapper class as `WP_AI_Client_Prompt_Builder`. The standalone `wordpress/wp-ai-client` package (used on WP < 7.0) returns a different class name — `WordPress\AI_Client\Builders\Prompt_Builder_With_WP_Error`, a subclass of `WordPress\AI_Client\Builders\Prompt_Builder` that adds the `WP_Error` translation. The fluent method names are identical between the two; both proxy to the underlying `php-ai-client` SDK via `__call`. So:
+
+- **Type hints in published code**: prefer interface-style typing over the concrete class name when possible. If you must reference the class, use `WP_AI_Client_Prompt_Builder` for Core 7.0+ and the fully-qualified plugin class for WP < 7.0 — handle both paths if your plugin supports both.
+- **Method names**: identical across both. Code that uses `wp_ai_client_prompt( ... )->using_temperature( 0.7 )->generate_text()` works on either.
+
+## Migration
+
+If your plugin used the standalone Composer packages before WP 7.0:
+
+### Recommended: bump to WP 7.0
+
+Update your plugin header to `Requires at least: 7.0` and remove the Composer dependencies on `wordpress/php-ai-client` and its transitive deps. Replace `AI_Client::prompt()` calls with `wp_ai_client_prompt()`. Remove `wordpress/wp-ai-client` if you weren't using its REST/JS layer.
+
+### If you must support WP < 7.0
+
+`wordpress/php-ai-client` is loaded by Core on 7.0+. Loading it via Composer too will cause duplicate-class errors. Wrap the autoloader:
+
+```php
+if ( ! function_exists( 'wp_get_wp_version' ) || version_compare( wp_get_wp_version(), '7.0', '<' ) ) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
+```
+
+Composer doesn't allow more granular conditional autoloading without splitting into two Composer setups. The `wordpress/wp-ai-client` package handles 7.0 transparently — no change needed.
+
+## Sources
+
+- Dev note: https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/
+- PHP AI Client repo: https://github.com/WordPress/php-ai-client
+- WP AI Client repo: https://github.com/WordPress/wp-ai-client
+- `WP_AI_Client_Prompt_Builder` source — read it directly when in doubt about a method signature; the dev note is canonical for the public surface but the class is the source of truth.

--- a/skills/wp-ai-client/references/prompt-builder.md
+++ b/skills/wp-ai-client/references/prompt-builder.md
@@ -188,7 +188,7 @@ Update your plugin header to `Requires at least: 7.0` and remove the Composer de
 `wordpress/php-ai-client` is loaded by Core on 7.0+. Loading it via Composer too will cause duplicate-class errors. Wrap the autoloader:
 
 ```php
-if ( ! function_exists( 'wp_get_wp_version' ) || version_compare( wp_get_wp_version(), '7.0', '<' ) ) {
+if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
     require_once __DIR__ . '/vendor/autoload.php';
 }
 ```

--- a/skills/wp-ai-client/references/rest-patterns.md
+++ b/skills/wp-ai-client/references/rest-patterns.md
@@ -1,0 +1,137 @@
+# REST patterns for AI features
+
+Why per-feature endpoints, what they should look like, and what to avoid.
+
+## Why not the client-side prompt API
+
+WordPress 7.0 ships a client-side JavaScript prompt builder in the `wordpress/wp-ai-client` package. It works, but it's intentionally locked behind a `manage_options` capability check. The reason: the JS API lets the caller send *any* prompt to *any* configured provider. That's fine for Core's own admin tooling. It is not safe for distributed plugins, where you can't predict what user role will hit the UI or what prompts will be constructed client-side.
+
+The recommended pattern: a separate REST endpoint per AI feature, scoped to that feature's permissions and inputs. The actual prompt construction stays server-side. The JS just calls your endpoint with structured input.
+
+## A canonical endpoint
+
+```php
+add_action( 'rest_api_init', function () {
+    register_rest_route( 'my-plugin/v1', '/summarize-post', array(
+        'methods'             => 'POST',
+        'permission_callback' => function ( WP_REST_Request $request ) {
+            $post_id = (int) $request->get_param( 'post_id' );
+            return $post_id && current_user_can( 'edit_post', $post_id );
+        },
+        'callback'            => 'my_plugin_summarize_post',
+        'args'                => array(
+            'post_id' => array(
+                'required'          => true,
+                'type'              => 'integer',
+                'sanitize_callback' => 'absint',
+            ),
+        ),
+    ) );
+} );
+
+function my_plugin_summarize_post( WP_REST_Request $request ) {
+    $post = get_post( (int) $request->get_param( 'post_id' ) );
+    if ( ! $post ) {
+        return new WP_Error( 'not_found', __( 'Post not found.', 'my-plugin' ), array( 'status' => 404 ) );
+    }
+
+    $result = wp_ai_client_prompt( 'Summarize this post in two sentences:' )
+        ->using_system_instruction( 'You are a concise WordPress editor.' )
+        ->with_text( wp_strip_all_tags( $post->post_content ) )
+        ->using_temperature( 0.3 )
+        ->generate_text_result();
+
+    return rest_ensure_response( $result );
+}
+```
+
+What this gives you:
+
+- **Per-feature capability.** `edit_post` on the specific post, not `manage_options`. Editors and authors can use the feature without being admins.
+- **Validated input.** `sanitize_callback` runs before your callback, so you never see a non-int post_id.
+- **Server-side prompt construction.** The user can't inject system instructions or change the model preference — those are baked into your endpoint.
+- **Free error handling.** Both `GenerativeAiResult` and `WP_Error` serialize through `rest_ensure_response()` with the right HTTP status.
+
+## Calling from JS
+
+```js
+import apiFetch from '@wordpress/api-fetch';
+
+const result = await apiFetch( {
+    path: '/my-plugin/v1/summarize-post',
+    method: 'POST',
+    data: { post_id: postId },
+} );
+
+console.log( result.text, result.tokenUsage, result.providerMetadata );
+```
+
+`@wordpress/api-fetch` injects the REST nonce automatically when called from an admin page.
+
+## Patterns by modality
+
+### Streaming text
+
+The dev note doesn't currently document a streaming method on the wrapper — `generate_text_result()` is request/response. If you need streaming UX, fall back to chunking on your end (multiple shorter prompts) or check the `WP_AI_Client_Prompt_Builder` source in case streaming has been added since.
+
+### Image generation that lands in the Media Library
+
+```php
+function my_plugin_generate_featured_image( WP_REST_Request $request ) {
+    $prompt = $request->get_param( 'prompt' );
+    $image  = wp_ai_client_prompt( $prompt )->generate_image();
+
+    if ( is_wp_error( $image ) ) {
+        return $image;
+    }
+
+    // Persist via existing Media Library helpers.
+    $upload = wp_upload_bits( 'ai-' . wp_generate_uuid4() . '.png', null, base64_decode( /* extract from data URI */ ) );
+    if ( ! empty( $upload['error'] ) ) {
+        return new WP_Error( 'upload_failed', $upload['error'], array( 'status' => 500 ) );
+    }
+
+    $attachment_id = wp_insert_attachment( array(
+        'post_mime_type' => 'image/png',
+        'post_title'     => sanitize_text_field( $prompt ),
+        'post_status'    => 'inherit',
+    ), $upload['file'] );
+
+    return rest_ensure_response( array( 'attachment_id' => $attachment_id ) );
+}
+```
+
+Use existing WP media helpers (`wp_upload_bits`, `wp_insert_attachment`, `wp_generate_attachment_metadata`). Don't reinvent uploads.
+
+### Structured data extraction
+
+```php
+$schema = array(
+    'type'       => 'object',
+    'properties' => array(
+        'title'     => array( 'type' => 'string' ),
+        'tags'      => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+        'category'  => array( 'type' => 'string' ),
+    ),
+    'required'   => array( 'title' ),
+);
+
+$json = wp_ai_client_prompt( 'Extract metadata from: ' . $content )
+    ->as_json_response( $schema )
+    ->generate_text();
+
+if ( is_wp_error( $json ) ) {
+    return $json;
+}
+
+return rest_ensure_response( json_decode( $json, true ) );
+```
+
+Validate the parsed JSON against your own schema afterward — model output is best-effort, not guaranteed.
+
+## What to avoid
+
+- **Building prompts on the client.** Even with a tight permission_callback, a server-built prompt is auditable, version-controlled, and can be filtered via `wp_ai_client_prevent_prompt`. A client-built prompt is none of those.
+- **Stuffing user input into the system instruction.** Treat user-supplied content as data, not instructions. Use `with_text()` for the user payload and `using_system_instruction()` only for the role/format guidance you author.
+- **Returning the full `GenerativeAiResult` to anonymous callers.** It includes provider/model metadata that may leak operational details. For public-facing endpoints, project to a smaller response shape.
+- **Per-request capability checks inside the callback only.** Use `permission_callback` — REST runs it before the callback, and it's the documented place for authorization. The callback is for logic, not auth.

--- a/skills/wp-ai-client/references/rest-patterns.md
+++ b/skills/wp-ai-client/references/rest-patterns.md
@@ -85,14 +85,36 @@ function my_plugin_generate_featured_image( WP_REST_Request $request ) {
         return $image;
     }
 
-    // Persist via existing Media Library helpers.
-    $upload = wp_upload_bits( 'ai-' . wp_generate_uuid4() . '.png', null, base64_decode( /* extract from data URI */ ) );
+    // Parse the data URI returned by the AI Client. Bound the size before decoding,
+    // restrict to known image subtypes, and re-validate MIME after upload.
+    $data_uri        = $image->getDataUri();
+    $max_image_bytes = (int) apply_filters( 'my_plugin_ai_image_max_bytes', 10 * MB_IN_BYTES );
+    if ( strlen( $data_uri ) > 2 * $max_image_bytes ) {
+        return new WP_Error( 'image_too_large', 'AI image response is too large to store.', array( 'status' => 500 ) );
+    }
+    if ( ! preg_match( '#^data:image/(?<subtype>png|jpeg|webp);base64,(?<payload>[A-Za-z0-9+/=]+)$#', $data_uri, $matches ) ) {
+        return new WP_Error( 'invalid_image', 'AI image response is not a supported data URI.', array( 'status' => 500 ) );
+    }
+    $data = base64_decode( $matches['payload'], true );
+    if ( false === $data || strlen( $data ) > $max_image_bytes ) {
+        return new WP_Error( 'invalid_image', 'AI image response could not be decoded or is too large.', array( 'status' => 500 ) );
+    }
+
+    $subtype   = strtolower( $matches['subtype'] );
+    $extension = ( 'jpeg' === $subtype ) ? 'jpg' : $subtype;
+    $mime_type = 'image/' . $subtype;
+
+    $upload = wp_upload_bits( 'ai-' . wp_generate_uuid4() . '.' . $extension, null, $data );
     if ( ! empty( $upload['error'] ) ) {
         return new WP_Error( 'upload_failed', $upload['error'], array( 'status' => 500 ) );
     }
+    if ( wp_get_image_mime( $upload['file'] ) !== $mime_type ) {
+        wp_delete_file( $upload['file'] );
+        return new WP_Error( 'invalid_image', 'AI image response is not a valid image.', array( 'status' => 500 ) );
+    }
 
     $attachment_id = wp_insert_attachment( array(
-        'post_mime_type' => 'image/png',
+        'post_mime_type' => $mime_type,
         'post_title'     => sanitize_text_field( $prompt ),
         'post_status'    => 'inherit',
     ), $upload['file'] );

--- a/skills/wp-ai-client/scripts/detect_ai_client.mjs
+++ b/skills/wp-ai-client/scripts/detect_ai_client.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * detect_ai_client.mjs
+ *
+ * Deterministic detection for the WP 7.0+ AI Client surface in the current repo.
+ * Reads only the filesystem; does not call WP-CLI or hit the running site.
+ *
+ * Outputs JSON to stdout:
+ *   {
+ *     "wp_floor":              "<earliest 'Requires at least' across plugin/theme headers, or null>",
+ *     "supports_ai_client":    <bool — true iff every detected floor is >= 7.0>,
+ *     "uses_ai_client":        <bool — true iff `wp_ai_client_prompt(` appears in PHP>,
+ *     "uses_legacy_packages":  <bool — true iff composer.json depends on wordpress/php-ai-client or wordpress/wp-ai-client>,
+ *     "feature_endpoints":     [<paths where wp_ai_client_prompt is used>],
+ *     "notes":                 [<advisory strings>]
+ *   }
+ *
+ * Usage:
+ *   node skills/wp-ai-client/scripts/detect_ai_client.mjs
+ *   node skills/wp-ai-client/scripts/detect_ai_client.mjs --root <path>
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const IGNORED_DIRS = new Set([
+  "node_modules",
+  "vendor",
+  ".git",
+  "dist",
+  "build",
+  "coverage",
+  ".next",
+  ".cache",
+  ".vercel",
+]);
+
+function parseArgs(argv) {
+  const args = { root: process.cwd() };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === "--root" && argv[i + 1]) {
+      args.root = path.resolve(argv[i + 1]);
+      i++;
+    }
+  }
+  return args;
+}
+
+async function* walk(dir) {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (IGNORED_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(full);
+    } else if (entry.isFile()) {
+      yield full;
+    }
+  }
+}
+
+function compareVersions(a, b) {
+  // Returns -1 if a<b, 0 if a==b, 1 if a>b. Handles "7.0", "7.0.1", "6.9.4".
+  const pa = String(a).split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = String(b).split(".").map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa[i] || 0;
+    const y = pb[i] || 0;
+    if (x < y) return -1;
+    if (x > y) return 1;
+  }
+  return 0;
+}
+
+function extractHeaderField(contents, field) {
+  // Plugin/theme headers: " * Requires at least: 7.0" or "Requires at least: 7.0"
+  const re = new RegExp(`^[\\s*#]*${field}\\s*:\\s*([^\\r\\n]+)`, "im");
+  const match = contents.match(re);
+  return match ? match[1].trim() : null;
+}
+
+async function main() {
+  const { root } = parseArgs(process.argv);
+  const result = {
+    wp_floor: null,
+    supports_ai_client: false,
+    uses_ai_client: false,
+    uses_legacy_packages: false,
+    feature_endpoints: [],
+    notes: [],
+  };
+
+  let lowestFloor = null;
+  const floors = [];
+
+  // 1) Composer dependency check.
+  const composerPath = path.join(root, "composer.json");
+  try {
+    const composer = JSON.parse(await fs.readFile(composerPath, "utf8"));
+    const deps = { ...(composer.require || {}), ...(composer["require-dev"] || {}) };
+    if (deps["wordpress/php-ai-client"] || deps["wordpress/wp-ai-client"]) {
+      result.uses_legacy_packages = true;
+      result.notes.push(
+        "Detected legacy Composer dep on wordpress/php-ai-client or wordpress/wp-ai-client. On WP 7.0+, php-ai-client is in core; conditional autoloading is required to avoid duplicate-class errors. See references/prompt-builder.md#migration."
+      );
+    }
+  } catch {
+    // No composer.json; fine.
+  }
+
+  // 2) Walk PHP files, gather signals.
+  for await (const file of walk(root)) {
+    if (!file.endsWith(".php")) continue;
+    let contents;
+    try {
+      contents = await fs.readFile(file, "utf8");
+    } catch {
+      continue;
+    }
+
+    // Plugin/theme header detection (Requires at least, plus a sanity check for header format).
+    if (
+      contents.includes("Plugin Name:") ||
+      contents.includes("Theme Name:") ||
+      contents.includes("Requires at least:")
+    ) {
+      const floor = extractHeaderField(contents, "Requires at least");
+      if (floor) {
+        floors.push({ file: path.relative(root, file), floor });
+        if (lowestFloor === null || compareVersions(floor, lowestFloor) < 0) {
+          lowestFloor = floor;
+        }
+      }
+    }
+
+    // AI Client usage.
+    if (contents.includes("wp_ai_client_prompt(")) {
+      result.uses_ai_client = true;
+      result.feature_endpoints.push(path.relative(root, file));
+    }
+
+    // Legacy SDK class reference (works as a hint even without composer.json).
+    if (/AI_Client\s*::\s*prompt\s*\(/.test(contents)) {
+      result.uses_legacy_packages = true;
+    }
+  }
+
+  result.wp_floor = lowestFloor;
+  result.supports_ai_client =
+    lowestFloor !== null && compareVersions(lowestFloor, "7.0") >= 0;
+
+  if (lowestFloor === null) {
+    result.notes.push(
+      "No 'Requires at least' header found in any PHP file. Cannot determine WP version floor; assume the project may run on < 7.0 unless confirmed otherwise."
+    );
+  } else if (!result.supports_ai_client) {
+    result.notes.push(
+      `Lowest 'Requires at least' is ${lowestFloor} (< 7.0). Either bump to 7.0 or use the conditional autoloader pattern.`
+    );
+  }
+
+  if (result.uses_ai_client && result.uses_legacy_packages) {
+    result.notes.push(
+      "Both wp_ai_client_prompt() and AI_Client::prompt() / legacy Composer deps were detected. Pick one path; mixing them on WP 7.0+ causes duplicate-class errors."
+    );
+  }
+
+  process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+}
+
+main().catch((err) => {
+  process.stderr.write(`detect_ai_client error: ${err.message}\n`);
+  process.exit(1);
+});

--- a/skills/wp-ai-connectors/SKILL.md
+++ b/skills/wp-ai-connectors/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: wp-ai-connectors
+description: "Use when building a WordPress AI provider plugin that registers with the in-core AI Client (WP 7.0+) so it shows up in Settings → Connectors and becomes available to every plugin using `wp_ai_client_prompt()`. Covers the PHP AI Client provider registry, the Connectors API auto-discovery flow, the `wp_connectors_init` override hook, API key sources (env / constant / database), and the connector array shape. Use this — not `wp-ai-client` — when the user wants to integrate a new AI service (Anthropic, OpenAI, Google, OpenRouter, Ollama, Mistral, custom) at the *provider* level rather than build a feature on top."
+compatibility: "Targets WordPress 7.0+ (PHP 7.4+). Filesystem-based agent with bash + node. Some workflows require WP-CLI."
+---
+
+# WP AI Connectors
+
+## When to use
+
+Use this skill when the task involves:
+
+- writing a plugin that integrates a new AI provider (commercial API, self-hosted Ollama, OpenRouter, Mistral, etc.) with the WordPress AI Client,
+- overriding metadata for a built-in connector (Anthropic, Google, OpenAI) — for example, customizing the description or pre-filling the credentials URL for an internal deployment,
+- diagnosing "my provider plugin is installed but doesn't appear in Settings → Connectors,"
+- understanding why a provider's API key is being read from the wrong source (env vs constant vs database).
+
+If the task is to *consume* AI features (build a summarization endpoint, add image generation to a block), route to `wp-ai-client` instead.
+
+## Inputs required
+
+- Repo root (run `wordpress-router` and `wp-project-triage` first).
+- Provider being integrated: name, ID slug (lowercase alphanumeric + underscores), authentication method (`api_key` or `none`).
+- Models the provider exposes and the modalities each supports.
+- Public credentials URL (where users go to get an API key) and a logo URL if you have one.
+
+## Procedure
+
+### 0) Triage and confirm scope
+
+1. Run triage: `node skills/wp-project-triage/scripts/detect_wp_project.mjs`
+2. Confirm this is a *provider* plugin, not a *feature* plugin. The two have different shapes:
+   - **Provider plugin**: registers with the `AiClient::defaultRegistry()` so other plugins can use the provider.
+   - **Feature plugin**: calls `wp_ai_client_prompt()` to build something. That's `wp-ai-client` territory.
+3. Set the plugin header's version requirements. Recommended: `Requires at least: 7.0` and `Requires PHP: 7.4`. The official Anthropic/Google/OpenAI provider plugins set `Requires at least: 6.9` because they bundle `wordpress/php-ai-client` as a Composer dep and use a `class_exists()` guard at registration — choose that path only if you have a clear reason to support 6.9.
+
+### 1) Register with the PHP AI Client provider registry
+
+Provider registration happens at the SDK level, not the WordPress level. The `wordpress/php-ai-client` package (bundled in WP 7.0 Core) maintains a registry accessed via `AiClient::defaultRegistry()`. Your plugin's bootstrap registers a provider class on that registry — passing the class name, not an instance.
+
+The canonical pattern, taken verbatim from `WordPress/ai-provider-for-anthropic` `plugin.php`:
+
+```php
+namespace WordPress\AnthropicAiProvider;
+
+use WordPress\AiClient\AiClient;
+use WordPress\AnthropicAiProvider\Provider\AnthropicProvider;
+
+function register_provider(): void {
+    if ( ! class_exists( AiClient::class ) ) {
+        return; // SDK not loaded; AI Client missing or WP < 7.0 without the Composer package.
+    }
+
+    $registry = AiClient::defaultRegistry();
+
+    if ( $registry->hasProvider( AnthropicProvider::class ) ) {
+        return; // Idempotent — don't double-register.
+    }
+
+    $registry->registerProvider( AnthropicProvider::class );
+}
+
+add_action( 'init', __NAMESPACE__ . '\\register_provider', 5 );
+```
+
+Notes:
+
+- The method is `registerProvider()`, not `register()`. Argument is a class name string, not an instance.
+- `class_exists( AiClient::class )` makes the plugin safely activate on sites without the SDK.
+- `hasProvider()` makes the registration idempotent.
+- `init` priority 5 runs before `_wp_connectors_init` at priority 10. Priorities between `plugins_loaded` and `init` priority 9 also work; `init` priority 5 is what every official provider plugin uses, so match it for consistency.
+
+The provider class itself (`AnthropicProvider` in this example) implements the SDK's provider interface and lives in your plugin's `src/` directory. See `references/provider-registration.md` for the full annotated pattern and where to look in the SDK source for the current interface contract.
+
+### 2) Let auto-discovery handle the connector
+
+Once your provider is in `AiClient::defaultRegistry()`, the Connectors API discovers it automatically and creates the connector entry with the right metadata. **You do not need to call `register()` on the connector registry yourself.** The flow:
+
+1. WordPress fires `init`.
+2. `_wp_connectors_init()` runs, registers built-in connectors (Anthropic/Google/OpenAI), then queries `AiClient::defaultRegistry()` for everything else.
+3. Your provider's metadata is merged on top of any defaults (provider registry values win).
+4. The `wp_connectors_init` action fires, giving plugins a final chance to override.
+
+If your provider used `api_key` auth, the database setting `connectors_ai_{your_id}_api_key` is created automatically and the env var / constant pattern `{YOUR_ID}_API_KEY` (uppercased) is wired up.
+
+### 3) Override metadata only when needed
+
+Use `wp_connectors_init` if you need to change an existing connector's display data — for example, an agency overriding the Anthropic connector description for a white-label install:
+
+```php
+add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) {
+    if ( $registry->is_registered( 'anthropic' ) ) {
+        $connector = $registry->unregister( 'anthropic' );
+        $connector['description'] = __( 'Custom description for our managed Anthropic deployment.', 'my-plugin' );
+        $registry->register( 'anthropic', $connector );
+    }
+} );
+```
+
+Notes:
+
+- Always `is_registered()` before `unregister()`. Unregistering a missing connector triggers `_doing_it_wrong()`.
+- `unregister()` returns the data; mutate it; pass back to `register()`.
+- IDs must match `/^[a-z0-9_]+$/`.
+- Outside the `wp_connectors_init` callback, query through `wp_get_connector()` / `wp_get_connectors()` — do not access the registry directly.
+
+### 4) Confirm the API key source order
+
+For `api_key` connectors, the AI Client looks up the key in this order. Document this in your provider plugin's readme so admins know:
+
+1. **Environment variable** — `{PROVIDER_ID}_API_KEY` (uppercased)
+2. **PHP constant** — `define( '{PROVIDER_ID}_API_KEY', '...' );` in `wp-config.php`
+3. **Database** — the `connectors_ai_{provider_id}_api_key` setting, edited via Settings → Connectors
+
+Database storage is unencrypted but masked in the UI. Encryption is being explored upstream ([#64789](https://core.trac.wordpress.org/ticket/64789)).
+
+### 5) Verify the connector card appears
+
+Check Settings → Connectors. You should see a card with your provider's name, description, logo, a "Get API key" link pointing at `authentication.credentials_url`, and a status indicator showing where the key is being read from (or "not configured").
+
+If the connector isn't showing up:
+
+- Confirm the provider class actually registers — add a temporary `error_log()` in your registration callback and reload.
+- Confirm the registration runs *before* `_wp_connectors_init` (priority 10 on `init`). Use `init` priority 5 or earlier.
+- Confirm the connector ID matches `/^[a-z0-9_]+$/` — uppercase or hyphens silently fail.
+- Confirm `type` is `ai_provider`. The Settings → Connectors screen currently only renders that type; other types are stored but not surfaced.
+
+## Verification
+
+- `wp_is_connector_registered( 'your_provider_id' )` returns `true` after `init`.
+- `wp_get_connector( 'your_provider_id' )` returns the expected `name`, `description`, `type`, `authentication`, and `plugin.slug` (if set).
+- The connector card renders on Settings → Connectors with the correct logo, description, and credentials link.
+- Setting an API key via env var, constant, and database (in turn) shows the right source on the card.
+- A feature plugin calling `wp_ai_client_prompt()->is_supported_for_text_generation()` returns `true` once your provider is configured.
+
+## Failure modes / debugging
+
+- **Connector doesn't appear**: registration runs too late (after `_wp_connectors_init`), or `type` isn't `ai_provider`, or ID has invalid characters.
+- **"Settings → Connectors shows the card but says no key configured" even though `MY_PROVIDER_API_KEY` is set**: confirm the constant/env var name matches `{PROVIDER_ID}_API_KEY` exactly (uppercased ID, `_API_KEY` suffix). The system does not respect alternate naming.
+- **Override not taking effect**: hooked too late, or hooked outside `wp_connectors_init`. Setting the registry instance outside `init` triggers `_doing_it_wrong()`.
+- **Duplicate-ID error during `register()`**: another plugin already registered that ID. Use `is_registered()` first; if you need to override, follow the unregister-modify-register pattern.
+- **Provider works locally but not on a managed host**: the host may have set `MY_PROVIDER_API_KEY` as a sealed env var. Env beats constant beats database — that's the intended priority and the host's value will win.
+
+## Escalation
+
+For canonical detail before inventing patterns:
+
+- Connectors API dev note: https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/
+- AI Client dev note (architecture and provider plugin list): https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/
+- PHP AI Client source (registry contract): https://github.com/WordPress/php-ai-client
+- Reference provider plugins:
+  - https://wordpress.org/plugins/ai-provider-for-anthropic/
+  - https://wordpress.org/plugins/ai-provider-for-google/
+  - https://wordpress.org/plugins/ai-provider-for-openai/
+- Community provider testing call (OpenRouter, Ollama, Mistral patterns): https://make.wordpress.org/ai/2026/03/25/call-for-testing-community-ai-connector-plugins/
+
+References:
+- `references/provider-registration.md`
+- `references/capabilities-declaration.md`
+- `references/community-providers.md`

--- a/skills/wp-ai-connectors/references/capabilities-declaration.md
+++ b/skills/wp-ai-connectors/references/capabilities-declaration.md
@@ -1,0 +1,69 @@
+# Declaring model capabilities
+
+A provider plugin's job is to make its models *describable*. The AI Client uses those descriptions to decide which model can fulfill a request — your declarations are what `is_supported_for_*()` and `using_model_preference()` check against.
+
+## What gets declared
+
+For each model the provider exposes:
+
+- **Model ID** — stable string. Site owners and feature plugins reference models by ID, so renaming is a breaking change.
+- **Display name** — for the Settings → Connectors UI and any admin model picker.
+- **Modalities supported** — text, image, speech (TTS), speech (STT), video. Inputs and outputs may differ (e.g., a vision model takes image input but outputs text).
+- **Capabilities** — structured output (JSON schema), system instructions, multi-turn (history), function calling, streaming, etc. The exact capability enum is defined in the PHP AI Client SDK.
+- **Limits** — context window size, max output tokens, max input file size.
+- **Recency hint** — whether this is a current-generation model, a legacy one, or a preview. Used to sort the model list so newer models appear first.
+
+The exact PHP shape is in the SDK source — the existing flagship providers are the canonical examples. The shape may evolve, so always read against the current SDK version.
+
+## Why ordering matters
+
+`using_model_preference()` is a *preference*, not a constraint. If none of the preferred models are available on the site, the AI Client falls back to "the first compatible model in the registered order." That means **your provider's model ordering directly affects which model handles a request when no preference matches.**
+
+The convention (followed by the three flagship providers): list newer models before older ones within a family. So `gpt-5.4` before `gpt-5.0` before `gpt-4.5-turbo`. A feature plugin that says "give me your best Anthropic model" gets `claude-opus-4-7` instead of a 2-year-old Claude 3.
+
+## Modality declarations
+
+A model can declare itself as supporting:
+
+- **Text input** (almost all models)
+- **Text output** (most generative models)
+- **Image input** (vision models)
+- **Image output** (image generation models — `gpt-image-2`, `imagen-4`, etc.)
+- **Audio input** (speech-to-text)
+- **Audio output** (text-to-speech, native speech generation)
+- **Video output** (video generation models)
+- **Multimodal output** — at least two output modalities for a single request
+
+Be honest in declarations. A model that *technically* accepts image input but produces unreliable results should not declare image input support — site owners will configure features around it and end up with a broken UX.
+
+## Capability declarations
+
+The SDK defines a set of optional capabilities each model can opt into. Common ones:
+
+- **`json_response`** — model can reliably return JSON matching a provided schema.
+- **`system_instruction`** — model honors a separate system prompt.
+- **`history`** — multi-turn conversation supported.
+- **`function_calling`** — tool/function invocation supported (relevant for agentic workflows but not exposed via the WP wrapper directly yet).
+- **`streaming`** — supports streaming responses (the WP wrapper doesn't currently expose streaming, but providers should still declare it for future use).
+
+Feature plugins use these declarations indirectly — `is_supported_for_text_generation()` returns `false` if the builder requested a JSON schema and no available model declares `json_response`. Mis-declaring a capability cascades into hard-to-diagnose failures for downstream features.
+
+## Logo and brand assets
+
+Connector cards display a logo (`logo_url` in the connector array). Conventions to follow:
+
+- **SVG preferred.** The card scales the logo; SVG stays sharp.
+- **Square or near-square aspect.** Wide horizontal logos crop awkwardly.
+- **Hosted on your provider's CDN, not WordPress.org.** The card just needs a URL; bundling the asset in the plugin is fine but `logo_url` should point to wherever the screen actually fetches from. Plugin-bundled assets work via `plugins_url()`.
+- **Match the provider's official brand.** Don't invent a logo; use the upstream's asset.
+
+## Versioning model declarations
+
+Models change. New ones launch, old ones get deprecated, capabilities expand. Two patterns to handle this gracefully:
+
+1. **Treat model IDs as a stable contract.** Don't rename `claude-sonnet-4-6` to `claude-sonnet-4.6` mid-release. If the upstream changes naming, add the new ID alongside the old one and mark the old one deprecated rather than removing it.
+2. **Update the provider plugin frequently.** Site owners update plugins; that's how new model availability propagates. A provider plugin that hasn't updated in 18 months is offering site owners a stale menu.
+
+## Cross-checking with feature detection
+
+Build a small smoke test in your provider plugin that exercises every declared capability against a configured key, and surface results in your provider plugin's settings or admin notice. This catches declaration drift early — when a provider quietly removes a capability and your plugin still claims to support it, the smoke test catches it before site owners do.

--- a/skills/wp-ai-connectors/references/community-providers.md
+++ b/skills/wp-ai-connectors/references/community-providers.md
@@ -1,0 +1,78 @@
+# Community provider patterns
+
+The three flagship provider plugins (Anthropic, Google, OpenAI) ship from the WordPress project itself. Several community provider plugins emerged during the WP 7.0 cycle, exercising patterns the flagships don't. Worth studying before writing a new one.
+
+Source: the [Call for Testing: Community AI Connector Plugins](https://make.wordpress.org/ai/2026/03/25/call-for-testing-community-ai-connector-plugins/) post lists the providers under active community development. Patterns below are drawn from that surface.
+
+## OpenRouter — the aggregator pattern
+
+OpenRouter is itself a router across many upstream providers (Anthropic, OpenAI, Google, Mistral, etc.). One plugin, many models. The pattern is interesting because:
+
+- A single provider declaration lists hundreds of models, drawn from OpenRouter's `/models` endpoint.
+- The models list shouldn't be hardcoded — fetch and cache (transient with a 24-hour expiry is a reasonable default).
+- Capabilities for each model are also exposed via OpenRouter's API, so the declarations can be data-driven rather than maintained by hand.
+- Model IDs follow OpenRouter's `provider/model` convention (e.g., `anthropic/claude-sonnet-4.6`) which is distinct from the flagship plugins. Site owners using both an aggregator and a direct provider will see overlapping models with different IDs.
+
+When to choose this pattern: aggregator services, multi-model gateways, internal LLM routers. Fetch-and-cache the catalog rather than enumerating it in PHP.
+
+## Ollama — the local provider pattern
+
+Ollama runs models on the user's own machine. Authentication method is `none`. Distinctives:
+
+- No API key. The connector card should show a "no authentication required" state, not "missing key."
+- The base URL (default `http://localhost:11434`) is the actual configuration that matters. Ollama users on non-default ports or remote installs need a way to set this.
+- The model list is whatever the user has pulled locally (`ollama list`). The provider plugin must query Ollama at runtime to know what's available — there's no cloud catalog.
+- Connection failures (Ollama not running, port wrong) need clear surfaced errors. Site owners may not realize they need to start the daemon.
+
+When to choose this pattern: any local-first or self-hosted backend (Ollama, llama.cpp servers, vLLM, LocalAI). Treat `none` auth as a UX prompt to configure the *endpoint* instead.
+
+## Mistral — the direct API pattern
+
+Mistral is a closer parallel to the three flagships: API key auth, hosted models, a stable model catalog. The interesting bit is licensing — Mistral has both proprietary and Apache-licensed open-weight models. A community provider plugin can:
+
+- Expose only the hosted models for simplicity, or
+- Expose both hosted and self-hostable models, with a configuration toggle for the endpoint.
+
+When to choose this pattern: any provider with a stable hosted API that mostly looks like the flagships. The declaration work is straightforward; the differentiator is curation (which models to expose) and brand fit.
+
+## Patterns worth borrowing
+
+Across these and other community providers, some patterns have emerged that aren't documented in the dev notes:
+
+### Cache the model catalog, refresh on demand
+
+```php
+function my_provider_get_models(): array {
+    $cached = get_transient( 'my_provider_models' );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+    $models = my_provider_fetch_catalog();
+    if ( is_wp_error( $models ) ) {
+        return array(); // Fail open — no models means feature detection returns false.
+    }
+    set_transient( 'my_provider_models', $models, DAY_IN_SECONDS );
+    return $models;
+}
+```
+
+Add a "Refresh model list" button on your provider's settings screen for admins who just upgraded their plan or pulled a new local model.
+
+### Declare a "verify connection" admin action
+
+Site owners need a way to confirm their key works without setting up a feature plugin first. A simple admin button that runs a one-token "ping" prompt and reports success/failure is dramatically more usable than letting them discover the failure when their first AI feature breaks.
+
+### Surface latency and pricing if you have the data
+
+The connector card itself doesn't show this in WP 7.0, but `getProviderMetadata()` and `getModelMetadata()` from `GenerativeAiResult` can carry it. Feature plugins that show their users "this took 1.2s and used 340 tokens" are noticeably better — and they can only do that if the provider populates the metadata.
+
+### Don't reimplement Settings → Connectors
+
+If your authentication needs are met by `api_key` or `none`, let the core screen handle the UX. Adding a duplicate settings screen inside your provider plugin fragments the admin experience. If you genuinely need a custom UI (OAuth, multi-tenant, model selection per role), build it as a *complement* to the connector card rather than a replacement.
+
+## What to avoid
+
+- **Declaring capabilities you can't reliably support.** A model that "kind of" supports JSON output isn't supporting it from the AI Client's perspective — feature plugins will request strict schema conformance and get garbage.
+- **Hardcoded API endpoints.** Even if the provider only has one URL today, expose it as a constant or filterable so on-prem and proxy setups can override.
+- **Storing keys in custom options.** The Connectors API already handles env / constant / database. Adding a custom `my_provider_secret_key` option on top creates two sources of truth and confuses site owners.
+- **Skipping deprecation announcements.** When upstream deprecates a model, log a `_doing_it_wrong()`-style notice rather than silently failing requests. Site owners need a chance to update before the model goes away.

--- a/skills/wp-ai-connectors/references/provider-registration.md
+++ b/skills/wp-ai-connectors/references/provider-registration.md
@@ -1,0 +1,179 @@
+# Provider registration
+
+The end-to-end shape of a WordPress AI provider plugin in WP 7.0+.
+
+## Two registries, one flow
+
+There are two registries involved. You only register against the first one:
+
+1. **`AiClient::defaultRegistry()`** — the PHP AI Client's provider registry (lives in the `wordpress/php-ai-client` package, bundled into Core). This is where your provider declares itself.
+2. **`WP_Connector_Registry`** — Core's connector registry, populated automatically by `_wp_connectors_init()` reading from registry #1. You only touch this if you need to *override* metadata on an existing connector via the `wp_connectors_init` action.
+
+The auto-discovery flow:
+
+```
+init priority 10 → _wp_connectors_init() runs:
+  1. Registers built-in connectors (Anthropic, Google, OpenAI) with hardcoded defaults.
+  2. Iterates AiClient::defaultRegistry()->getProviders().
+  3. For each provider, builds a connector array; merges metadata on top of any defaults
+     (provider registry values take precedence).
+  4. Fires the `wp_connectors_init` action with the WP_Connector_Registry instance.
+```
+
+This means: if your plugin registers a provider on `init` priority 5 (or earlier), the connector card appears automatically on Settings → Connectors with no further work.
+
+## The connector array shape
+
+Whether auto-generated or manually overridden, every connector is an associative array with this shape:
+
+```php
+array(
+    'name'           => 'My Provider',                 // Display name on the card.
+    'description'    => 'Text and image generation.',  // Short description on the card.
+    'logo_url'       => 'https://example.com/logo.svg',// Optional. SVG preferred.
+    'type'           => 'ai_provider',                 // Currently the only type rendered on the screen.
+    'authentication' => array(
+        'method'          => 'api_key',                            // 'api_key' or 'none'.
+        'credentials_url' => 'https://provider.example/api-keys',  // Where users get their key.
+        'setting_name'    => 'connectors_ai_my_provider_api_key',  // Auto-generated; don't customize.
+    ),
+    'plugin'         => array(
+        'slug' => 'ai-provider-for-my-provider',  // Optional. Enables install/activate UI.
+    ),
+)
+```
+
+## Authentication methods
+
+Only two methods are supported in WP 7.0:
+
+- **`api_key`** — single API key, looked up from env var → PHP constant → database (in that order).
+- **`none`** — no authentication needed. Use for local providers like Ollama running on `localhost:11434`.
+
+Other authentication methods (OAuth, JWT, mTLS) are not yet supported by the Settings → Connectors screen, though the underlying registry accepts arbitrary `authentication` data. Until that lands, providers needing other auth must ship their own admin UI for credentials.
+
+## API key naming convention
+
+For `api_key` connectors, names are derived from the provider ID (lowercase alphanumeric + underscores):
+
+| Source | Pattern | Example for ID `my_provider` |
+| --- | --- | --- |
+| Database setting | `connectors_ai_{id}_api_key` | `connectors_ai_my_provider_api_key` |
+| Environment variable | `{ID}_API_KEY` (uppercased) | `MY_PROVIDER_API_KEY` |
+| PHP constant | `{ID}_API_KEY` (uppercased) | `define( 'MY_PROVIDER_API_KEY', '...' );` |
+
+These naming patterns are not configurable — overriding `setting_name` in the connector array does not work.
+
+## Provider class contract
+
+The exact PHP interface lives in `wordpress/php-ai-client` and may evolve as the SDK matures. Read the source rather than memorizing it:
+
+- Source: https://github.com/WordPress/php-ai-client
+- Look for the `ProviderInterface` (or equivalent) and the existing flagship provider implementations under `src/Providers/` for working examples.
+
+The shape is roughly:
+
+- A class with a static or instance method that returns the provider's metadata (name, ID, description, logo, credentials URL).
+- A method to list available models with their capabilities (modalities supported, context window, pricing, recency).
+- A method to execute a request given a normalized prompt builder result and an authenticated credential.
+- The provider is expected to translate from the SDK's normalized request shape to the upstream API and back.
+
+When in doubt, copy from `wordpress/ai-provider-for-anthropic`, `wordpress/ai-provider-for-google`, or `wordpress/ai-provider-for-openai`. They are the reference implementations.
+
+## Canonical bootstrap (verbatim from `ai-provider-for-anthropic`)
+
+This is the actual `plugin.php` from `WordPress/ai-provider-for-anthropic` v1.0.2. Copy this shape — it's the documented pattern across all three flagship plugins:
+
+```php
+<?php
+/**
+ * Plugin Name: AI Provider for Anthropic
+ * Plugin URI: https://github.com/WordPress/ai-provider-for-anthropic
+ * Description: AI Provider for Anthropic for the WordPress AI Client.
+ * Requires at least: 6.9
+ * Requires PHP: 7.4
+ * Version: 1.0.2
+ * Author: WordPress AI Team
+ * Author URI: https://make.wordpress.org/ai/
+ * License: GPL-2.0-or-later
+ * Text Domain: ai-provider-for-anthropic
+ *
+ * @package WordPress\AnthropicAiProvider
+ */
+
+declare(strict_types=1);
+
+namespace WordPress\AnthropicAiProvider;
+
+use WordPress\AiClient\AiClient;
+use WordPress\AnthropicAiProvider\Provider\AnthropicProvider;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    return;
+}
+
+require_once __DIR__ . '/src/autoload.php';
+
+function register_provider(): void {
+    if ( ! class_exists( AiClient::class ) ) {
+        return;
+    }
+
+    $registry = AiClient::defaultRegistry();
+
+    if ( $registry->hasProvider( AnthropicProvider::class ) ) {
+        return;
+    }
+
+    $registry->registerProvider( AnthropicProvider::class );
+}
+
+add_action( 'init', __NAMESPACE__ . '\\register_provider', 5 );
+```
+
+What each part does:
+
+- **`Requires at least: 6.9`** — the official plugins target 6.9 because they bundle `wordpress/php-ai-client` as a Composer dependency. If you skip the Composer bundle and rely on Core's bundled SDK, set `Requires at least: 7.0` instead.
+- **`require_once __DIR__ . '/src/autoload.php';`** — loads the plugin's autoloader (Composer or hand-rolled PSR-4). The provider class lives under `src/`.
+- **`class_exists( AiClient::class )`** — guards against the SDK not being loaded. Without this, the plugin fatals on sites where the SDK isn't bundled and Core hasn't yet provided it.
+- **`hasProvider( AnthropicProvider::class )`** — makes registration idempotent.
+- **`registerProvider( AnthropicProvider::class )`** — the actual registration call. Argument is a class name string, not an instance. The SDK instantiates the provider lazily.
+- **`add_action( 'init', ..., 5 )`** — runs before `_wp_connectors_init` at priority 10.
+
+## Hook timing — what works and what doesn't
+
+The Connectors API runs `_wp_connectors_init()` on `init` priority 10. Your provider must be registered before that.
+
+| Hook | Priority | Works? |
+| --- | --- | --- |
+| `plugins_loaded` | any | yes |
+| `init` | 0–9 | yes |
+| `init` | 10+ | no (registry already queried) |
+| `wp_loaded` | any | no (too late) |
+| `wp_connectors_init` | any | no (this is for *overriding* connectors, not adding providers) |
+
+**Convention: use `init` priority 5.** That's what every official provider plugin does. There's nothing magic about priority 5 — `plugins_loaded` works equally well — but matching the official pattern reduces friction for anyone reading your code.
+
+## Public API for querying connectors
+
+After `init`, three functions are available for any plugin (yours or others) to query the registered connectors:
+
+```php
+// Boolean check.
+if ( wp_is_connector_registered( 'my_provider' ) ) { /* ... */ }
+
+// Single connector data, or null if not registered.
+$connector = wp_get_connector( 'my_provider' );
+
+// All connectors, keyed by ID.
+$all = wp_get_connectors();
+foreach ( $all as $id => $data ) {
+    printf( '%s: %s', $data['name'], $data['description'] );
+}
+```
+
+Use these — not the registry directly — outside the `wp_connectors_init` callback.
+
+## What `Settings → Connectors` actually shows
+
+Per the dev note, only `ai_provider` connectors with `api_key` (or `none`) authentication get the full admin UI in WP 7.0. The PHP registry accepts other types and methods, but the screen ignores them. Future releases are expected to expand this — track #64789 and the Connectors API dev note's "Looking ahead" section.

--- a/skills/wp-ai-plugin/SKILL.md
+++ b/skills/wp-ai-plugin/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: wp-ai-plugin
+description: "Use when extending the canonical WordPress AI plugin (`wordpress.org/plugins/ai`, repo `WordPress/ai`, v0.8.0+) — adding a downstream Experiment via the `wpai_default_feature_classes` filter or `wpai_register_features` action, registering a paired Ability that consumes Guidelines automatically, customizing prompts/responses through documented filters, or respecting `wp_supports_ai()` and the `WPAI_*` constants. Use this — not `wp-ai-client` — when the user wants to add a feature *to the AI plugin itself* rather than build an independent AI feature in their own plugin."
+compatibility: "Targets WordPress 7.0+ (PHP 7.4+) and the AI plugin v0.6.0+ (Abstract_Feature) or v0.8.0+ (wp_supports_ai, Guidelines, dashboard widgets). Filesystem-based agent with bash + node. Some workflows require WP-CLI."
+---
+
+# WP AI Plugin
+
+## When to use
+
+Use this skill when the task involves:
+
+- adding a new Experiment to the canonical AI plugin (a content-classification experiment, a new editorial workflow, a custom suggestion type),
+- pairing the Experiment with a registered Ability so it's reachable via the Abilities API, REST, and MCP,
+- opting into Guidelines so the Experiment respects site editorial standards,
+- customizing the AI plugin's behavior in your own plugin via its hooks/filters (prompt overrides, response filtering, feature visibility),
+- diagnosing "my Experiment doesn't appear in Settings → AI" or "the plugin works but my filter never fires".
+
+If the task is to build an AI feature in your own plugin without involving the canonical AI plugin, route to `wp-ai-client` instead. If it's to write a provider plugin, route to `wp-ai-connectors`.
+
+## Inputs required
+
+- Repo root (run `wordpress-router` and `wp-project-triage` first).
+- Confirmation that the canonical AI plugin (`WordPress/ai`, slug `ai`) is installed and active. v0.6.0+ exposes `Abstract_Feature` and the `WPAI_*` constants. v0.8.0+ adds `wp_supports_ai()`, the Guidelines service, and the AI Status / AI Capabilities dashboard widgets.
+- Whether you're extending *upstream* (PR to `WordPress/ai`) or *downstream* (your own plugin that hooks into the AI plugin). The patterns differ.
+- Target AI plugin version. The 0.x cycle has had renames; the source is the canonical reference.
+
+## Procedure
+
+### 0) Triage and confirm AI plugin context
+
+1. Run triage: `node skills/wp-project-triage/scripts/detect_wp_project.mjs`
+2. Confirm the AI plugin is active and identify its version:
+   - The `WPAI_*` constants (set in `ai.php` `constants()`): `WPAI_VERSION`, `WPAI_PLUGIN_FILE`, `WPAI_PLUGIN_DIR`, `WPAI_PLUGIN_URL`, `WPAI_DEFAULT_ABILITY_CATEGORY`.
+   - The plugin slug `ai` in `wp-content/plugins/ai/`.
+   - `Main` singleton at `WordPress\AI\Main::get_instance()`.
+3. The canonical "copy this" reference is `includes/Experiments/Example_Experiment/Example_Experiment.php` in the AI plugin's source. Open it before writing your own.
+
+If the project is the AI plugin itself, you're working *upstream*. Otherwise you're working *downstream* and your code should treat the AI plugin as an optional dependency — degrade gracefully if it's not active.
+
+### 1) Gate on `wp_supports_ai()`
+
+Any code that depends on the AI plugin should guard with `wp_supports_ai()`. The function is provided by Core (WP 7.0) or the bundled SDK — not by the AI plugin itself — so use `function_exists()`:
+
+```php
+if ( ! function_exists( 'wp_supports_ai' ) || ! wp_supports_ai() ) {
+    return; // AI features not supported on this site.
+}
+```
+
+The AI plugin itself uses this gate internally before initializing experiments (PR #268).
+
+### 2) Subclass `Abstract_Feature` for the Experiment
+
+Your Experiment class extends `WordPress\AI\Abstracts\Abstract_Feature` and implements three methods: `get_id()` (static), `load_metadata()` (returns label, description, category, optional stability and image), and `register()` (set up hooks). The constructor is `final` — don't override it.
+
+Verbatim canonical example, from `includes/Experiments/Example_Experiment/Example_Experiment.php`:
+
+```php
+namespace WordPress\AI\Experiments\Example_Experiment;
+
+use WordPress\AI\Abstracts\Abstract_Feature;
+use WordPress\AI\Experiments\Experiment_Category;
+
+class Example_Experiment extends Abstract_Feature {
+    public static function get_id(): string {
+        return 'example-experiment';
+    }
+
+    protected function load_metadata(): array {
+        return array(
+            'label'       => __( 'Example Experiment', 'ai' ),
+            'description' => __( 'Demonstrates the AI experiment system with example hooks and functionality.', 'ai' ),
+            'category'    => Experiment_Category::ADMIN,
+        );
+    }
+
+    public function register(): void {
+        add_action( 'wp_footer', array( $this, 'add_footer_content' ), 20 );
+        add_filter( 'document_title_parts', array( $this, 'modify_title' ), 10, 1 );
+        add_action( 'rest_api_init', array( $this, 'register_rest_route' ) );
+    }
+
+    // ... your hooks' callbacks ...
+}
+```
+
+Categories: `Experiment_Category::EDITOR` (`'editor'`), `Experiment_Category::ADMIN` (`'admin'`), or `Feature_Category::OTHER` (`'other'`, the fallback). Stability values in `load_metadata()`: `'experimental'` (default), `'stable'`, `'deprecated'`. See `references/experiments-framework.md` for the contract details and the Loader/Registry flow.
+
+### 3) Register the Experiment with the AI plugin
+
+Two extension points exist; pick one. Both are documented in `includes/Features/Loader.php`.
+
+**Filter (preferred for class-string registration):**
+
+```php
+add_filter( 'wpai_default_feature_classes', function ( array $classes ): array {
+    if ( ! class_exists( '\\WordPress\\AI\\Abstracts\\Abstract_Feature' ) ) {
+        return $classes; // AI plugin not active.
+    }
+    $classes[ My_Experiment::get_id() ] = My_Experiment::class;
+    return $classes;
+} );
+```
+
+The Loader instantiates the class for you (`new $class()`), validates that it implements `WordPress\AI\Contracts\Feature`, and adds it to the registry.
+
+**Action (when you need custom instantiation):**
+
+```php
+add_action( 'wpai_register_features', function ( $registry ) {
+    if ( ! class_exists( '\\WordPress\\AI\\Abstracts\\Abstract_Feature' ) ) {
+        return;
+    }
+    $registry->register_feature( new My_Experiment( /* injected dependencies */ ) );
+} );
+```
+
+The action receives the `WordPress\AI\Features\Registry` instance. `register_feature()` returns `false` if the ID is already registered (idempotent).
+
+### 4) Pair with an Ability (recommended)
+
+The canonical Experiment pattern registers an Ability inside its `register()` method, hooking on `wp_abilities_api_init`. The Ability is a separate class extending `WordPress\AI\Abstracts\Abstract_Ability`.
+
+From `includes/Experiments/Title_Generation/Title_Generation.php`:
+
+```php
+public function register(): void {
+    add_action( 'wp_abilities_api_init', array( $this, 'register_abilities' ) );
+    // ... other hooks ...
+}
+
+public function register_abilities(): void {
+    wp_register_ability(
+        'ai/' . $this->get_id(),
+        array(
+            'label'         => $this->get_label(),
+            'description'   => $this->get_description(),
+            'ability_class' => My_Internal_Linker_Ability::class,
+        ),
+    );
+}
+```
+
+The `ability_class` key points to your `Abstract_Ability` subclass. That class implements the prompt logic (`input_schema()`, `output_schema()`, `execute_callback()`, `permission_callback()`). The Ability is what the Abilities API exposes; the Experiment is the Settings → AI integration.
+
+Naming convention: ability IDs use the `ai/` prefix when registered by the AI plugin. Your downstream plugin can use its own prefix (e.g., `my-plugin/internal-links`).
+
+### 5) Opt into Guidelines (if your Ability generates content)
+
+Guidelines integration is automatic at the Ability level — set `guideline_categories()` on your `Abstract_Ability` subclass and `Abstract_Ability::load_system_instruction_from_file()` will append the formatted guidelines to your system instruction:
+
+```php
+class My_Internal_Linker_Ability extends \WordPress\AI\Abstracts\Abstract_Ability {
+
+    protected function guideline_categories(): array {
+        return array( 'site', 'copy' ); // Or any subset of: 'site', 'copy', 'images', 'additional'.
+    }
+
+    // ... input_schema, output_schema, execute_callback, permission_callback, meta ...
+}
+```
+
+Returning an empty array (the default) skips Guidelines entirely. When `guideline_categories()` returns a non-empty array AND the Gutenberg `wp_guideline` CPT is registered, the system instruction is automatically appended with an XML-tagged `<guidelines>` block. See `references/guidelines-integration.md` for the full Guidelines service API and how to use it outside `Abstract_Ability` if needed.
+
+### 6) Add a dashboard widget if useful (optional)
+
+v0.8.0 ships two dashboard widgets: `wpai_status` and `wpai_capabilities`, both registered via standard `wp_add_dashboard_widget()` in `Dashboard_Widgets`. **There is no AI-plugin-specific widget framework** in v0.8.0 — to add your own, use standard WordPress:
+
+```php
+add_action( 'wp_dashboard_setup', function () {
+    if ( ! current_user_can( 'manage_options' ) ) return;
+    if ( ! function_exists( 'wp_supports_ai' ) || ! wp_supports_ai() ) return;
+
+    wp_add_dashboard_widget(
+        'my_plugin_ai_stats',
+        __( 'My Plugin — AI activity', 'my-plugin' ),
+        'my_plugin_render_ai_stats_widget'
+    );
+} );
+```
+
+See `references/dashboard-widgets.md` for design conventions matching the AI plugin's two widgets.
+
+### 7) Customize via filters (downstream)
+
+The plugin exposes filters at several layers. The most useful ones, by need:
+
+- **Disable a specific feature**: `wpai_feature_{$id}_enabled` (returns bool, last value wins). `Abstract_Feature::is_enabled()` reads this.
+- **Disable AI features globally**: `wpai_features_enabled` (default `true`, applied in `Loader::initialize_features()`).
+- **Customize Guidelines max length**: `wpai_max_guideline_length` (default 5000 chars per category).
+- **Disable Guidelines integration**: `wpai_use_guidelines` (default `true`).
+- **Modify a system instruction before sending**: filters fire inside each Ability's `load_system_instruction_from_file()`. Search source for `apply_filters` near the Ability's `system-instruction.php` file.
+
+For the full filter list at the version you're targeting, grep the source — see `references/hooks-and-filters.md`.
+
+## Verification
+
+- Settings → AI lists your Experiment with the correct label, description, and category.
+- Toggling the Experiment on/off persists across reloads (writes to `wpai_feature_{$id}_enabled`).
+- With the AI plugin deactivated, your downstream code does not produce fatals or PHP notices (the `function_exists( 'wp_supports_ai' )` and `class_exists` guards work).
+- If your Ability declared `guideline_categories()`, edits to the site Guidelines (in Gutenberg's `wp_guideline` CPT) change the system instruction your Ability uses.
+- Your Ability is discoverable through the Abilities API: `/wp-json/wp-abilities/v1/abilities` lists `ai/{your-id}` (or your custom prefix).
+
+## Failure modes / debugging
+
+- **Experiment doesn't show in Settings → AI**: filter or action hook is registered too late. The filter `wpai_default_feature_classes` runs inside `Loader::register_features()` which is called early in plugin bootstrap; register your hook on `plugins_loaded` priority 10 or earlier. Action `wpai_register_features` runs inside the same `register_features()` call — same timing constraint.
+- **`Class not found: WP\AI\Features\Abstract_Feature`**: namespace is wrong. Correct path is `WordPress\AI\Abstracts\Abstract_Feature`. (Common error — earlier docs used `WP\AI`.)
+- **Filter never fires**: spelled the filter name wrong. Real names are `wpai_default_feature_classes`, `wpai_register_features`, `wpai_features_enabled`, `wpai_features_initialized`. The legacy `ai_experiments_*` prefix was deprecated in 0.6.0 and exists only via `apply_filters_deprecated` for the per-feature toggle.
+- **Guidelines do nothing**: either `guideline_categories()` returned empty, the Gutenberg `wp_guideline` CPT isn't registered, or `wpai_use_guidelines` filter returned false. Check `Guidelines::get_instance()->is_available()`.
+- **Experiment registers but `register()` never runs**: the feature's `is_enabled()` returns false. Check the global toggle (`wpai_features_enabled` option, default off until admin enables it on Settings → AI), then the per-feature toggle.
+
+## Escalation
+
+For canonical detail before inventing patterns:
+
+- **AI plugin source**: https://github.com/WordPress/ai (clone it; the source IS the canonical reference for everything in this skill)
+- **Key files to read directly**:
+  - `includes/Abstracts/Abstract_Feature.php` — Feature contract
+  - `includes/Abstracts/Abstract_Ability.php` — Ability contract, including the Guidelines integration
+  - `includes/Contracts/Feature.php` — the interface Feature classes implement
+  - `includes/Features/Loader.php` — the registration mechanism (extension hooks documented inline)
+  - `includes/Features/Registry.php` — the registry passed to `wpai_register_features`
+  - `includes/Experiments/Example_Experiment/Example_Experiment.php` — canonical example to copy
+  - `includes/Experiments/Title_Generation/Title_Generation.php` — Experiment + paired Ability registration
+  - `includes/Services/Guidelines.php` — Guidelines service (v0.8.0+)
+- **AI Team blog (release notes, roadmap)**: https://make.wordpress.org/ai/
+- **Plugin lead's #core-ai channel** on WordPress Slack for live discussion
+
+References:
+- `references/experiments-framework.md`
+- `references/dashboard-widgets.md`
+- `references/guidelines-integration.md`
+- `references/hooks-and-filters.md`

--- a/skills/wp-ai-plugin/references/dashboard-widgets.md
+++ b/skills/wp-ai-plugin/references/dashboard-widgets.md
@@ -1,0 +1,96 @@
+# Dashboard widgets
+
+The AI plugin v0.8.0 ships two dashboard widgets and uses standard WordPress for registration. **There is no AI-plugin-specific widget framework.** Earlier drafts of this skill claimed there was — they were wrong.
+
+## What ships in v0.8.0
+
+`includes/Admin/Dashboard/Dashboard_Widgets.php` registers two widgets via standard `wp_add_dashboard_widget()`, gated on `current_user_can( 'manage_options' )`:
+
+- **`wpai_status`** — AI Status widget (`AI_Status_Widget` class). Onboarding state, configured connectors, available Features and Experiments.
+- **`wpai_capabilities`** — AI Capabilities widget (`AI_Capabilities_Widget` class). Counts of available Abilities across the plugin and connected providers.
+
+Both are constructed with the `Registry` instance and rendered via standard dashboard widget callbacks. Styles are enqueued via `Asset_Loader::enqueue_style( 'dashboard-widgets', 'admin/dashboard' )`.
+
+## How to add your own widget
+
+Standard WordPress. There's no AI-plugin-specific registration hook to use:
+
+```php
+add_action( 'wp_dashboard_setup', function () {
+    // Match the AI plugin's gating: admin only, AI must be supported.
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+    if ( ! function_exists( 'wp_supports_ai' ) || ! wp_supports_ai() ) {
+        return;
+    }
+
+    wp_add_dashboard_widget(
+        'my_plugin_ai_stats',
+        __( 'My Plugin — AI activity', 'my-plugin' ),
+        'my_plugin_render_ai_stats_widget'
+    );
+} );
+
+function my_plugin_render_ai_stats_widget(): void {
+    $stats = my_plugin_get_24h_stats();
+    if ( empty( $stats ) ) {
+        echo '<p>' . esc_html__( 'No activity yet.', 'my-plugin' ) . '</p>';
+        return;
+    }
+    // Render compactly: counts, sparkline, status indicator.
+}
+```
+
+Widget IDs prefixed with `wpai_` are reserved for the AI plugin itself. Use your own prefix.
+
+## When a dashboard widget is the right surface
+
+Dashboard widgets earn their place when:
+
+- The data is *operational* — what's happening on the site right now, not what the user can do.
+- The data is small — a few numbers, a short list, a status indicator.
+- Site admins benefit from seeing it without navigating somewhere.
+
+Examples that fit: AI request counts in the last 24h, pending suggestions awaiting review, recent provider errors. Examples that don't: a long log of every request, a configuration panel, anything needing real interaction beyond a click-through to detail.
+
+## Design conventions matching the AI plugin's two widgets
+
+To make your widget feel native alongside `wpai_status` and `wpai_capabilities`:
+
+- **No expensive queries on dashboard load.** The dashboard is opened constantly. Cache aggressively (transients with short TTLs, or pre-compute via cron).
+- **Compact markup.** Dashboard widgets are narrow. Use definition lists (`<dl>`) or short tables, not multi-column layouts.
+- **No JavaScript dependencies unless absolutely necessary.** A widget that loads a 200KB React chunk to display a status indicator is the wrong tradeoff.
+- **Respect color schemes and dark mode.** Use WordPress core CSS variables (`var(--wp-admin-theme-color)` etc.) rather than hardcoded colors.
+- **Show a useful empty state.** "No activity yet" with a link to the relevant settings is much better than a blank widget.
+
+A widget should be a teaser. If users want detail, link them to the full screen — Settings → AI for configuration, Settings → Connectors for credentials, your own admin page for deep data.
+
+## Permissions
+
+The AI plugin's widgets gate on `manage_options`. Match that for any widget that exposes operational AI data. If your widget shows data that requires a stricter capability (e.g., billing/spend), wrap rendering in a `current_user_can()` check and degrade gracefully.
+
+If you need an editor-visible signal about AI features, the post editor sidebar is the right surface — not the dashboard. Dashboard widgets are for admins.
+
+## Removing the AI plugin's built-in widgets
+
+If you're managing a deployment that should hide the built-in widgets, use standard `remove_meta_box()` after they register:
+
+```php
+add_action( 'wp_dashboard_setup', function () {
+    remove_meta_box( 'wpai_status', 'dashboard', 'normal' );
+    remove_meta_box( 'wpai_capabilities', 'dashboard', 'normal' );
+}, 20 ); // Priority 20 to run after AI plugin's priority 10.
+```
+
+The widget IDs (`wpai_status`, `wpai_capabilities`) are stable across the v0.8.x line.
+
+## What might land later
+
+The AI plugin's roadmap mentions an "AI Request Logging & Observability Dashboard" as planned (per the readme). If that ships with a registration framework for third-party widgets, this reference will need an update. As of v0.8.0, no such framework exists in source — confirmed by reading `includes/Admin/Dashboard/Dashboard_Widgets.php` end to end.
+
+## Source
+
+- `includes/Admin/Dashboard/Dashboard_Widgets.php` — the orchestrator (~80 lines)
+- `includes/Admin/Dashboard/AI_Status_Widget.php` — Status widget renderer
+- `includes/Admin/Dashboard/AI_Capabilities_Widget.php` — Capabilities widget renderer

--- a/skills/wp-ai-plugin/references/experiments-framework.md
+++ b/skills/wp-ai-plugin/references/experiments-framework.md
@@ -1,0 +1,146 @@
+# Experiments framework
+
+The conceptual model and lifecycle for AI plugin Experiments, anchored to `WordPress/ai` v0.8.0 source.
+
+## What an Experiment is
+
+An "Experiment" in the AI plugin is a class that extends `WordPress\AI\Abstracts\Abstract_Feature`, which implements `WordPress\AI\Contracts\Feature`. The same `Abstract_Feature` is used for all features — Experiments are simply Features with `stability` set to `'experimental'`.
+
+Three stability levels exist (declared in `load_metadata()` or defaulted):
+
+- **`'experimental'`** — opt-in, may change shape, may be dropped, may be promoted (default if unspecified)
+- **`'stable'`** — graduated through testing and contributor consensus
+- **`'deprecated'`** — slated for removal
+
+Image Generation was promoted from `'experimental'` to `'stable'` in v0.8.0 (#418). Title Generation has been stable for several releases. Refine from Notes is currently experimental (added v0.8.0, #289). The path is experimental → stable → potentially core.
+
+## The contract (`Abstract_Feature`)
+
+From `includes/Abstracts/Abstract_Feature.php`:
+
+- **`final public function __construct()`** — do not override. Calls `static::get_id()` and `$this->load_metadata()` to populate properties.
+- **`abstract public static function get_id(): string`** — return a unique slug-style ID. Called statically.
+- **`abstract protected function load_metadata(): array`** — return `['label', 'description', 'category', 'stability'?, 'image'?]`. `label` and `description` are required; missing them throws `InvalidArgumentException`. `category` defaults to `Feature_Category::OTHER` if empty. `stability` defaults to `'experimental'`.
+- **`abstract public function register(): void`** — set up hooks. Called by `Loader::initialize_features()` only if `is_enabled()` returns true.
+- **`final public function is_enabled(): bool`** — checks the global features toggle (`wpai_features_enabled` option) AND the per-feature toggle (`wpai_feature_{$id}_enabled` option), runs the `wpai_feature_{$id}_enabled` filter, caches the result. Cannot be overridden.
+- **`public function register_settings(): void`** — optional override. Use `register_setting()` for custom feature settings.
+- **`public function get_settings_fields(): array`** — optional override. Return field definitions for the DataForm UI on the AI settings page.
+- **`final protected function get_field_option_name( string $name ): string`** — generates `wpai_feature_{$id}_field_{$name}`. Use for namespaced option storage.
+
+The interface (`Contracts\Feature`) lists eight public methods total: `get_id` (static), `get_label`, `get_description`, `get_category`, `get_stability`, `register`, `is_enabled`, `get_settings_fields_metadata`, plus `get_image` (added v0.8.0).
+
+## The canonical example
+
+`includes/Experiments/Example_Experiment/Example_Experiment.php` is shipped specifically as a copy-this reference. It demonstrates:
+
+- subclassing `Abstract_Feature`,
+- implementing `get_id`, `load_metadata`, `register`,
+- using `Experiment_Category::ADMIN`,
+- registering hooks (`wp_footer`, `document_title_parts`, `rest_api_init`) inside `register()`,
+- a paired REST endpoint with permission_callback.
+
+Read it before writing your own; that's what it's there for.
+
+## Registration: the two extension points
+
+From `includes/Features/Loader.php`. Both fire inside `Loader::register_features()`, which runs early in the plugin's bootstrap (after the Loader is constructed in `Main`).
+
+### `wpai_default_feature_classes` filter
+
+```php
+$items = apply_filters( 'wpai_default_feature_classes', $feature_classes );
+```
+
+Filter receives an array of `[ feature_id => fully_qualified_class_string ]`. The Loader then:
+
+1. Validates each item is a class string (logs `_doing_it_wrong` and skips otherwise),
+2. Validates the class implements `Feature` interface (logs `_doing_it_wrong` and skips otherwise),
+3. Instantiates with `new $class()` inside try/catch (skips with `_doing_it_wrong` if construction throws),
+4. Adds the resulting instance to the registry.
+
+Use this filter when you can register by class string alone.
+
+### `wpai_register_features` action
+
+```php
+do_action( 'wpai_register_features', $this->registry );
+```
+
+Action receives the `Registry` instance. Call `$registry->register_feature( $instance )` with an already-instantiated Feature. Returns `false` if the ID is already registered.
+
+Use this action when you need custom construction (dependency injection, factory pattern, conditional registration based on runtime state).
+
+### Built-in Experiments
+
+The plugin's own Experiments are registered via `Experiments::register_default_experiment_classes()` hooked to `wpai_default_feature_classes` at priority 9. The current list (v0.8.0):
+
+```
+Abilities_Explorer, Content_Classification, Content_Resizing, Excerpt_Generation,
+Alt_Text_Generation, Meta_Description, Review_Notes, Refine_Notes,
+Summarization, Title_Generation
+```
+
+Plus the internal `Image_Generation` Feature (registered separately as a stable Feature in `Loader::get_default_features()`).
+
+## The enabled-state model
+
+`Abstract_Feature::is_enabled()` is layered:
+
+1. **Global toggle** — `wpai_features_enabled` option. Settings → AI's master switch. Returns false immediately if off.
+2. **Per-feature toggle** — `wpai_feature_{$id}_enabled` option. The Settings → AI screen renders one toggle per registered Feature.
+3. **Per-feature filter** — `wpai_feature_{$id}_enabled` filter (same name as the option). Last filter value wins. Use this in mu-plugins or hosting controls to force-enable or force-disable specific features.
+4. **Deprecated legacy filter** — `ai_experiments_experiment_{$id}_enabled` runs through `apply_filters_deprecated` for compat with code written before the 0.6.0 rename.
+
+Result is cached on the instance. Filters firing after the first `is_enabled()` call have no effect on that instance — important for testing.
+
+## Pairing with an Ability
+
+Most Experiments register one or more Abilities inside their `register()` method. The pattern (from `Title_Generation`):
+
+```php
+public function register(): void {
+    add_action( 'wp_abilities_api_init', array( $this, 'register_abilities' ) );
+    // Other hooks for editor UI, REST endpoints, etc.
+}
+
+public function register_abilities(): void {
+    wp_register_ability(
+        'ai/' . $this->get_id(),
+        array(
+            'label'         => $this->get_label(),
+            'description'   => $this->get_description(),
+            'ability_class' => My_Ability::class,
+        ),
+    );
+}
+```
+
+The `ability_class` key is the AI plugin's convention — it points to a class extending `WordPress\AI\Abstracts\Abstract_Ability` (which itself extends WordPress core's `WP_Ability`). The Ability class implements:
+
+- `input_schema(): array`
+- `output_schema(): array`
+- `execute_callback( $input ): mixed`
+- `permission_callback( $input ): mixed`
+- `meta(): array`
+- `category(): string` (defaults to `WPAI_DEFAULT_ABILITY_CATEGORY`)
+- `guideline_categories(): array` (optional, for Guidelines integration)
+
+The Ability is what the Abilities API exposes (and therefore what's reachable via REST and MCP). The Experiment is the Settings → AI surface.
+
+## Promotion path
+
+The 0.5.0 release notes referenced "Finalize requirements to elevate an Experiment to a Feature." Working criteria (per contributor discussions):
+
+- Stable user-facing UX with documented behavior
+- At least one fully-tested provider integration
+- No outstanding critical accessibility issues
+- Plugin lead approval after contributor review
+
+If you're building an Experiment with the explicit goal of seeing it graduate, work the contributor channels (`#core-ai` Slack, GitHub Discussions) early. Promotion is a community decision.
+
+## Where to put your Experiment
+
+- **Upstream contribution to `WordPress/ai`**: PR adding `includes/Experiments/My_Experiment/My_Experiment.php` and `includes/Abilities/My_Experiment/My_Experiment.php`. Follow the contributor guide (`CONTRIBUTING.md`); AI-authored code requires explicit disclosure per the AI Authorship guidelines.
+- **Downstream plugin extending the AI plugin**: your own plugin hooks `wpai_default_feature_classes` to add your class. Faster to ship, good for testing demand. Treat the AI plugin as an optional dependency; gate every entry point.
+
+The downstream pattern is what most agencies and hosts will use. Upstream contribution is for Experiments general enough to belong in the canonical plugin.

--- a/skills/wp-ai-plugin/references/guidelines-integration.md
+++ b/skills/wp-ai-plugin/references/guidelines-integration.md
@@ -1,0 +1,151 @@
+# Guidelines integration
+
+The AI plugin v0.8.0 introduced Guidelines integration (#359). Site editorial standards live in Gutenberg's `wp_guideline` custom post type, and the AI plugin reads them into prompts when an Ability declares interest.
+
+## Where Guidelines live
+
+Guidelines are stored as a `wp_guideline` custom post type provided by Gutenberg 23.0+. Each post stores guidelines in four post meta fields:
+
+- `_guideline_copy` — text/copy guidelines (voice, tone, banned terms)
+- `_guideline_images` — image guidelines (style, accessibility, alt text rules)
+- `_guideline_site` — site context (what the site is about)
+- `_guideline_additional` — anything else
+
+Plus per-block guidelines via `_guideline_block_{$sanitized_block_name}` (e.g., `_guideline_block_core_paragraph`).
+
+The `WordPress\AI\Services\Guidelines` service reads from this CPT. Site owners edit Guidelines through Gutenberg's UI, not through the AI plugin's settings.
+
+## The integration pattern (most code paths)
+
+The cleanest path: **declare `guideline_categories()` on your `Abstract_Ability` subclass.** The Ability's `load_system_instruction_from_file()` automatically appends formatted Guidelines to the system instruction:
+
+```php
+class My_Internal_Linker_Ability extends \WordPress\AI\Abstracts\Abstract_Ability {
+
+    /**
+     * @return list<string> Subset of: 'site', 'copy', 'images', 'additional'.
+     */
+    protected function guideline_categories(): array {
+        return array( 'site', 'copy' );
+    }
+
+    // ... rest of the Ability ...
+}
+```
+
+When the Ability runs:
+
+1. `load_system_instruction_from_file()` loads the base instruction from `system-instruction.php` (or `prompt.php`).
+2. If `guideline_categories()` returns non-empty AND `Guidelines::is_available()` is true, it calls `get_guidelines_for_prompt( $block_name )`.
+3. The result is appended after a fixed preamble: *"The following guidelines represent the site's editorial standards. Apply them where relevant. Do not fabricate content to satisfy guidelines. If guidelines conflict with the input, prioritize accuracy."*
+4. The full instruction (base + preamble + `<guidelines>...</guidelines>` block) is passed to the model.
+
+Returning an empty array (the default) skips Guidelines entirely.
+
+## Categories cheat sheet
+
+Pick the categories your Ability actually benefits from:
+
+| Category | When to use |
+| --- | --- |
+| `site` | Anything that should know what the site is about — name, audience, mission |
+| `copy` | Anything generating text that should match site voice/tone |
+| `images` | Image-generating Abilities, alt-text generation |
+| `additional` | Catch-all for site-specific rules that don't fit elsewhere |
+
+Existing Abilities in the AI plugin source show real choices: `Title_Generation` uses `['site', 'copy']`, image-related Abilities use `['site', 'images']`, etc. Search source for `guideline_categories(): array` to see all the existing declarations.
+
+## Using Guidelines outside `Abstract_Ability`
+
+If you're not using `Abstract_Ability` (e.g., you're writing a standalone REST endpoint or admin tool that wants to respect Guidelines), use the singleton service directly:
+
+```php
+use WordPress\AI\Services\Guidelines;
+
+$service = Guidelines::get_instance();
+
+if ( ! $service->is_available() ) {
+    // wp_guideline CPT not registered (Gutenberg < 23.0 or experiment off).
+    $guidelines_xml = '';
+} else {
+    $guidelines_xml = $service->format_for_prompt(
+        array( 'site', 'copy' ),  // Categories.
+        'core/paragraph'          // Optional block name for block-specific guidelines.
+    );
+}
+
+// Stack onto your own system instruction.
+$system_instruction = $base_instruction;
+if ( '' !== $guidelines_xml ) {
+    $system_instruction .= "\n\n" . $guidelines_xml;
+}
+```
+
+The service caches results internally (singleton pattern). For tests, call `Guidelines::reset_cache()` between cases.
+
+### Available methods on the service
+
+| Method | Returns | Use |
+| --- | --- | --- |
+| `is_available(): bool` | `true` if `wp_guideline` CPT is registered | Gate before calling other methods |
+| `get_guidelines( ?string $category = null ): ?array` | Keyed array of category → text, or null | Direct access to raw guideline strings |
+| `get_block_guidelines( string $block_name ): ?string` | Block-specific guideline text or null | When you only want guidelines for one block type |
+| `format_for_prompt( array $categories, ?string $block_name = null ): string` | XML-tagged string suitable for prompt injection, or `''` | The standard integration call |
+| `reset_cache(): void` | — | Test cleanup |
+
+## XML output shape
+
+`format_for_prompt()` returns a string like:
+
+```xml
+<guidelines>
+<site-context>The site is a Brooklyn-based food blog focused on weeknight cooking.</site-context>
+<copy-guidelines>Use a friendly, conversational tone. Avoid superlatives.</copy-guidelines>
+<block-guidelines>For paragraph blocks, keep sentences under 30 words.</block-guidelines>
+</guidelines>
+```
+
+Tag names per category:
+
+- `site` → `<site-context>`
+- `copy` → `<copy-guidelines>`
+- `images` → `<image-guidelines>`
+- `additional` → `<additional-guidelines>`
+- block-specific → `<block-guidelines>`
+
+Each category is wrapped only if it has content. Returns empty string if nothing applies.
+
+## Length limits
+
+Each category is truncated to the value of the `wpai_max_guideline_length` filter (default 5000 characters). Override for sites with shorter or longer guideline content:
+
+```php
+add_filter( 'wpai_max_guideline_length', fn() => 2000 );
+```
+
+## Disabling Guidelines globally
+
+The `wpai_use_guidelines` filter (default `true`) gates the entire integration:
+
+```php
+add_filter( 'wpai_use_guidelines', '__return_false' );
+```
+
+When false, `should_use_guidelines()` returns false even if the CPT is registered. Use this for tests, staging environments, or sites where Guidelines should be ignored.
+
+## Cache invalidation
+
+The service caches guidelines on first read for the request. If your code edits Guidelines and then expects the new values to take effect *in the same request*, call `Guidelines::reset_cache()` after the edit. Most code doesn't need this — the cache is per-request, so the next pageload reads fresh data.
+
+## What not to do
+
+- **Don't bypass the integration with a "raw mode" toggle in your Ability.** If site owners want different behavior in different contexts, that's what Guidelines' own context system is for.
+- **Don't read `wp_guideline` CPT directly with `get_posts()`.** The Service handles status (Gutenberg saves as `'draft'` by default), caching, sanitization, and length limits. Reimplementing means missing all of that.
+- **Don't pass user-supplied content as guideline text into the prompt.** The XML-wrapping is a structural marker for the model, not a security boundary. User content goes in the `with_text()` payload.
+- **Don't make your Ability worse when Guidelines is on.** If the system instruction stops working when Guidelines append themselves, the prompt was fragile. Test with and without Guidelines.
+
+## Source
+
+- `includes/Services/Guidelines.php` — full service implementation
+- `includes/Abstracts/Abstract_Ability.php` — search for `guideline_categories` and `get_guidelines_for_prompt` to see how the integration ties into Ability execution
+- `includes/Abilities/Title_Generation/Title_Generation.php` — real Ability with `guideline_categories()` declared

--- a/skills/wp-ai-plugin/references/hooks-and-filters.md
+++ b/skills/wp-ai-plugin/references/hooks-and-filters.md
@@ -1,0 +1,122 @@
+# Hooks, filters, constants, and gates
+
+The public extension surface of the AI plugin v0.8.0. Anchored to source — the source is canonical.
+
+## Constants (v0.6.0+)
+
+Defined in `ai.php` `constants()`. The 0.6.0 release renamed the family from `AIE_*` to `WPAI_*` (#317). Current values:
+
+| Constant | Source | Use |
+| --- | --- | --- |
+| `WPAI_VERSION` | `'0.8.0'` (string literal) | Version detection in downstream code |
+| `WPAI_PLUGIN_FILE` | `__FILE__` (ai.php) | The main plugin file path |
+| `WPAI_PLUGIN_DIR` | `plugin_dir_path( WPAI_PLUGIN_FILE )` | Filesystem path to the plugin directory |
+| `WPAI_PLUGIN_URL` | `plugin_dir_url( WPAI_PLUGIN_FILE )` | URL to the plugin directory (for asset references) |
+| `WPAI_DEFAULT_ABILITY_CATEGORY` | `'ai-experiments'` | Default category for abilities registered by the plugin |
+
+Use these in downstream plugins to detect the AI plugin's presence and version, and to reference its assets when integrating with its UI.
+
+```php
+if ( defined( 'WPAI_VERSION' ) && version_compare( WPAI_VERSION, '0.8.0', '>=' ) ) {
+    // Guidelines integration is available.
+}
+```
+
+**Note**: earlier drafts of this skill referred to `WPAI_PATH`, `WPAI_URL`, `WPAI_FILE`. Those names are wrong. The actual constants are `WPAI_PLUGIN_DIR`, `WPAI_PLUGIN_URL`, `WPAI_PLUGIN_FILE`.
+
+## Top-level functions
+
+### `wp_supports_ai()` (v0.8.0+ usage)
+
+The primary gate. Returns `true` when AI features are usable on the site (provider configured, capability checks pass). The function itself is not defined in the AI plugin — it's provided by Core (WP 7.0) or the bundled SDK. Use `function_exists()`:
+
+```php
+if ( ! function_exists( 'wp_supports_ai' ) || ! wp_supports_ai() ) {
+    return; // Don't initialize AI-dependent code.
+}
+```
+
+The AI plugin uses this gate internally before initializing experiments (#268). Mirror it in your downstream code.
+
+### Helper functions in `WordPress\AI` namespace
+
+`includes/helpers.php` exposes utility functions used by the plugin's own Abilities. Useful ones for downstream extensions:
+
+- `WordPress\AI\normalize_content( string $content ): string` — strips HTML, collapses whitespace, applies `wpai_pre_normalize_content` and `wpai_normalize_content` filters.
+- `WordPress\AI\format_guidelines_for_prompt( array $categories, ?string $block_name = null ): string` — convenience wrapper around `Guidelines::get_instance()->format_for_prompt()`.
+- `WordPress\AI\get_post_context( int $post_id ): string` — formatted post context for prompts.
+- `WordPress\AI\get_preferred_models_for_text_generation(): array` — returns the plugin's preferred model list for `using_model_preference()`.
+
+These are namespaced functions in `WordPress\AI`. Import as `use function WordPress\AI\normalize_content;` (or use the fully qualified name).
+
+## Filters
+
+### Feature lifecycle
+
+| Filter | Where | Default | Use |
+| --- | --- | --- | --- |
+| `wpai_default_feature_classes` | `Loader::get_default_features()` | array of built-in classes | Add or remove Feature class strings before instantiation |
+| `wpai_features_enabled` | `Loader::initialize_features()` | `true` | Master kill switch for all features |
+| `wpai_feature_{$id}_enabled` | `Abstract_Feature::is_enabled()` | option value | Per-feature override (force on/off in code) |
+| `ai_experiments_experiment_{$id}_enabled` | `Abstract_Feature::is_enabled()` | option value | Deprecated, kept via `apply_filters_deprecated` for legacy compat |
+
+### Guidelines
+
+| Filter | Where | Default | Use |
+| --- | --- | --- | --- |
+| `wpai_use_guidelines` | `Guidelines::should_use_guidelines()` | `true` | Disable Guidelines integration entirely |
+| `wpai_max_guideline_length` | `Guidelines::format_for_prompt()` | `5000` (chars) | Per-category truncation length |
+
+### Content normalization
+
+| Filter | Where | Default | Use |
+| --- | --- | --- | --- |
+| `wpai_pre_normalize_content` | `WordPress\AI\normalize_content()` | input | Modify content before normalization |
+| `wpai_normalize_content` | `WordPress\AI\normalize_content()` | output | Modify content after normalization |
+
+### Per-Ability filters
+
+Each Ability fires filters around its system instruction loading and prompt construction. The exact names are `wpai_{ability_id}_*` patterns and vary per Ability. Search the source:
+
+```bash
+grep -rn "apply_filters" wp-content/plugins/ai/includes/Abilities/
+```
+
+That gives you every Ability-level filter with file/line context.
+
+## Actions
+
+| Action | Where | Use |
+| --- | --- | --- |
+| `wpai_register_features` | `Loader::register_features()` | Register a Feature instance into the registry (alternative to the filter pattern) |
+| `wpai_features_initialized` | `Loader::initialize_features()` | Fires after every enabled Feature's `register()` has run; safe to assume features are wired up |
+
+The plugin also fires the standard WordPress activation hook via `register_activation_hook( WPAI_PLUGIN_FILE, ... )`, which downstream code generally shouldn't depend on (use your own activation hook for your own plugin).
+
+## Hook timing
+
+The AI plugin bootstraps via `WordPress\AI\Main::get_instance()`, called at the bottom of `ai.php`. Main hooks subsequent setup on standard WordPress lifecycle. From an extension perspective:
+
+- **`plugins_loaded` priority 10**: safe to register `wpai_default_feature_classes` filter and `wpai_register_features` action callbacks. Both fire later, but registering early ensures you're attached.
+- **`init` priority 5**: also safe and used by AI provider plugins for the AI Client registry. AI plugin-specific hooks are not version-gated by `init`.
+- **Inside any action that the AI plugin's Loader fires**: too late for `wpai_default_feature_classes` and `wpai_register_features` (they've already run). Use `wpai_features_initialized` if you need to react after features are wired up.
+
+The AI plugin's `Loader::register_features()` runs once per request, early in the bootstrap. If your downstream filter registers conditionally (e.g., based on user role), the registration only happens for that request — site admins will see the feature when they're admins, others won't. That's by design.
+
+## Reading the source for the latest
+
+The hook surface evolves. To get the current authoritative list:
+
+```bash
+# In the AI plugin root
+grep -rn "apply_filters\|do_action" includes/ | grep -v "@since\|@param" | sort -u
+```
+
+That gives you every filter and action with file/line context. The Experiment classes (`includes/Experiments/`) are usually where the most interesting integration points live — search there first when looking for ways to customize a specific feature.
+
+## What not to do
+
+- **Don't replace `Abstract_Feature` with your own base class.** The framework hooks are wired into that hierarchy; subclassing it is the supported path.
+- **Don't write to `WPAI_*` constants.** They're set during the plugin's bootstrap; modifying them has no effect after that and creates "why isn't this taking?" debugging confusion.
+- **Don't rely on filters that fire only inside private methods.** They may be removed without notice. Stick to the documented public extension surface.
+- **Don't assume backward compatibility across 0.x releases.** The plugin is explicitly experimental; renames and reshapes happen. Pin your minimum version requirement (`WPAI_VERSION` check) and test against the next release before recommending it to users.


### PR DESCRIPTION
Adds three skills covering WordPress 7.0+ AI surfaces — `wp-ai-client`, `wp-ai-connectors`, `wp-ai-plugin` — plus additive extensions to `wp-abilities-api` for the WP 7.0+ JS API and the MCP Adapter. The eval harness gets an 8-line change so it accepts either the existing `WP 6.9 + PHP 7.2.24` baseline or a new `WP 7.0 + PHP 7.4` one; existing skills are unaffected.

Background: this is one of the three approaches I sketched in #48 (the dual-baseline one). I'm opening it as a concrete reference for that discussion rather than asserting the policy is decided — if maintainers prefer the `class_exists`-guards approach or want to keep the repo single-baseline, happy to close and reshape.

## Summary

- Three new skills covering WordPress 7.0+ AI surfaces: `wp-ai-client`, `wp-ai-connectors`, `wp-ai-plugin`.
- Additive extensions to `wp-abilities-api` for the WP 7.0+ client-side JS API and the MCP Adapter (existing 6.9 content untouched).
- Decision-tree entries in `wordpress-router` so AI tasks route to the right skill.
- Eight-line patch to `eval/harness/run.mjs` accepting either the existing `WordPress 6.9 + PHP 7.2.24` baseline or a new `WordPress 7.0 + PHP 7.4` baseline. Existing skills are unaffected.
- Compatibility policy + skill-set-v1 + README updated to reflect the dual-baseline + the three new skills.

Diff: +2,570 / −10 across 26 files. No existing skill's frontmatter, body, or scenarios are modified.

## Why dual-baseline

The new AI surfaces (`wp_ai_client_prompt()`, `WP_Connector_Registry`, the canonical AI plugin's `Abstract_Feature`) literally do not exist on 6.9. A skill targeting them with a 6.9 floor would either lie in its compatibility line or load-bear `class_exists()` guards in every example — both options trade honesty for the harness check. The dual-baseline approach keeps each skill's declared floor truthful and the harness still gates against drift (now expressed against either of two named baselines).

The harness change is small enough to read here:

```js
const matchesLegacyBaseline =
  compatibility.includes("WordPress 6.9") && compatibility.includes("PHP 7.2.24");
const matchesAiEraBaseline =
  compatibility.includes("WordPress 7.0") && compatibility.includes("PHP 7.4");
assert(
  matchesLegacyBaseline || matchesAiEraBaseline,
  ...
);
```

## What's added

### `wp-ai-client` — building features with the in-core AI Client
SKILL.md plus three references (`prompt-builder.md`, `rest-patterns.md`, `error-handling.md`) and a `detect_ai_client.mjs` script.

Anchored to canonical surfaces: `wp_ai_client_prompt()`, `WP_AI_Client_Prompt_Builder`, the `is_supported_for_*()` family, `using_abilities()` as the bridge to the Abilities API, the `wp_ai_client_prevent_prompt` filter (clarifies that the filter receives a clone of the builder), `GenerativeAiResult`. Reference patterns include per-feature REST endpoints (vs. the high-privilege client-side prompt API), structured output via `as_json_response()`, and image generation that lands in the Media Library with bounded data-URI parsing and post-upload MIME re-validation.

Sources cited: the [AI Client dev note](https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/), [`WordPress/php-ai-client`](https://github.com/WordPress/php-ai-client), [`WordPress/wp-ai-client`](https://github.com/WordPress/wp-ai-client), Trac [#64591](https://core.trac.wordpress.org/ticket/64591).

### `wp-ai-connectors` — provider plugins
SKILL.md plus three references (`provider-registration.md`, `capabilities-declaration.md`, `community-providers.md`).

Encodes the canonical bootstrap from `WordPress/ai-provider-for-anthropic` v1.0.2 verbatim: `AiClient::defaultRegistry()->registerProvider(Class::class)` (class-name string, not instance; `registerProvider`, not `register`), `class_exists` + `hasProvider` guards, `init` priority 5 to run before `_wp_connectors_init` at 10, auto-discovery means you do *not* call `WP_Connector_Registry::register()` for new providers, the API key naming convention (`connectors_ai_{id}_api_key`, env/constant `{ID}_API_KEY`), and the env > constant > database priority order. Community-providers reference covers the OpenRouter (aggregator), Ollama (`none` auth, local), and Mistral (direct-API) patterns.

Sources cited: the [Connectors API dev note](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/), the AI Client dev note, the three flagship provider plugins, the [Call for Testing](https://make.wordpress.org/ai/2026/03/25/call-for-testing-community-ai-connector-plugins/) post.

### `wp-ai-plugin` — extending the canonical AI plugin
SKILL.md plus four references (`experiments-framework.md`, `dashboard-widgets.md`, `guidelines-integration.md`, `hooks-and-filters.md`).

Anchored to `WordPress/ai` v0.8.0 source. Covers `Abstract_Feature` (correct namespace `WordPress\AI\Abstracts\Abstract_Feature`, not `WP\AI\Features\Abstract_Feature` — a common error), the two extension points (`wpai_default_feature_classes` filter, `wpai_register_features` action), the canonical `Example_Experiment` as the copy-this starting point, paired-Ability registration via `wp_abilities_api_init`, `guideline_categories()` opting an Ability into Guidelines automatically, `wp_supports_ai()` gating, and the actual `WPAI_*` constant names (`WPAI_PLUGIN_FILE`, `WPAI_PLUGIN_DIR`, `WPAI_PLUGIN_URL` — not `WPAI_FILE`/`WPAI_PATH`/`WPAI_URL`). The dashboard-widgets reference explicitly states there is no AI-plugin-specific widget framework in v0.8.0 — extensions use standard `wp_add_dashboard_widget()`.

Source cited: [`WordPress/ai`](https://github.com/WordPress/ai) (the source is the canonical reference) plus the [AI Team blog](https://make.wordpress.org/ai/).

### `wp-abilities-api` — additive extensions
Two new references:

- `references/client-side.md` — WP 7.0+ JavaScript API: `@wordpress/abilities` and `@wordpress/core-abilities`, `registerAbility` / `executeAbility`, the `core/abilities` store, how annotations (`readonly` / `destructive` / `idempotent`) drive the HTTP method (`GET` / `DELETE` / `POST`) when `executeAbility` calls a server-registered ability through REST.
- `references/mcp-exposure.md` — installing the MCP Adapter via Composer, how abilities map to MCP tools, the default server vs. a custom server (`create_server()` has 13 parameters in v0.5.0+; the 7th is the required transports array), the two `mcp_adapter_default_server_*` filters, the Plain-permalinks gotcha, and Application Passwords for local Claude Desktop / Cursor integration.

The SKILL.md update adds step 6 (consume from JS) wording for the WP 7.0+ surface and a new step 7 (expose via MCP). The 6.9 content is unchanged and `wp-abilities-api` keeps its 6.9 + PHP 7.2.24 baseline; the new references are additive context for sites running 7.0.

### `wordpress-router/references/decision-tree.md`
Adds entries for AI Client / Connectors API / canonical AI plugin / MCP Adapter so AI-related tasks route correctly. Existing entries unchanged.

### Eval scenarios
Four new scenarios under `eval/scenarios/`:

- `ai-client-add-feature-endpoint.json` — "add a 'rewrite paragraph' button to the editor"
- `ai-connectors-register-provider.json` — "build a Mistral provider plugin"
- `ai-plugin-register-experiment.json` — "add an internal-link suggestion Experiment to `WordPress/ai`"
- `abilities-mcp-expose.json` — "expose existing abilities to Claude Desktop via MCP"

Each lists explicit success criteria pinned to method names / namespaces / hook timing — they catch the named errors a model is most likely to produce on these surfaces (e.g., `register()` vs `registerProvider()`, the wrong namespace for `Abstract_Feature`, missing `class_exists` guards).

### Docs
- `docs/compatibility-policy.md` — names both baselines, documents that 7.0+ is only for skills covering features unavailable on 6.9.
- `docs/skill-set-v1.md` — lists the three new skills.
- `README.md` — adds the three new skills to the Available Skills table (matches PR #22's precedent).

## Verification

Locally on `feat/wp-ai-skills`:

- `node eval/harness/run.mjs` → `OK: skills frontmatter and triage report sanity checks passed.`
- `node shared/scripts/skillpack-build.mjs --clean --out=/tmp/x --targets=codex,vscode` → both packs build.
- `node skills/wp-ai-client/scripts/detect_ai_client.mjs` → returns the documented JSON shape on a non-WP repo.

CI (`.github/workflows/ci.yml`) is unchanged. The `skills-ref validate` step in CI explicitly enumerates a subset of skills today (it does not currently validate `wp-rest-api`, `wp-phpstan`, `wpds`, `blueprint`, `wp-plugin-directory-guidelines` either) — I left it unchanged here so this PR is purely additive. Adding the new skills to that list is a separate cleanup if maintainers want it.

## Test plan

- [ ] `node eval/harness/run.mjs` passes on CI.
- [ ] Skillpack build + smoke install in CI passes (it already runs against the codex and vscode targets).
- [ ] Frontmatter on each of the three new skills matches the new baseline string `WordPress 7.0` + `PHP 7.4`.
- [ ] Frontmatter on every existing skill still matches `WordPress 6.9` + `PHP 7.2.24`.
- [ ] `wordpress-router` decision-tree changes route AI/MCP queries correctly without breaking existing routes.
- [ ] Spot-check one example from each new skill against the canonical source (Anthropic provider plugin, `Example_Experiment.php`, dev notes) to confirm method/namespace accuracy.

## Notes for maintainers

- Issue #48 frames the policy question. This PR is one option. I'm happy to close it and re-open under a different shape if a different approach wins the discussion there.
- AI authorship: the three new skills were drafted by Claude (Opus 4.7) against the canonical sources cited above and reviewed by me. `docs/ai-authorship.md` is intentionally not modified in this PR — the existing table is per-skill discretion (PR #22 did not extend it either) and I'd rather follow the maintainer's preference than guess.
- No version bump on the standalone skillpack manifest (none exists separately from `skills/`); the build script auto-discovers `skills/*/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
