### PR TITLE
Add wp-abuse-and-compromise-response skill (response counterpart to planned wp-security)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Agent Skills solve this by giving AI assistants **expert-level WordPress knowled
 | **wp-block-development** | Gutenberg blocks: `block.json`, attributes, rendering, deprecations |
 | **wp-block-themes** | Block themes: `theme.json`, templates, patterns, style variations |
 | **wp-plugin-development** | Plugin architecture, hooks, settings API, security |
+| **wp-abuse-and-compromise-response** | Response to a suspected or confirmed compromise: triage, investigation, cleanup, and post-cleanup hardening |
 | **wp-rest-api** | REST API routes/endpoints, schema, auth, and response shaping |
 | **wp-interactivity-api** | Frontend interactivity with `data-wp-*` directives and stores |
 | **wp-abilities-api** | Capability-based permissions and REST API authentication |

--- a/docs/ai-authorship.md
+++ b/docs/ai-authorship.md
@@ -35,6 +35,7 @@ All v1 skills followed the same process described above. As skills diverge in th
 | [wp-block-development](../skills/wp-block-development/SKILL.md) | Yes | Yes | Yes |
 | [wp-block-themes](../skills/wp-block-themes/SKILL.md) | Yes | Yes | Yes |
 | [wp-plugin-development](../skills/wp-plugin-development/SKILL.md) | Yes | Yes | Yes |
+| [wp-abuse-and-compromise-response](../skills/wp-abuse-and-compromise-response/SKILL.md) | Yes (Claude Opus 4.7) | Yes (community contributor with hosting-provider abuse-response background) | Pending |
 | [wp-rest-api](../skills/wp-rest-api/SKILL.md) | Yes | Yes | Yes |
 | [wp-interactivity-api](../skills/wp-interactivity-api/SKILL.md) | Yes | Yes | Yes |
 | [wp-abilities-api](../skills/wp-abilities-api/SKILL.md) | Yes | Yes | Yes |

--- a/eval/scenarios/abuse-confirmed-redirect-cleanup.json
+++ b/eval/scenarios/abuse-confirmed-redirect-cleanup.json
@@ -1,0 +1,28 @@
+{
+  "name": "Confirmed redirect-injection cleanup",
+  "skills": ["wordpress-router", "wp-project-triage", "wp-abuse-and-compromise-response"],
+  "query": "My WordPress site redirects mobile visitors to a casino site, but works normally for me when I'm logged in. I have SSH access and database access. Help me clean it up.",
+  "expected_behavior": [
+    "Step 1: Route via wordpress-router and triage with wp-project-triage to confirm WP install",
+    "Step 2: Confirm inputs: SSH and DB access available; ask about backup recency",
+    "Step 3: Contain — warn user about the redirect actively harming mobile users; suggest maintenance mode if traffic is significant",
+    "Step 4: Tell user NOT to change credentials yet — investigate first",
+    "Step 5: Classify as redirect injection (mobile-conditional, admin-excluded — classic conditional redirect)",
+    "Step 6: Investigate: grep .htaccess (root + subdirs) for RewriteCond/RewriteRule with external URLs; check wp-config.php for prepended PHP; check active theme functions.php for header() calls; check wp_options for siteurl/home tampering; check for injected JS in posts/options",
+    "Step 7: Recommend backup + DB dump as evidence before cleanup",
+    "Step 8: Clean: reset .htaccess to WP defaults, restore wp-config.php from scratch, reinstall active theme fresh, clean any wp_options or post content with injected content",
+    "Step 9: Check common-injection-points: mu-plugins/, wp_options autoloaded entries, scheduled cron, uploads/.php files",
+    "Step 10: Rotate credentials: WP admin passwords, DB password, secret keys, hosting credentials",
+    "Step 11: Verify: wp core verify-checksums, wp plugin verify-checksums, external scan (Sucuri SiteCheck), test from clean mobile browser session",
+    "Step 12: Harden: 2FA, DISALLOW_FILE_EDIT, deny PHP in uploads, limit login attempts, WAF recommendation"
+  ],
+  "success_criteria": [
+    "Skill routes to wp-abuse-and-compromise-response based on compromise indicators",
+    "AI does NOT rotate credentials before investigation",
+    "AI preserves evidence (snapshot or backup) before destructive cleanup",
+    "AI checks mu-plugins/, wp-config.php prepend/append, and autoloaded wp_options (the commonly-missed persistence points)",
+    "AI verifies cleanup via verify-checksums AND external scanner AND clean-browser test, not just one",
+    "AI recommends post-cleanup hardening that includes 2FA and PHP-execution-denial in uploads",
+    "AI flags escalation criteria (e.g. if site can't be reached clean after one attempt)"
+  ]
+}

--- a/eval/scenarios/abuse-reinfection-after-cleanup.json
+++ b/eval/scenarios/abuse-reinfection-after-cleanup.json
@@ -1,0 +1,24 @@
+{
+  "name": "Reinfection within days of previous cleanup",
+  "skills": ["wordpress-router", "wp-project-triage", "wp-abuse-and-compromise-response"],
+  "query": "I cleaned my WordPress site last week — restored from backup, updated everything, changed all passwords. Three days later the same spam links are back. What did I miss?",
+  "expected_behavior": [
+    "Step 1: Recognize this as a reinfection scenario — backdoor was missed during prior cleanup, not a new compromise",
+    "Step 2: Direct user to the persistence-mechanism catalog: mu-plugins/, wp-config.php prepend/append, autoloaded wp_options, scheduled cron events, drop-ins, plugin directories with WP-flavored names, web shells with non-standard extensions",
+    "Step 3: Question whether the backup itself was compromised — if compromise predates the backup, restoring from it re-introduces the malware",
+    "Step 4: Question whether the attacker has alternate access (SSH key in ~/.ssh/authorized_keys, host control-panel SSO, secondary admin account that was not caught)",
+    "Step 5: Recommend specific deep checks: ls -la wp-content/mu-plugins/, diff wp-config.php against a reconstructed-from-scratch version, query wp_options autoload entries for eval/base64/gzinflate, list cron events",
+    "Step 6: Consider shared-hosting neighbor compromise if everything else checks out — escalate to host",
+    "Step 7: For reinfection cases specifically: recommend doing manual cleanup path (b in skill) rather than relying on backup restore, because the backup is suspect",
+    "Step 8: Recommend external scanner as a second opinion (Sucuri, Wordfence) to catch heuristic patterns missed by manual review"
+  ],
+  "success_criteria": [
+    "AI does NOT recommend repeating the exact same cleanup that just failed",
+    "AI focuses on persistence mechanisms (mu-plugins, autoload options, prepended wp-config.php) over surface symptoms",
+    "AI questions the backup's integrity and suggests manual cleanup alternative",
+    "AI considers host-level or shared-hosting causes",
+    "AI recommends external scanning as a cross-check",
+    "AI does NOT suggest just changing passwords again as a solution",
+    "AI explicitly flags escalation to host if reinfection persists after thorough manual cleanup"
+  ]
+}

--- a/eval/scenarios/abuse-suspected-but-unconfirmed.json
+++ b/eval/scenarios/abuse-suspected-but-unconfirmed.json
@@ -1,0 +1,24 @@
+{
+  "name": "Suspected compromise — confirm or rule out",
+  "skills": ["wordpress-router", "wp-project-triage", "wp-abuse-and-compromise-response"],
+  "query": "I think my WordPress site might be hacked but I'm not sure. Search results show some weird keywords, but the site looks normal to me when I visit it. Can you help me figure out if it's actually compromised?",
+  "expected_behavior": [
+    "Step 1: Route via wordpress-router; confirm WP install",
+    "Step 2: Recognize SEO spam indicator (search results show keywords absent from visible site = cloaking pattern)",
+    "Step 3: Ask user for inputs: access type (admin/SFTP/DB/WP-CLI), backup recency, hosting environment",
+    "Step 4: Direct user to verify cloaking: search Google for site:domain.com with pharma/casino/loan keywords; fetch site as Googlebot; view source for hidden divs/links",
+    "Step 5: If cloaking confirmed: classify as SEO spam injection, proceed with investigation",
+    "Step 6: If cloaking NOT confirmed but symptoms persist: run cheap checks anyway (verify-checksums, list admin users, list cron, scan uploads for .php) since SEO spam is one of the most-missed categories",
+    "Step 7: For SEO spam specifically: check theme footer.php/header.php/functions.php, wp_options for hidden links, wp_posts for injected script tags",
+    "Step 8: Reference common-injection-points for less-obvious spots: mu-plugins, autoloaded options, drop-ins",
+    "Step 9: If still nothing found: recommend external malware scanner (Sucuri SiteCheck) for second opinion before declaring clean"
+  ],
+  "success_criteria": [
+    "AI recognizes the cloaking pattern (visible site clean, search results dirty)",
+    "AI does NOT immediately declare 'looks fine' based on owner view alone",
+    "AI checks Googlebot-perspective view of the site",
+    "AI runs verify-checksums and cheap inspection commands even before confirming compromise",
+    "AI flags both confirmation paths (yes-compromised → cleanup; no-still-suspicious → external scanner)",
+    "AI doesn't recommend credential rotation or hardening until compromise is confirmed and cleaned"
+  ]
+}

--- a/skills/wordpress-router/references/decision-tree.md
+++ b/skills/wordpress-router/references/decision-tree.md
@@ -47,6 +47,8 @@ Route by intent even if repo kind is broad (like `wp-site`):
   - Route → `wp-performance`.
 - **Security / nonces / capabilities / sanitization/escaping / uploads**
   - Route → `wp-security` (planned).
+- **Compromise / hacked / defaced / malware / redirect injection / SEO spam / phishing page / mailer abuse / cryptominer / reinfection**
+  - Route → `wp-abuse-and-compromise-response`.
 
 ## Step 3: guardrails checklist (always)
 

--- a/skills/wp-abuse-and-compromise-response/SKILL.md
+++ b/skills/wp-abuse-and-compromise-response/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: wp-abuse-and-compromise-response
+description: "Use when responding to a suspected or confirmed WordPress site compromise — defacement, redirect injection, SEO spam, phishing-page host, mailer abuse, cryptominer, or supply-chain plugin attack. Walks through triage, investigation, cleanup, and post-cleanup hardening."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Requires WP admin OR SSH/SFTP access; full triage benefits from database access and WP-CLI. Some steps reference standard malware-scan services."
+---
+
+# WordPress Abuse & Compromise Response
+
+## When to use
+
+Trigger this skill when the user reports any of:
+
+- **Visible signs:** defacement, unexpected popups/ads, redirects to scam/casino/pharma sites, search results showing keywords they never wrote.
+- **Hidden signs:** sudden traffic drop, sudden CPU/memory spike, white-screen-of-death, unknown admin users, modified core files.
+- **External signals:** Google Safe Browsing warning, Search Console security issue, host abuse notification, customer-reported spam from the site's domain.
+
+Also trigger when the user *suspects* compromise but isn't sure — step 0 confirms or rules out.
+
+This skill is response-focused. Upfront prevention (without an active incident) belongs in the planned `wp-security` skill; section 7 here covers post-cleanup hardening only.
+
+## Inputs required
+
+- Site URL (and any other domains pointing to the same install).
+- Access available: WP admin / SSH or SFTP / database / WP-CLI on the server.
+- Backup availability — when was the last known-clean backup?
+- Reported symptoms (visible / hidden / external).
+- Hosting environment — shared, VPS, managed, or self-hosted.
+- Time-sensitivity — is the site actively serving malicious content to real users?
+
+## Procedure
+
+### 0) Triage and confirm WP install
+
+- Run project triage: `node skills/wp-project-triage/scripts/detect_wp_project.mjs`
+- Confirm `project.kind` is one of `wp-site`, `wp-plugin`, `wp-theme`, `wp-block-theme`, `wp-core`. If `unknown`, this skill does not apply — escalate.
+- Run the fast compromise-signature scan: `node skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs`
+- The scan does NOT replace step 3 — it surfaces high-confidence indicators (PHP in uploads, eval+base64 patterns, mu-plugins present, recent core mtimes, WP-flavored bait directories) that often confirm category early.
+
+### 1) Contain — *preserve evidence, kill live sessions*
+
+- If actively serving malware/phishing to visitors: take site offline (maintenance plugin, `.htaccess` deny-all, or have the host suspend serving while preserving files).
+- If only suspected, no live harm: leave up, plan to act within hours.
+- Take a file snapshot (compressed tar) and a DB dump for evidence. Store offline.
+- **Rotate WP secret keys/salts now** — generate new at https://api.wordpress.org/secret-key/1.1/salt/ and replace in `wp-config.php`. This invalidates every existing session (including the attacker's), but does NOT trigger password-change emails or otherwise tip off the attacker.
+- **Defer full password rotation until after step 5** — backdoors will silently re-establish access if you rotate credentials before cleanup. WordPress.org's [hacked-site FAQ](https://wordpress.org/documentation/article/faq-my-site-was-hacked/) recommends an initial reset-and-rotate-again approach; this skill prefers the salts-only initial rotation because it kills sessions without warning the attacker, then a full credential rotation after cleanup (step 5). Pick the path that matches the situation — if you cannot complete investigation + cleanup within hours, do a full password reset now and another after cleanup.
+
+### 2) Classify the compromise type
+
+Match signals to categories using [references/signals.md](references/signals.md). Quick mapping:
+
+| Signal | Likely category |
+|---|---|
+| Defacement / political content | Defacement (often opportunistic file-overwrite) |
+| Spam keywords in search results, hidden links in source | SEO spam injection |
+| Redirects to casino/pharma, mobile-only or referrer-conditional | Redirect injection |
+| Unfamiliar `/login`/`/verify`/`/PayPal` paths added | Phishing-page host |
+| Outbound spam, domain on blocklists | Mailer abuse |
+| `eval(gzinflate(base64_decode(...)))` patterns | WP-VCD-style eval+base64 loader (nulled-plugin malware family) |
+| Plugin recently updated, multiple unrelated sites hit same day | Supply-chain plugin compromise |
+
+Multiple categories often co-exist — one breach drops phishing + cryptominer + redirect simultaneously.
+
+### 3) Investigate
+
+Cheap deterministic checks first:
+
+```bash
+wp core verify-checksums                    # modified core files
+wp plugin verify-checksums --all            # modified plugins from .org repo
+wp user list --role=administrator           # unfamiliar admins?
+wp cron event list                          # unfamiliar hooks?
+find wp-content/uploads -name "*.php" -o -name "*.phtml" -o -name "*.phar"
+```
+
+Then DB queries, log triage, and the full investigation playbook in [references/investigation.md](references/investigation.md).
+
+See [references/common-injection-points.md](references/common-injection-points.md) for the catalog of where attackers hide — particularly `mu-plugins/`, autoloaded `wp_options`, and `wp-config.php` prepend/append (intentionally not part of `verify-checksums`).
+
+**Don't skip the local-machine scan.** Per the [WordPress.org hacked-site FAQ](https://wordpress.org/documentation/article/faq-my-site-was-hacked/), a major vector for site compromise is the **site owner's own computer** being infected with malware that exfiltrates SFTP/admin credentials from saved sessions or browser storage. Before assuming the breach happened server-side, ask the user to run a current malware scan on every machine that has logged into the site. If their local machine is the source, all server-side cleanup is futile until that's resolved.
+
+### 4) Clean
+
+Before any destructive step, confirm with the user:
+
+- [ ] Full file + DB snapshot of the current state stored outside the site.
+- [ ] Access to reinstall any custom plugins/themes from original sources.
+- [ ] Understanding that all logged-in users will be logged out when salts are rotated in step 5.
+
+If any is no, pause and resolve. The compromise is rarely so urgent that an hour of prep matters less than an unrecoverable mistake.
+
+Two paths. Prefer (a) when available.
+
+**(a) Restore from a known-clean backup:** confirm backup predates compromise (timestamps + DB content), restore files + DB, re-apply legitimate changes since the backup, skip to step 5.
+
+**(b) Manual cleanup:** replace WP core with a fresh wordpress.org download. Delete every plugin/theme directory and reinstall fresh from official sources. Reconstruct `wp-config.php` from scratch (do not "clean" the existing one — see [references/common-injection-points.md](references/common-injection-points.md) §2). Delete every `.php`/`.phtml`/`.phar`/`.htaccess` from `wp-content/uploads/`. Reset root `.htaccess` to WP defaults. Clean DB: delete suspicious users, suspicious `wp_options` rows (eval/base64/iframe patterns), injected `<script>` from `wp_posts`, unfamiliar tables, unfamiliar cron events.
+
+### 5) Rotate credentials — full pass, after cleanup
+
+(Salts were already rotated in step 1. This is the full credential pass.)
+
+In order: WP admin passwords (`wp user reset-password $(wp user list --format=ids)`) → DB user password → WP secret keys/salts (rotate again — new from https://api.wordpress.org/secret-key/1.1/salt/) → hosting credentials → SSH `authorized_keys` audit → API keys (Akismet, payment gateway, mail) → 2FA on every admin.
+
+Per the [WordPress.org hacked-site FAQ](https://wordpress.org/documentation/article/faq-my-site-was-hacked/), salts and passwords should be rotated **again** after cleanup — even if you rotated already in step 1 — because the cleanup may have introduced changes you'd want to confirm don't include lingering compromise paths.
+
+### 6) Verify clean
+
+Re-run the cheap checks from step 3 — all must return clean. Then:
+
+- External malware scanner (Sucuri SiteCheck, Wordfence, MalCare) reports clean.
+- Submit Search Console reconsideration request if Safe Browsing flagged the site.
+- Test originally-affected URLs in a private browser session on a different network.
+
+### 7) Harden — *prevent recurrence*
+
+Full checklist in [references/hardening.md](references/hardening.md). Minimum:
+
+- 2FA for every admin. Non-negotiable.
+- Strong unique passwords for all users.
+- Limit login attempts (plugin or host-level fail2ban).
+- `define('DISALLOW_FILE_EDIT', true);` in `wp-config.php`.
+- Deny PHP execution in `wp-content/uploads/` via `.htaccess`.
+- Updated core/plugins/themes; remove unused.
+- Automated offsite backups, tested.
+
+## Verification
+
+Cleanup is successful when **all** of these hold:
+
+- [ ] `wp core verify-checksums` returns no warnings.
+- [ ] `wp plugin verify-checksums --all` returns no warnings.
+- [ ] `wp user list --role=administrator` shows only known users.
+- [ ] No `.php` files under `wp-content/uploads/`.
+- [ ] No unknown plugins in `wp option get active_plugins`.
+- [ ] No unknown cron events.
+- [ ] External malware scanner reports clean.
+- [ ] Originally-affected behavior is gone from a clean browser session.
+- [ ] All credentials in step 5 rotated.
+- [ ] 2FA enabled for every admin.
+
+## Failure modes / debugging
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Compromise reappears within days | Backdoor missed (commonly `mu-plugins/`, prepended `wp-config.php`, autoloaded `wp_options` row, scheduled cron) | Re-investigate persistence mechanisms — see [references/common-injection-points.md](references/common-injection-points.md) |
+| Backup itself is compromised | Backup taken after initial breach | Restore further back OR proceed with manual cleanup (step 4 path b) |
+| Site breaks after cleanup | Wrong plugin/theme version, missing custom mods | Test on staging first; diff against pre-cleanup snapshot for legitimate customizations |
+| Reinfection within hours | Shared-hosting neighbor compromise, OR attacker still has SSH/control-panel access | Contact host. Audit `~/.ssh/authorized_keys`, control-panel SSO |
+| Still Safe-Browsing-flagged after cleanup | Cached judgment | Submit reconsideration in Search Console after verifying clean externally |
+| Site keeps sending spam after cleanup | Compromise at MTA/server level, not WP | Escalate to host — server-level audit needed |
+
+## Escalation
+
+Stop trying to handle inside the agent loop and escalate to a human when:
+
+- Card data, health data, or other regulated PII may have been exposed → legal notification obligations (GDPR, US state breach laws, HIPAA).
+- Site is sending mass spam to thousands of recipients → host should be involved immediately.
+- You can't reach a clean state after one cleanup attempt → recommend a specialist forensic service.
+- Attacker behavior suggests targeted/persistent threat (multiple reinfections, specific-file access patterns) → law enforcement may be appropriate.
+- Site owner runs a business critical to other people (donations, hospital, school) and is over their head → managed-WP host or specialist firm.
+
+## See also
+
+- [references/signals.md](references/signals.md) — full signal-to-category mapping
+- [references/investigation.md](references/investigation.md) — DB queries, log triage, deep checks
+- [references/common-injection-points.md](references/common-injection-points.md) — catalog of where attackers hide (mu-plugins, autoload, drop-ins, etc.)
+- [references/hardening.md](references/hardening.md) — full post-cleanup hardening checklist
+- `scripts/detect_compromise_signals.mjs` — deterministic fast-scan helper called in step 0

--- a/skills/wp-abuse-and-compromise-response/SKILL.md
+++ b/skills/wp-abuse-and-compromise-response/SKILL.md
@@ -41,8 +41,8 @@ This skill is response-focused. Upfront prevention (without an active incident) 
 - If actively serving malware/phishing to visitors: take site offline (maintenance plugin, `.htaccess` deny-all, or have the host suspend serving while preserving files).
 - If only suspected, no live harm: leave up, plan to act within hours.
 - Take a file snapshot (compressed tar) and a DB dump for evidence. Store offline.
-- **Rotate WP secret keys/salts now** — generate new at https://api.wordpress.org/secret-key/1.1/salt/ and replace in `wp-config.php`. This invalidates every existing session (including the attacker's), but does NOT trigger password-change emails or otherwise tip off the attacker.
-- **Defer full password rotation until after step 5** — backdoors will silently re-establish access if you rotate credentials before cleanup. WordPress.org's [hacked-site FAQ](https://wordpress.org/documentation/article/faq-my-site-was-hacked/) recommends an initial reset-and-rotate-again approach; this skill prefers the salts-only initial rotation because it kills sessions without warning the attacker, then a full credential rotation after cleanup (step 5). Pick the path that matches the situation — if you cannot complete investigation + cleanup within hours, do a full password reset now and another after cleanup.
+- **Rotate WP secret keys/salts now** — generate new at https://api.wordpress.org/secret-key/1.1/salt/ and replace in `wp-config.php`. This invalidates every existing session (including the attacker's) and does not send password-change emails. The attacker WILL notice their session was killed (it's an observable signal) and may try to re-establish access via any backdoor they planted — that's why this is paired with steps 2–7, not a standalone fix.
+- **Defer full password rotation until after step 5** — backdoors will silently re-establish credential access if you rotate before cleanup. WordPress.org's [hacked-site FAQ](https://wordpress.org/documentation/article/faq-my-site-was-hacked/) recommends an initial reset-and-rotate-again approach; this skill prefers the salts-only initial rotation because it doesn't blast password-change emails to thousands of customer accounts on a WooCommerce/membership site. Pick the path that matches the situation — if you cannot complete investigation + cleanup within hours, also reset admin/editor passwords now and again after cleanup.
 
 ### 2) Classify the compromise type
 
@@ -112,7 +112,23 @@ Two paths. Prefer (a) when available.
 
 (Salts were already rotated in step 1. This is the full credential pass.)
 
-In order: WP admin passwords (`wp user reset-password $(wp user list --format=ids)`) → DB user password → WP secret keys/salts (rotate again — new from https://api.wordpress.org/secret-key/1.1/salt/) → hosting credentials → SSH `authorized_keys` audit → API keys (Akismet, payment gateway, mail) → 2FA on every admin.
+In order:
+
+1. **Privileged WP users only** (NOT customers/subscribers/everyone). Default `wp user reset-password` emails every targeted user a reset link — on a WooCommerce or membership site this would blast thousands of emails to customers and to any attacker-controlled account. Scope tightly and skip the email blast:
+   ```bash
+   wp user reset-password \
+       $(wp user list --role=administrator,editor --format=ids) \
+       --skip-email
+   ```
+   Then notify the legitimate admins/editors out-of-band (Slack, in-person, separate email account) with new credentials.
+2. DB user password (and update `wp-config.php`).
+3. WP secret keys / salts — rotate **again** even if you rotated in step 1 (new at https://api.wordpress.org/secret-key/1.1/salt/).
+4. Hosting credentials (cPanel / dashboard, SFTP, SSH).
+5. SSH `authorized_keys` audit — remove unfamiliar keys.
+6. API keys (Akismet, payment gateway, transactional mail, anything connected).
+7. 2FA on every admin.
+
+For non-admin users (subscribers/customers), prefer "force re-login + invalidate sessions" over a mass password reset. The salts rotation in step 1 already invalidates their sessions.
 
 Per the [WordPress.org hacked-site FAQ](https://wordpress.org/documentation/article/faq-my-site-was-hacked/), salts and passwords should be rotated **again** after cleanup — even if you rotated already in step 1 — because the cleanup may have introduced changes you'd want to confirm don't include lingering compromise paths.
 

--- a/skills/wp-abuse-and-compromise-response/SKILL.md
+++ b/skills/wp-abuse-and-compromise-response/SKILL.md
@@ -78,6 +78,20 @@ See [references/common-injection-points.md](references/common-injection-points.m
 
 **Don't skip the local-machine scan.** Per the [WordPress.org hacked-site FAQ](https://wordpress.org/documentation/article/faq-my-site-was-hacked/), a major vector for site compromise is the **site owner's own computer** being infected with malware that exfiltrates SFTP/admin credentials from saved sessions or browser storage. Before assuming the breach happened server-side, ask the user to run a current malware scan on every machine that has logged into the site. If their local machine is the source, all server-side cleanup is futile until that's resolved.
 
+**Check for known vulnerabilities affecting the installed versions.** A breach is often the result of an unpatched CVE in a specific plugin/theme/core version — knowing which CVE points at the entry point and confirms the attack vector. Run:
+
+```bash
+node skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs --check-vulns
+```
+
+This queries [wpvulnerability.com](https://www.wpvulnerability.com/) (free, no API key, aggregates WPScan + Patchstack + WP.org sources) for each detected component. Alternatives if you prefer different data sources:
+
+- **Patchstack** vulnerability database: https://patchstack.com/database/
+- **WPScan** API (free tier 25 requests/day; API key for more): https://wpscan.com/api
+- **Wordfence Intelligence** CVE feed: https://www.wordfence.com/threat-intel/
+
+If a vulnerability matching the installed version appears in the report, treat the unpatched component as the most likely entry point and prioritize patching it during step 4 (clean).
+
 ### 4) Clean
 
 Before any destructive step, confirm with the user:

--- a/skills/wp-abuse-and-compromise-response/references/common-injection-points.md
+++ b/skills/wp-abuse-and-compromise-response/references/common-injection-points.md
@@ -1,0 +1,199 @@
+# Common injection points
+
+Catalog of where attackers hide things, ordered roughly by frequency of being missed during cleanup. This is the doc that prevents re-infection.
+
+If a compromise reappears within days of cleanup, **the missed backdoor is almost always somewhere in this list.**
+
+## 1. mu-plugins/ — the most-missed hiding place
+
+`wp-content/mu-plugins/` (must-use plugins) auto-load on every request without requiring activation. They don't appear in the WP admin's Plugins page. Many cleanups skip this directory entirely.
+
+Check for:
+
+```bash
+ls -la wp-content/mu-plugins/
+```
+
+Most legitimate sites don't use mu-plugins. If the directory exists and contains files you don't recognize, treat as compromised.
+
+Common payload patterns inside:
+- A small PHP file that `require_once`s a hidden file elsewhere (often inside `uploads/` or a benign-named directory)
+- A file that re-installs other malware on each request (auto-repair after partial cleanups)
+
+## 2. wp-config.php — prepended or appended
+
+`wp-config.php` is intentionally not part of WP's checksum file, so `verify-checksums` won't catch modifications.
+
+Attackers commonly:
+- Prepend PHP at the very top, before the `<?php` of legitimate config
+- Append PHP at the end, after the closing block
+- Inject a `require` statement pointing at a backdoor file elsewhere
+
+After cleanup, manually re-create `wp-config.php` from scratch using:
+- DB credentials (host, name, user, pass)
+- A fresh set of salts from https://api.wordpress.org/secret-key/1.1/salt/
+- Standard table prefix
+- Any legitimate constants (debug, memory limit, etc.)
+
+Don't trust the file you found — diff it against a clean baseline you control.
+
+## 3. wp_options — autoloaded malicious payloads
+
+The `wp_options` table loads every row marked `autoload='yes'` on every request. Attackers store serialized PHP or base64 blobs that get eval'd by a small loader elsewhere.
+
+Query patterns to flag (see [investigation.md](investigation.md) for the full SQL):
+- `option_value` containing `eval(`, `base64_decode`, `gzinflate`
+- `option_value` containing `<script>` or `<iframe>` (especially if option name is generic like `widget_text`, `wp_user_roles`, or random)
+- Autoloaded options with very large values (multi-KB) and obscure names — often base64-encoded payloads
+
+Cleanup: delete the suspicious row (after verifying it's not legitimate plugin data), then re-test.
+
+## 4. Active theme's functions.php — appended code
+
+Quick to drop, hard to spot unless the file is large to begin with. Attackers:
+- Append code after the legitimate theme code
+- Add a `require` for a file elsewhere
+
+After cleanup, replace the theme with a fresh download. If it's a custom theme, diff against version control.
+
+## 5. .htaccess — root and subdirectories
+
+Multiple `.htaccess` files can affect behavior:
+- Root `.htaccess` — main rewrite rules
+- Per-directory `.htaccess` — override or add rules
+- Particularly `wp-content/uploads/.htaccess` — used to allow PHP execution there, or to redirect
+
+`RewriteRule` and `RewriteCond` lines with external URLs in the destination are red flags.
+
+Standard WP root `.htaccess` is small (~10 lines, no external URLs). If yours is larger, investigate.
+
+## 6. Scheduled WP cron events
+
+A cron hook fires on its schedule and can execute any registered function. Compromises use this for:
+- Periodic outbound spam blasts
+- Periodic re-infection (if cleanup misses other backdoors, the cron event reinstalls them)
+- Sleeper backdoors that activate weeks later
+
+After cleanup, list all cron events and remove any you don't recognize:
+
+```bash
+wp cron event list
+wp cron event delete <hook-name>
+```
+
+Match hook names to known plugins. Anything unmatched is suspect.
+
+## 7. Plugin directories with WP-flavored names
+
+Attackers create plugin directories with names that look like WordPress infrastructure:
+- `wp-config-php/` (not a real plugin)
+- `wp-content-update/`
+- `akismet-update/`
+- `wordpress-update/`
+- `wp-includes-update/`
+
+Or random short hex/alphanumeric names: `a1b2c3/`, `xyz/`.
+
+After cleanup, `ls wp-content/plugins/` and verify every directory corresponds to a plugin you intentionally installed.
+
+## 8. Web shells in unusual file extensions
+
+Default WP/PHP setups execute `.php` files. But misconfigurations can execute:
+- `.phtml`
+- `.phar`
+- `.php3`, `.php4`, `.php5`, `.php7`
+- `.pht`
+- Any file with `application/x-httpd-php` MIME handler
+
+When grepping for backdoors, check all of these. Hosts with strict configurations may only execute `.php`, but you can't assume that.
+
+## 9. Database — fake admin user with manipulated meta
+
+A user might appear non-admin in `wp_users.user_role`-equivalent fields but have admin caps via `wp_usermeta`:
+
+```sql
+SELECT u.ID, u.user_login, um.meta_value
+FROM wp_users u
+JOIN wp_usermeta um ON u.ID = um.user_id
+WHERE um.meta_key = 'wp_capabilities'
+  AND um.meta_value LIKE '%administrator%';
+```
+
+Or via `wp_user_level` >= 10. Or via custom capability arrays serialized into `wp_capabilities`.
+
+## 10. Active theme's `header.php` and `footer.php` — script/iframe injection
+
+Frontend-visible compromises that inject JavaScript or iframes for ad fraud / cryptominer drops often go here. After cleanup, diff the theme against the official version.
+
+## 11. `index.php` in WP root — replaced or wrapped
+
+WP root `index.php` is a tiny file (~17 lines, just bootstrap). If it's larger or contains anything beyond the bootstrap, it's been tampered with.
+
+Standard content:
+
+```php
+<?php
+/**
+ * Front to the WordPress application. This file doesn't do anything, but loads
+ * wp-blog-header.php which does and tells WordPress to load the theme.
+ *
+ * @package WordPress
+ */
+define( 'WP_USE_THEMES', true );
+require __DIR__ . '/wp-blog-header.php';
+```
+
+Replace if different.
+
+## 12. Drop-ins — auto-loaded files directly in wp-content/
+
+WordPress drop-ins live **directly in `wp-content/`** (not a `drop-ins/` subdirectory — that directory does not exist in stock WP). The recognized drop-in filenames are auto-loaded by core and rarely audited:
+
+- `advanced-cache.php`
+- `db.php`
+- `db-error.php`
+- `install.php`
+- `maintenance.php`
+- `object-cache.php`
+- `php-error.php`
+- `fatal-error-handler.php`
+- Multisite-only: `sunrise.php`, `blog-deleted.php`, `blog-inactive.php`, `blog-suspended.php`
+
+Reference: https://developer.wordpress.org/reference/functions/_get_dropins/
+
+Grep approach:
+
+```bash
+ls -la wp-content/{advanced-cache,db,db-error,install,maintenance,object-cache,php-error,fatal-error-handler,sunrise,blog-deleted,blog-inactive,blog-suspended}.php 2>/dev/null
+```
+
+Any file present is auto-loaded. Verify each against a known legitimate source (the caching plugin's drop-in, your hosting provider's `object-cache.php`, etc.). Unfamiliar content = compromise indicator.
+
+Also check: any custom code in `WP_CONTENT_DIR` referenced by an explicit `require` in `wp-config.php`.
+
+## 13. Plugin / theme update files left around
+
+Some compromises arrive via a fake "update" — attacker drops a file that pretends to be an update payload. Check:
+
+- `wp-content/upgrade/` — should be empty most of the time. If files persist there, may have been used to deliver malware.
+- Plugin / theme backup directories (`.bak`, `.old`) — often left intentionally by an attacker as fallback access.
+
+---
+
+## Backdoor persistence checklist
+
+After cleanup, before declaring victory, verify the following are clean:
+
+- [ ] `wp-content/mu-plugins/` — empty or contains only files you put there
+- [ ] `wp-config.php` — reconstructed from scratch, not the post-compromise version
+- [ ] `wp_options` autoloaded rows — no eval / base64 / gzinflate patterns
+- [ ] Active theme — fresh reinstall or diff-clean against source
+- [ ] All `.htaccess` files — only standard WP rewrite rules + your intentional rules
+- [ ] Scheduled cron events — only those matching known plugins
+- [ ] `wp-content/plugins/` — only directories for plugins you intentionally installed
+- [ ] `wp_users` and `wp_usermeta` — only known admins
+- [ ] `wp-content/uploads/` — no `.php`, `.phtml`, `.phar`, `.htaccess`, etc.
+- [ ] Drop-in files in `wp-content/` (e.g. `object-cache.php`, `advanced-cache.php`, `db.php`) — only those you intentionally added or that came from a known caching/optimization plugin
+- [ ] Root `index.php` — matches stock WP
+
+If any one of these isn't clean, the cleanup isn't done.

--- a/skills/wp-abuse-and-compromise-response/references/hardening.md
+++ b/skills/wp-abuse-and-compromise-response/references/hardening.md
@@ -180,12 +180,32 @@ Remove anything that fails. Deactivated plugins still get loaded for admin pages
 
 Auto-updates for minor releases of core, plugins, and themes are reasonable. Major core updates should be tested on staging first.
 
-### Vulnerability scanning
+### Vulnerability scanning — ongoing
 
-Subscribe to a vuln feed and act on alerts. Options:
-- Wordfence (free + paid)
-- Patchstack (free + paid)
-- WPScan vulnerability database
+A patched install is a much smaller attack surface than an unpatched one. Three things to set up:
+
+**1. Subscribe to a vulnerability feed** so you hear about new CVEs against your installed plugins/themes/core within hours, not weeks:
+
+| Source | Cost | Notes |
+|---|---|---|
+| [Patchstack](https://patchstack.com/) | Free + paid | WordPress-focused database; free tier includes alerts |
+| [WPScan](https://wpscan.com/) | Free tier (25 API requests/day) + paid | Used by `wp-cli-vulnerability-scanner` plugin |
+| [Wordfence Intelligence](https://www.wordfence.com/threat-intel/) | Free | Public CVE feed; daily updates |
+| [wpvulnerability.com](https://www.wpvulnerability.com/) | Free, no API key | Community aggregator of WPScan/Patchstack/WP.org sources |
+
+**2. Run an automated weekly scan** of installed components against your chosen feed:
+
+```bash
+# Using the detect script from this skill (queries wpvulnerability.com)
+node skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs --check-vulns
+
+# Or use a security plugin's built-in scanner
+wp wordfence scan          # if Wordfence is installed
+```
+
+Cron this from real server cron (not WP cron) so it runs even if WP itself is misbehaving. Alert on any non-empty result.
+
+**3. Patch promptly.** A CVE is worthless to an attacker once the version is patched. The window between disclosure and exploitation is now measured in hours for popular plugins.
 
 ### Premium plugin verification
 

--- a/skills/wp-abuse-and-compromise-response/references/hardening.md
+++ b/skills/wp-abuse-and-compromise-response/references/hardening.md
@@ -1,0 +1,319 @@
+# Post-cleanup hardening checklist
+
+Extension of step 7 in [SKILL.md](../SKILL.md). Run through this after a compromise has been cleaned and verified. Goal: make the same kind of attack much harder next time.
+
+Ordered roughly by impact-per-effort.
+
+## 1. Identity and access
+
+### Two-factor authentication for every admin
+
+Non-negotiable. Most WP compromises start with a credential compromise (phishing, reuse from another breach, brute force). 2FA blocks all of those.
+
+Options:
+- Built-in via plugin (Wordfence Login Security, miniOrange 2FA, Two-Factor)
+- Application-level (Authy / Authenticator)
+- Hardware (YubiKey / WebAuthn) — best, but requires plugin support
+
+### Strong unique passwords
+
+For all users, not just admins. Subscribers/customers with weak passwords can be elevated via a privilege-escalation bug; defense in depth.
+
+### Remove unused accounts
+
+Every former employee, every test account, every "just in case" account. Audit `wp user list` quarterly.
+
+### Rename default `admin` username
+
+If the site still uses `admin`, half the brute-force attempts succeed at the username step before even trying passwords.
+
+```sql
+UPDATE wp_users SET user_login='your-new-name' WHERE user_login='admin';
+```
+
+(Or do this via WP admin UI by creating a new admin, then deleting the old one.)
+
+## 2. Login surface reduction
+
+### Limit login attempts
+
+Block IPs after N failed attempts. Options:
+- Plugin: Limit Login Attempts Reloaded, Wordfence
+- Host-level: fail2ban with a WordPress filter
+- WAF level: Cloudflare rate-limiting rules on `/wp-login.php` and `/xmlrpc.php`
+
+### Disable XML-RPC if unused
+
+XML-RPC was historically used by mobile apps and pingbacks. Most modern sites don't need it. It's a common amplification target for brute force and pingback DDoS.
+
+Disable by adding to a mu-plugin or theme `functions.php`:
+
+```php
+add_filter( 'xmlrpc_enabled', '__return_false' );
+```
+
+Or block at the web-server level (`.htaccess` or nginx).
+
+### Hide WP version
+
+Not a real defense, but reduces noise from automated scanners targeting specific WP versions. Remove the generator meta tag and version query strings.
+
+### Custom login URL (optional)
+
+Plugins like WPS Hide Login move `wp-login.php` to a custom path. **Security-through-obscurity** — not a real defense against a targeted attacker, but blocks automated bots that hit `/wp-login.php` directly. Lower priority than rate limiting.
+
+## 3. File-system hardening
+
+### Disable file editing in admin
+
+Stops a compromised admin account from being used to modify theme/plugin files via the WP admin UI.
+
+```php
+// In wp-config.php
+define( 'DISALLOW_FILE_EDIT', true );
+define( 'DISALLOW_FILE_MODS', true );  // also stops plugin/theme installs from admin
+```
+
+`DISALLOW_FILE_MODS` is stricter — use only if you do plugin updates via WP-CLI or deployment.
+
+### Disable PHP execution in uploads
+
+PHP files should never execute from `wp-content/uploads/`. Add this `.htaccess` inside `wp-content/uploads/`:
+
+```
+<Files "*.php">
+  Order Deny,Allow
+  Deny from all
+</Files>
+<Files "*.phtml">
+  Order Deny,Allow
+  Deny from all
+</Files>
+<Files "*.phar">
+  Order Deny,Allow
+  Deny from all
+</Files>
+```
+
+For nginx (in server block):
+
+```nginx
+location ~* /wp-content/uploads/.*\.(php|phtml|phar)$ {
+    deny all;
+}
+```
+
+### File permissions
+
+Standard recommended permissions:
+- Files: 644 (`-rw-r--r--`)
+- Directories: 755 (`drwxr-xr-x`)
+- `wp-config.php`: 440 (`-rw-------`)
+
+Recursive set:
+
+```bash
+find . -type f -exec chmod 644 {} \;
+find . -type d -exec chmod 755 {} \;
+chmod 440 wp-config.php
+```
+
+Per the [WordPress.org hardening guide](https://developer.wordpress.org/advanced-administration/security/hardening/), `wp-config.php` should be **400 or 440** (read-only by owner, optionally by group). Some hosting setups require 440 so the web server's group can read; use 400 where 440 isn't required.
+
+### Disable directory listings
+
+```
+# Apache .htaccess
+Options -Indexes
+```
+
+```nginx
+# nginx
+autoindex off;
+```
+
+### Restrict the WordPress database user's privileges
+
+After install, WordPress only needs `SELECT`, `INSERT`, `UPDATE`, `DELETE` on its own database for day-to-day operation. `CREATE`, `ALTER`, `DROP` are only needed during plugin/theme installs and core upgrades.
+
+Per the [WordPress.org hardening guide](https://developer.wordpress.org/advanced-administration/security/hardening/), the practical pattern: create a separate admin DB user for upgrade-time use, and run the site under a restricted user the rest of the time. A compromise that gets DB access via the runtime user then cannot `DROP TABLE` or create new ones.
+
+```sql
+-- Restricted runtime user (example)
+GRANT SELECT, INSERT, UPDATE, DELETE ON wp_database.* TO 'wp_runtime'@'localhost';
+-- Privileged user used only for core/plugin/theme upgrades
+GRANT ALL PRIVILEGES ON wp_database.* TO 'wp_admin'@'localhost';
+```
+
+Swap in `wp_admin` for the upgrade flow, then swap back to `wp_runtime` once done.
+
+### HTTP basic auth in front of `/wp-admin/`
+
+Adds a server-level credential prompt before the WordPress login page even loads. Stops most automated bots from reaching `wp-login.php` and brute-forcing it. Per the [WordPress.org hardening guide](https://developer.wordpress.org/advanced-administration/security/hardening/).
+
+Apache example:
+
+```
+# .htaccess in /wp-admin/
+AuthType Basic
+AuthName "Restricted Admin"
+AuthUserFile /path/outside/web-root/.htpasswd
+Require valid-user
+```
+
+Generate `.htpasswd` with `htpasswd -c /path/outside/web-root/.htpasswd <username>`. Store the file outside the web root.
+
+For `wp-login.php` (which isn't inside `/wp-admin/`), use `<Files wp-login.php>` directives. AJAX needs to remain reachable, so exempt `admin-ajax.php`.
+
+## 4. Plugin and theme discipline
+
+### Audit and remove
+
+For each installed plugin and theme:
+- Do you actually use it?
+- Is it still maintained? (Last update within 12 months on .org)
+- Does it come from a trusted source? (No "nulled" / pirated plugins — major WP-VCD vector)
+
+Remove anything that fails. Deactivated plugins still get loaded for admin pages; uninstall completely.
+
+### Keep updated
+
+Auto-updates for minor releases of core, plugins, and themes are reasonable. Major core updates should be tested on staging first.
+
+### Vulnerability scanning
+
+Subscribe to a vuln feed and act on alerts. Options:
+- Wordfence (free + paid)
+- Patchstack (free + paid)
+- WPScan vulnerability database
+
+### Premium plugin verification
+
+For premium plugins (non-.org repo), verify the source. Download only from the vendor's official site. Confirm the file hash if the vendor publishes one.
+
+### Plugin family discipline
+
+If a plugin vendor has had a confirmed supply-chain compromise, audit all of their plugins on your sites. Compromised vendors often distribute interconnected plugin families — one compromise can be a window into all of them.
+
+## 5. Server / hosting
+
+### HTTPS everywhere
+
+Force HTTPS site-wide. Use HSTS for visitor browsers:
+
+```
+# .htaccess
+Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+```
+
+### PHP version
+
+Run a supported PHP version (currently 8.1+; minimum acceptable is whatever has security support — check https://www.php.net/supported-versions.php).
+
+### Disable dangerous PHP functions
+
+If your host allows custom `php.ini` or `.user.ini`, disable functions WP doesn't legitimately need:
+
+```ini
+disable_functions = exec,passthru,shell_exec,system,proc_open,popen,curl_multi_exec,parse_ini_file,show_source
+```
+
+Some legitimate plugins use `exec` / `shell_exec` (e.g. ImageMagick wrappers). Test before enforcing.
+
+### Web Application Firewall
+
+A WAF in front of the site blocks many attacks before they reach PHP. Options:
+- Cloudflare (free tier acceptable for basic)
+- Sucuri Firewall
+- Wordfence Premium (PHP-level, not cloud, but still blocks at the WP request level)
+
+### Disable PHP execution in writable directories beyond uploads
+
+Anywhere users can write should not execute PHP:
+- `wp-content/cache/` (most caching plugins)
+- `wp-content/backups/` (backup plugins)
+- Any plugin's own `cache/` or `tmp/` directory
+
+Same `.htaccess` pattern as uploads.
+
+## 6. Backups and monitoring
+
+### Automated offsite backups
+
+- Frequency: daily for content-changing sites, less for static
+- Storage: offsite (different provider from hosting). On-host backups don't survive host-level compromise.
+- Tested: restore one to a staging environment quarterly. Untested backups are not backups.
+
+### File integrity monitoring
+
+Run `wp core verify-checksums` and `wp plugin verify-checksums` in a real cron job (server cron, not WP cron). Alert on any flag.
+
+```bash
+# /etc/cron.d/wp-integrity (example)
+0 3 * * * /var/www/site && wp core verify-checksums && wp plugin verify-checksums --all
+```
+
+### External uptime + content monitoring
+
+Tools that fetch the site from outside and alert on:
+- Downtime
+- Unexpected redirects
+- Content changes
+- Safe Browsing flags
+
+Examples: UptimeRobot (basic), Sucuri, MalCare, custom Pingdom/StatusCake setups.
+
+## 7. Application-level defenses
+
+### Disable user enumeration
+
+Knowing valid usernames helps targeted brute force. WP exposes them via:
+- `/?author=N` redirect to author pages
+- REST API `/wp-json/wp/v2/users`
+
+Both can be disabled at the firewall / plugin level if user enumeration is a concern.
+
+### Disable / restrict REST API endpoints
+
+If you don't use the REST API publicly, restrict it to authenticated users. Many plugins enable endpoints by default that leak data.
+
+### Use a strong DB table prefix
+
+Default is `wp_`. A non-default prefix doesn't stop a determined attacker (it's queryable), but it stops some opportunistic SQL injection payloads that hardcode `wp_options`. Set at install; changing later is involved.
+
+### Disable comments if unused
+
+The comment system is the entry point for many spam and XSS attacks. If your site doesn't use comments, disable them site-wide:
+
+```php
+add_filter( 'comments_open', '__return_false', 20, 2 );
+add_filter( 'pings_open', '__return_false', 20, 2 );
+```
+
+## 8. Recovery preparedness
+
+After cleanup, your future self will thank you for:
+
+- Documented current state (active plugin list, theme, custom code locations)
+- Repository (or at least zip) of every custom plugin and theme
+- Documented credential rotation procedure (who has access to what, how to revoke)
+- One-page incident response runbook stored outside the site
+- Contact details for the host's abuse team
+
+The first hour of an incident is much easier when you don't have to look up basics.
+
+---
+
+## Minimum acceptable post-compromise hardening
+
+If only a subset is feasible, do at least:
+
+1. 2FA for every admin
+2. Strong unique passwords for every user
+3. Login attempt limit (plugin or fail2ban)
+4. `DISALLOW_FILE_EDIT` in `wp-config.php`
+5. PHP execution denied in `wp-content/uploads/`
+6. Updated core + plugins + themes; removed unused
+7. Automated offsite backups, tested
+
+That's the floor. Everything else is improvement.

--- a/skills/wp-abuse-and-compromise-response/references/hardening.md
+++ b/skills/wp-abuse-and-compromise-response/references/hardening.md
@@ -80,20 +80,14 @@ define( 'DISALLOW_FILE_MODS', true );  // also stops plugin/theme installs from 
 
 PHP files should never execute from `wp-content/uploads/`. Add this `.htaccess` inside `wp-content/uploads/`:
 
+```apache
+# Apache 2.4+ syntax
+<FilesMatch "\.(php|phtml|phar|php3|php4|php5|php7|pht)$">
+  Require all denied
+</FilesMatch>
 ```
-<Files "*.php">
-  Order Deny,Allow
-  Deny from all
-</Files>
-<Files "*.phtml">
-  Order Deny,Allow
-  Deny from all
-</Files>
-<Files "*.phar">
-  Order Deny,Allow
-  Deny from all
-</Files>
-```
+
+(The older `Order Deny,Allow` / `Deny from all` syntax from `mod_access_compat` is deprecated since Apache 2.4 and silently does nothing on servers without the compat module loaded.)
 
 For nginx (in server block):
 
@@ -108,7 +102,7 @@ location ~* /wp-content/uploads/.*\.(php|phtml|phar)$ {
 Standard recommended permissions:
 - Files: 644 (`-rw-r--r--`)
 - Directories: 755 (`drwxr-xr-x`)
-- `wp-config.php`: 440 (`-rw-------`)
+- `wp-config.php`: 440 (`-r--r-----`) or 400 (`-r--------`) — see note below
 
 Recursive set:
 
@@ -132,20 +126,25 @@ Options -Indexes
 autoindex off;
 ```
 
-### Restrict the WordPress database user's privileges
+### Restrict the WordPress database user's privileges (with a real caveat)
 
-After install, WordPress only needs `SELECT`, `INSERT`, `UPDATE`, `DELETE` on its own database for day-to-day operation. `CREATE`, `ALTER`, `DROP` are only needed during plugin/theme installs and core upgrades.
-
-Per the [WordPress.org hardening guide](https://developer.wordpress.org/advanced-administration/security/hardening/), the practical pattern: create a separate admin DB user for upgrade-time use, and run the site under a restricted user the rest of the time. A compromise that gets DB access via the runtime user then cannot `DROP TABLE` or create new ones.
+Per the [WordPress.org hardening guide](https://developer.wordpress.org/advanced-administration/security/hardening/), one model is: a restricted runtime DB user (SELECT/INSERT/UPDATE/DELETE only) for day-to-day operation, plus a privileged admin DB user used only for upgrades. A compromise that gets DB access via the runtime user then cannot `DROP TABLE` or create new ones.
 
 ```sql
--- Restricted runtime user (example)
+-- Restricted runtime user
 GRANT SELECT, INSERT, UPDATE, DELETE ON wp_database.* TO 'wp_runtime'@'localhost';
--- Privileged user used only for core/plugin/theme upgrades
+-- Privileged user, used only for core/plugin/theme installs and upgrades
 GRANT ALL PRIVILEGES ON wp_database.* TO 'wp_admin'@'localhost';
 ```
 
-Swap in `wp_admin` for the upgrade flow, then swap back to `wp_runtime` once done.
+**Important caveat:** many WordPress plugins call `dbDelta()` to create or alter tables not only at activation but also during routine operation (cache invalidation, schema migrations on plugin update, on-demand table creation, etc.). Running long-term under a `SELECT/INSERT/UPDATE/DELETE`-only user will silently break those plugins — often with subtle errors that are hard to diagnose.
+
+If you adopt this model:
+- Test thoroughly on a staging copy first with every plugin you actually use.
+- Watch error logs for `CREATE TABLE` / `ALTER TABLE` failures after plugin updates.
+- Be ready to grant `CREATE`/`ALTER`/`INDEX` temporarily when a plugin needs schema work.
+
+The cleaner alternative for most sites: use the standard WP DB user with full privileges on its own database, and instead invest in keeping the runtime *environment* secure (file permissions, WAF, 2FA, vuln scanning).
 
 ### HTTP basic auth in front of `/wp-admin/`
 
@@ -235,10 +234,15 @@ Run a supported PHP version (currently 8.1+; minimum acceptable is whatever has 
 If your host allows custom `php.ini` or `.user.ini`, disable functions WP doesn't legitimately need:
 
 ```ini
-disable_functions = exec,passthru,shell_exec,system,proc_open,popen,curl_multi_exec,parse_ini_file,show_source
+disable_functions = exec,passthru,shell_exec,system,proc_open,popen,show_source
 ```
 
-Some legitimate plugins use `exec` / `shell_exec` (e.g. ImageMagick wrappers). Test before enforcing.
+Caveats — DO NOT blindly include these even though some hardening guides list them:
+- `curl_multi_exec` — used by legitimate plugins that fetch from multiple URLs in parallel (page builders, analytics, social integrations).
+- `parse_ini_file` — used by some plugins for config loading.
+- `exec` / `shell_exec` — some plugins legitimately need these (ImageMagick wrappers, backup plugins that shell out to `mysqldump`).
+
+Test on staging first. The list above is a reasonable default but should be tuned to your actual plugin set.
 
 ### Web Application Firewall
 

--- a/skills/wp-abuse-and-compromise-response/references/investigation.md
+++ b/skills/wp-abuse-and-compromise-response/references/investigation.md
@@ -1,0 +1,220 @@
+# Investigation — detailed commands and queries
+
+Extension of step 3 in [SKILL.md](../SKILL.md). When the cheap checks turn up something, dig deeper here.
+
+## File-system investigation
+
+### Find recently modified PHP files
+
+```bash
+# Modified in the last 30 days under WP core (should match release timestamps only)
+find wp-admin wp-includes -name "*.php" -mtime -30 -ls
+
+# Modified in the last 7 days site-wide
+find . -name "*.php" -mtime -7 -ls
+
+# Suspiciously small PHP files (web shells are often tiny)
+find . -name "*.php" -size -1k -mtime -90 -ls
+```
+
+### Find files that shouldn't exist where they are
+
+```bash
+# .php in uploads (NEVER legitimate)
+find wp-content/uploads -name "*.php" -o -name "*.phtml" -o -name "*.phar"
+
+# .htaccess in uploads (rare to be legitimate; usually attacker bypass)
+find wp-content/uploads -name ".htaccess"
+
+# Files with no extension that contain PHP
+find . -type f ! -name "*.*" -exec grep -l "<?php" {} \;
+```
+
+### Grep for known malware patterns
+
+```bash
+# Obfuscated payload signatures
+grep -rl "eval(gzinflate(base64_decode" . 2>/dev/null
+grep -rl "eval(base64_decode" . 2>/dev/null
+grep -rl "preg_replace.*\/e.*base64" . 2>/dev/null   # legacy /e modifier RCE
+
+# Web shell signatures
+grep -rl "eval(\$_POST\|eval(\$_GET\|eval(\$_REQUEST" .
+grep -rl "assert(\$_POST\|assert(\$_GET\|assert(\$_REQUEST" .
+grep -rl "system(\$_\|shell_exec(\$_\|passthru(\$_\|exec(\$_" .
+
+# Known malware-family file names
+find . -name "wp-vcd.php" -o -name "wp-tmp.php" -o -name "wp-feed.php"
+find . -iname "c99.php" -o -iname "r57.php" -o -iname "wso.php" -o -iname "b374k.php"
+```
+
+### Find plugin directories not from the .org repo
+
+```bash
+# Plugins that exist locally but aren't tracked by WP-CLI's plugin list
+wp plugin list --format=csv | tail -n +2 | cut -d, -f1 > /tmp/known-plugins.txt
+ls wp-content/plugins/ | sort > /tmp/dir-plugins.txt
+diff /tmp/known-plugins.txt /tmp/dir-plugins.txt
+```
+
+## Database investigation
+
+### Recently created users
+
+```sql
+SELECT ID, user_login, user_email, user_registered, user_status
+FROM wp_users
+ORDER BY user_registered DESC
+LIMIT 30;
+```
+
+Look for:
+- Recent additions you don't recognize
+- Emails on unusual domains (gmail/yandex/protonmail are common in compromises; corporate emails are not)
+- High `ID` values clustered together (often a sign of bulk-added users)
+- `user_login` patterns like `admin1`, `adminer`, `wp_admin`, single-letter handles
+
+### Hidden admin users
+
+Some compromises add admin capabilities via `wp_usermeta` rather than the role column:
+
+```sql
+SELECT u.ID, u.user_login, u.user_email, um.meta_value
+FROM wp_users u
+JOIN wp_usermeta um ON u.ID = um.user_id
+WHERE um.meta_key = 'wp_capabilities'
+  AND um.meta_value LIKE '%administrator%';
+```
+
+### Autoloaded options carrying malicious payloads
+
+```sql
+SELECT option_id, option_name, LEFT(option_value, 300) AS preview, autoload
+FROM wp_options
+WHERE autoload = 'yes'
+  AND (option_value LIKE '%eval(%'
+       OR option_value LIKE '%base64_decode%'
+       OR option_value LIKE '%gzinflate%'
+       OR option_value LIKE '%<script%'
+       OR option_value LIKE '%<iframe%');
+```
+
+### Look for suspicious cron events
+
+```sql
+SELECT option_value
+FROM wp_options
+WHERE option_name = 'cron';
+```
+
+Parse the result (it's a PHP-serialized array). Or via WP-CLI:
+
+```bash
+wp cron event list
+```
+
+Suspicious entries:
+- Hook names that don't match any known plugin or theme
+- Events scheduled to fire very frequently (every minute, every 5 minutes)
+- Events with `next_run_gmt` far in the future (sleeper jobs)
+
+### Posts with injected content
+
+```sql
+-- Posts with script tags (frequently injected)
+SELECT ID, post_title, post_modified, LEFT(post_content, 200)
+FROM wp_posts
+WHERE post_status IN ('publish', 'draft')
+  AND (post_content LIKE '%<script%'
+       OR post_content LIKE '%<iframe%'
+       OR post_content LIKE '%base64%');
+
+-- Posts modified in bulk recently (sign of an injection sweep)
+SELECT DATE(post_modified) AS day, COUNT(*) AS modified_count
+FROM wp_posts
+GROUP BY day
+ORDER BY day DESC
+LIMIT 30;
+```
+
+A sudden spike in modified posts on a single day usually indicates an injection sweep.
+
+### Unfamiliar tables
+
+```sql
+SHOW TABLES;
+```
+
+Stock WordPress (single-site) has 12 tables: `wp_commentmeta`, `wp_comments`, `wp_links`, `wp_options`, `wp_postmeta`, `wp_posts`, `wp_term_relationships`, `wp_term_taxonomy`, `wp_termmeta`, `wp_terms`, `wp_usermeta`, `wp_users`.
+
+Plugins add their own tables — most legitimate ones use clearly-named prefixes (e.g. `wp_woocommerce_*`, `wp_yoast_*`). Unknown tables with generic names like `wp_data`, `wp_log`, `wp_temp` deserve scrutiny.
+
+## Log investigation
+
+### Brute-force / credential-stuffing patterns
+
+In access logs:
+```
+grep "POST .*wp-login.php" access.log | awk '{print $1}' | sort | uniq -c | sort -rn | head -20
+```
+
+Many POSTs from a single IP = brute force attempt. Many POSTs from many IPs in a short window = credential-stuffing or distributed brute force.
+
+### XML-RPC abuse
+
+```
+grep "xmlrpc.php" access.log | awk '{print $1}' | sort | uniq -c | sort -rn | head -20
+```
+
+`xmlrpc.php` is often abused for:
+- Amplified brute force (one request tries many credentials via `system.multicall`)
+- Pingback DDoS (the site is used as a reflector to attack others)
+
+If you see traffic to it and don't use XML-RPC, disable it.
+
+### Suspicious GET patterns
+
+```
+grep "uploads/.*\.php" access.log
+grep "wp-content/.*\.php?.*=.*base64" access.log
+```
+
+Either pattern is a strong signal — visitors should not be requesting PHP files from `uploads/`, and base64-looking query parameters are a backdoor invocation pattern.
+
+### Error log signals
+
+Recent PHP errors with stack traces pointing to unusual files (`/tmp/`, weird `wp-content` paths) often reveal where backdoors live:
+
+```
+tail -1000 error.log | grep -i "fatal\|parse error" | head -50
+```
+
+## File integrity — depth check
+
+The cheap `wp core verify-checksums` only catches files that should exist but have been modified. It does not catch:
+
+- Files added to core directories that shouldn't be there
+- Plugin/theme files for plugins NOT in the .org repo (premium / custom)
+- Modifications to `wp-config.php` (intentionally not checksummed)
+
+For deeper checks:
+
+```bash
+# Compare your wp-admin and wp-includes against a fresh download
+mkdir /tmp/clean-wp && cd /tmp/clean-wp
+wp core download
+diff -rq /tmp/clean-wp/wordpress/wp-admin /path/to/site/wp-admin | head -50
+diff -rq /tmp/clean-wp/wordpress/wp-includes /path/to/site/wp-includes | head -50
+```
+
+Any "Only in /path/to/site/..." line is a file present in the live install but not in clean core — strong signal.
+
+## When investigation hits a wall
+
+If after running everything above you can't find the compromise mechanism:
+
+1. **Compromise may be at the host level** — server-wide malware, SSH key compromise, control panel breach. Contact the host.
+2. **Compromise may be in a custom plugin/theme you've already cleared.** Re-audit those by hand, line by line.
+3. **Compromise may live in `mu-plugins/`** which is easy to miss. See [common-injection-points.md](common-injection-points.md) §1.
+4. **Compromise may be in scheduled tasks at the OS level**, not WP cron. Check `crontab -l` and `/etc/cron.*/` if you have shell access.
+5. **Bring in an external scanner** (Sucuri SiteCheck, Wordfence, MalCare) to compare findings — they catch some things heuristic scans miss.

--- a/skills/wp-abuse-and-compromise-response/references/signals.md
+++ b/skills/wp-abuse-and-compromise-response/references/signals.md
@@ -1,0 +1,243 @@
+# Compromise signals — full taxonomy
+
+This is the longer version of step 2 in [SKILL.md](../SKILL.md). Use it when the quick signal-to-category mapping isn't enough.
+
+## How to read this doc
+
+For each compromise category, you get:
+
+- **Telltale signals** — what the site looks like / behaves like
+- **Where to look first** — fastest place to confirm
+- **Co-occurrence patterns** — what often comes with it
+- **Notes** — operational gotchas
+
+Most real compromises mix categories. A single attack frequently drops a phishing page, a redirect rule, and a backdoor in `mu-plugins/` all at once.
+
+---
+
+## 1. Defacement
+
+**Telltale signals:**
+- Visible message on the homepage (political, "hacked by X", joke content)
+- Often replaces `index.php` or the active theme's `header.php`
+- Site looks visually broken or replaced
+
+**Where to look first:**
+- File-modified timestamps on `index.php`, `wp-content/themes/<active>/header.php`, `wp-content/themes/<active>/index.php`
+- Recent modifications to `wp-config.php` (defacement often paired with credential theft)
+
+**Co-occurrence:**
+- Often low-sophistication, opportunistic. May come bundled with other goodies (backdoor, redirect) because the attacker dropped everything they had.
+- May be the noisiest signal of a compromise that started weeks earlier.
+
+**Notes:**
+- Visible defacement is the easiest to spot but means the attacker chose to be loud. Quieter compromises (SEO spam, mailer abuse) often run undetected for much longer.
+
+---
+
+## 2. SEO spam injection
+
+**Telltale signals:**
+- Search results show pages or keywords that don't exist on the visible site (pharma, casino, replica goods, payday loans)
+- View source: hidden `<div>` with links, often pushed off-screen via CSS
+- Sudden ranking changes — site ranks for keywords the owner never targeted
+- Google Search Console reports "hacked content" or "spam" issue
+
+**Where to look first:**
+- Search the site via Google: `site:yourdomain.com viagra` (or pharma/loan/replica keywords)
+- View source of homepage — look for hidden links
+- Theme `footer.php`, `header.php`, `functions.php` for injected `echo` or `printf` with link content
+- `wp_options` table for autoloaded options containing `<a href`
+- `wp_posts.post_content` for added `<script>` or hidden link blocks
+
+**Co-occurrence:**
+- Often paired with cloaking — different content shown to Googlebot vs real users
+- Combined with redirect injection for user-agent-conditional behavior
+
+**Notes:**
+- Cloaking makes manual verification hard. Use Google's "Fetch as Google" / URL Inspection in Search Console, or curl with `User-Agent: Googlebot`.
+- This category is heavily monetized. Sites often stay infected for months because the compromise is invisible to the owner.
+
+---
+
+## 3. Redirect injection
+
+**Telltale signals:**
+- Visitors redirected to scam sites, dating sites, fake virus warnings, pharma
+- Often mobile-only, or referrer-conditional (only when coming from Google search results)
+- Site behaves normally for the admin (whose IP / cookies are excluded)
+
+**Where to look first:**
+- `.htaccess` (root + every subdirectory) — look for `RewriteRule`, `RewriteCond` with external URLs
+- `wp-config.php` — prepended PHP code that does `header('Location: ...')`
+- Active theme's `functions.php` — appended redirect logic
+- Database `wp_options` table — option `siteurl` or `home` may have been changed
+- Inline JavaScript injection in posts or footer
+
+**Co-occurrence:**
+- Conditional logic is the giveaway. Pure attacker-controlled redirects don't care about your user-agent — sophisticated ones do, to evade detection.
+- The condition is the diagnostic: redirect-only-on-mobile, redirect-only-from-Google, redirect-only-on-first-visit.
+
+**Notes:**
+- Admin users with cached login cookies often don't see the redirect — always test from an incognito session on a different network.
+- If site URL in `wp_options` was changed, you may be locked out of admin. Restore via direct DB edit.
+
+---
+
+## 4. Phishing-page host
+
+**Telltale signals:**
+- Unfamiliar login-looking pages added under the site (`/secure-update/`, `/PayPal/login/`, `/banking/`, etc.)
+- Pages mimic well-known brands (PayPal, banks, DHL, Microsoft 365)
+- Often pure HTML+PHP files dropped, not WordPress posts
+- Host abuse team notification citing phishing
+
+**Where to look first:**
+- `wp-content/uploads/` for `.php`, `.html`, and folders with brand names
+- Site root for unfamiliar folders containing index files
+- Recent file additions: `find . -type f -mtime -7 -name "*.php" -o -name "*.html"`
+
+**Co-occurrence:**
+- Almost always paired with credential compromise — the attacker uses the phishing page to steal credentials, sometimes from the host themselves
+- Often comes with email-sending capability (to lure victims to the phish)
+- Backdoor near-guaranteed — attacker wants to be able to re-upload phishing pages
+
+**Notes:**
+- Host abuse teams treat phishing as one of the most serious categories — expect a short window before suspension if not addressed.
+- Brand impersonation is a legal issue too — the impersonated brand may serve takedowns directly to the host.
+
+---
+
+## 5. Mailer abuse (outbound spam)
+
+**Telltale signals:**
+- Customers / random people complain about spam from `your-domain.com`
+- Domain landed on blocklists (Spamhaus, SpamCop, SORBS)
+- Sudden surge in outbound mail volume
+- Hosting provider flags the account for outbound spam
+
+**Where to look first:**
+- Mail logs (if accessible) — look for high-volume sends to unfamiliar recipients
+- `wp_cron` events — spam often runs on a schedule via a custom hook
+- Database for unfamiliar tables with names like `wp_mail_queue`, `wp_recipients`, etc.
+- `wp-content/` for standalone PHP scripts using `mail()` or `wp_mail()` directly
+
+**Co-occurrence:**
+- Phishing-page host (mailer abuse is often the delivery mechanism for phishing campaigns)
+- Mass user enumeration via WP forms
+
+**Notes:**
+- Outbound mail abuse damages the domain reputation for legitimate mail. Even after cleanup, transactional emails may bounce until the domain reputation recovers.
+- Hosting providers act fast on this — they bear the abuse complaints, and their IPs get blocklisted.
+
+---
+
+## 6. Cryptominer
+
+**Telltale signals:**
+- Mysterious high CPU usage, slow site
+- Hosting provider warns about resource exhaustion
+- Processes you didn't start (visible via `top`/`htop` if you have shell access)
+- `/tmp` files with random names
+
+**Where to look first:**
+- Process list: anything PHP-based running in a loop, or unfamiliar binaries
+- `/tmp/` and other writable directories for downloaded binaries
+- `wp-config.php` and `mu-plugins/` for code that spawns child processes (`exec`, `system`, `shell_exec`)
+- Cron: `wp cron event list` for hooks that fire frequently and execute external commands
+
+**Co-occurrence:**
+- Backdoor (the miner needs a way to be re-installed if killed)
+- Sometimes paired with SEO spam (one attacker, multiple monetization paths)
+
+**Notes:**
+- On shared hosting, the host will usually catch this quickly — they're paying the CPU bill.
+- Browser-side cryptominers (JS injected into pages) are a separate sub-category — look for unfamiliar `<script>` tags using crypto-mining libraries (Coinhive descendants, etc.).
+
+---
+
+## 7. WP-VCD and other known malware families
+
+**Telltale signals:**
+- `eval(gzinflate(base64_decode(...)))` blocks in PHP files
+- Newly-added `wp-tmp.php` or `wp-feed.php` files in WP root
+- Same code pattern across multiple files (one file infects others on load)
+
+**Where to look first:**
+```bash
+grep -rl "eval(gzinflate(base64_decode" wp-content wp-admin wp-includes
+grep -rl "wp-tmp.php\|wp-feed.php\|wp-vcd" .
+```
+
+**Co-occurrence:**
+- WP-VCD typically arrives via pirated themes and plugins ("nulled" downloads). If user installed something from a non-official source, this is the prime suspect.
+- Spreads internally across all PHP files on the host once installed
+- Adds itself to scheduled tasks, hooks, and replicates
+
+**Notes:**
+- The eval+base64 pattern is the most recognizable malware signature in WP. Easy to grep for, easy to confirm.
+- Eradication is hard because the malware actively re-infects from any surviving copy. Full file reset is usually required.
+
+---
+
+## 8. Supply-chain plugin compromise
+
+**Telltale signals:**
+- Specific plugin (or family of plugins from one vendor) was recently updated
+- Multiple unrelated sites in the same plugin's user base report the same compromise pattern at the same time
+- Compromise persists even after standard cleanup, because the "clean" plugin reinstall is still compromised
+
+**Where to look first:**
+- Recent activity in `wp-content/plugins/` matching plugin update timestamps
+- Plugin's official changelog vs what's actually installed
+- Plugin's GitHub issues / security advisories for recent CVEs
+- Compare installed plugin files against the version on wordpress.org via `wp plugin verify-checksums`
+
+**Co-occurrence:**
+- Once weaponized, supply-chain plugin compromises often drop everything-and-the-kitchen-sink: backdoors, spam, redirects, miners.
+- Plugin families from a single vendor that share a code base can all be affected by one compromise — observed pattern: a multi-plugin slider/popup/widget vendor with plugins active on tens of thousands of sites becomes a high-value supply-chain target.
+
+**Notes:**
+- This is the hardest category to detect early. The plugin's filesystem checksums won't help if the malicious version is the current published one.
+- Mitigation: if a plugin vendor has had a confirmed supply-chain compromise once, treat their entire plugin family with extra scrutiny going forward. Audit installs of all plugins from that vendor when one is implicated.
+- Subscribe to vulnerability feeds (Wordfence, Patchstack) for early warning of plugin compromises.
+
+---
+
+## 9. Anonymous backdoors (no other visible compromise)
+
+**Telltale signals:**
+- Site appears fully clean but file scans flag suspicious PHP
+- Web shell files: `c99.php`, `r57.php`, `wso.php`, `b374k.php`, files with names like `<random>.php` accepting `?cmd=` parameters
+- Empty / nearly-empty PHP files with a single `eval()` of a request parameter
+
+**Where to look first:**
+```bash
+grep -rl "eval(\$_POST\|eval(\$_GET\|eval(\$_REQUEST\|assert(\$_POST" .
+find . -name "*.php" -size -1k -mtime -90        # tiny suspicious files
+```
+
+**Co-occurrence:**
+- Often the first thing dropped — attacker uses the backdoor to deliver everything else later
+- Combined with persistence techniques (mu-plugins, cron, autoload options)
+
+**Notes:**
+- Easy to miss in a cleanup because they look small and unremarkable.
+- If you find one, look harder — backdoors travel in packs.
+
+---
+
+## Combined-signal triage table
+
+When multiple signals appear together, this combination usually tells you what you're dealing with:
+
+| Combination | Likely category |
+|---|---|
+| Defacement + theme/index modified | Opportunistic file-overwrite |
+| SEO spam + cloaking + hidden links in footer | Long-running monetization compromise |
+| Redirect + conditional logic (mobile only) + `.htaccess` modified | Targeted ad-fraud redirect |
+| Phishing page in uploads + outbound mail spike | Phishing campaign hosted on the site |
+| Unknown admin user + recent plugin install | Backdoor + persistence |
+| Cron event you don't recognize + outbound mail | Scheduled mailer abuse |
+| eval+base64 pattern across many files | WP-VCD or similar |
+| Plugin updated + multiple sites compromised same day | Supply-chain |

--- a/skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs
+++ b/skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs
@@ -226,7 +226,243 @@ function scanRecentCoreModifications(wpRoot, days = 30) {
   return recent;
 }
 
-function main() {
+// ---------------------------------------------------------------------------
+// Vulnerability lookup (optional, only when --check-vulns is passed)
+// ---------------------------------------------------------------------------
+//
+// Queries the wpvulnerability.com API (free, no API key required). The service
+// aggregates vulnerability data from WPScan, Patchstack, and WP.org sources.
+// Reference: https://www.wpvulnerability.com/
+//
+// Swappable: if you'd rather use WPScan or Patchstack directly, replace the
+// VULN_API_BASE constant and the response-shape adapters below.
+
+const VULN_API_BASE = "https://www.wpvulnerability.com/api/v3";
+const VULN_FETCH_TIMEOUT_MS = 5000;
+const VULN_CONCURRENCY = 5;
+
+function detectWpCoreVersion(wpRoot) {
+  const versionFile = path.join(wpRoot, "wp-includes", "version.php");
+  const content = readFileSafe(versionFile);
+  if (!content) return null;
+  const m = content.match(/\$wp_version\s*=\s*['"]([^'"]+)['"]/);
+  return m ? m[1] : null;
+}
+
+function parseWpPluginHeader(filePath) {
+  const content = readFileSafe(filePath, 16 * 1024);
+  if (!content) return null;
+  const nameMatch = content.match(/^[\s*]*Plugin Name:\s*(.+)$/im);
+  if (!nameMatch) return null;
+  const versionMatch = content.match(/^[\s*]*Version:\s*(.+)$/im);
+  return {
+    name: nameMatch[1].trim(),
+    version: versionMatch ? versionMatch[1].trim() : null,
+  };
+}
+
+function detectInstalledPlugins(wpRoot) {
+  const pluginsDir = path.join(wpRoot, "wp-content", "plugins");
+  if (!statSafe(pluginsDir)) return [];
+  const plugins = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    const slug = ent.name;
+    const pluginDir = path.join(pluginsDir, slug);
+    // The main plugin file is usually <slug>.php; fall back to scanning .php files in the root
+    const candidates = [path.join(pluginDir, `${slug}.php`)];
+    try {
+      const dirEntries = fs.readdirSync(pluginDir);
+      for (const f of dirEntries) {
+        if (f.endsWith(".php") && !candidates.includes(path.join(pluginDir, f))) {
+          candidates.push(path.join(pluginDir, f));
+        }
+      }
+    } catch { /* ignore */ }
+    for (const candidate of candidates) {
+      const header = parseWpPluginHeader(candidate);
+      if (header) {
+        plugins.push({ slug, name: header.name, version: header.version });
+        break;
+      }
+    }
+  }
+  return plugins;
+}
+
+function parseWpThemeHeader(styleCssPath) {
+  const content = readFileSafe(styleCssPath, 8 * 1024);
+  if (!content) return null;
+  const nameMatch = content.match(/^[\s\/*]*Theme Name:\s*(.+)$/im);
+  if (!nameMatch) return null;
+  const versionMatch = content.match(/^[\s\/*]*Version:\s*(.+)$/im);
+  return {
+    name: nameMatch[1].trim(),
+    version: versionMatch ? versionMatch[1].trim() : null,
+  };
+}
+
+function detectInstalledThemes(wpRoot) {
+  const themesDir = path.join(wpRoot, "wp-content", "themes");
+  if (!statSafe(themesDir)) return [];
+  const themes = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(themesDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    const slug = ent.name;
+    const styleCss = path.join(themesDir, slug, "style.css");
+    const header = parseWpThemeHeader(styleCss);
+    if (header) {
+      themes.push({ slug, name: header.name, version: header.version });
+    }
+  }
+  return themes;
+}
+
+async function fetchJsonWithTimeout(url, timeoutMs = VULN_FETCH_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: controller.signal, headers: { "User-Agent": "wp-abuse-detect-script/1" } });
+    if (!res.ok) return { error: `HTTP ${res.status}`, url };
+    const data = await res.json();
+    return { data, url };
+  } catch (e) {
+    return { error: String(e?.message || e), url };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function compareVersions(a, b) {
+  // Returns negative if a<b, 0 if equal, positive if a>b. Handles X.Y.Z and pre-release suffixes loosely.
+  const pa = String(a).split(/[.+-]/).map((p) => parseInt(p, 10));
+  const pb = String(b).split(/[.+-]/).map((p) => parseInt(p, 10));
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i += 1) {
+    const x = isNaN(pa[i]) ? 0 : pa[i];
+    const y = isNaN(pb[i]) ? 0 : pb[i];
+    if (x !== y) return x - y;
+  }
+  return 0;
+}
+
+function vulnAffectsInstalledVersion(vuln, installedVersion) {
+  if (!installedVersion) return true; // assume affected when version unknown
+  // wpvulnerability.com vuln records vary in shape; check operator-style fields, fallback to "patched_in"
+  const ops = vuln?.operator || vuln?.affected || null;
+  if (Array.isArray(ops)) {
+    for (const op of ops) {
+      const v = op?.version;
+      const operator = op?.operator;
+      if (!v || !operator) continue;
+      const cmp = compareVersions(installedVersion, v);
+      if (operator === "<=" && cmp <= 0) return true;
+      if (operator === "<" && cmp < 0) return true;
+      if (operator === "=" && cmp === 0) return true;
+      if (operator === ">=" && cmp >= 0) return true;
+      if (operator === ">" && cmp > 0) return true;
+    }
+    return false;
+  }
+  const patchedIn = vuln?.patched_in || vuln?.fixed_in;
+  if (patchedIn) return compareVersions(installedVersion, patchedIn) < 0;
+  return true;
+}
+
+function flattenVulnRecords(apiResult, installedVersion) {
+  // wpvulnerability.com response shape: { ..., vulnerabilities: [ { id, title, source, ..., operator: [...] } ] }
+  if (!apiResult?.data) return { error: apiResult?.error, vulns: [] };
+  const candidates = apiResult.data?.vulnerabilities || apiResult.data?.vulns || [];
+  const matched = [];
+  for (const v of candidates) {
+    if (vulnAffectsInstalledVersion(v, installedVersion)) {
+      matched.push({
+        id: v.id || v.cve || v.title?.slice(0, 40) || "unknown",
+        title: v.title || v.summary || null,
+        source: v.source || null,
+        severity: v.severity || v.cvss?.severity || null,
+        score: v.cvss?.score || null,
+        patched_in: v.patched_in || v.fixed_in || null,
+        url: v.source_url || v.url || null,
+      });
+    }
+  }
+  return { vulns: matched };
+}
+
+async function runWithConcurrency(items, worker, concurrency = VULN_CONCURRENCY) {
+  const results = [];
+  let i = 0;
+  const lanes = Array(Math.min(concurrency, items.length)).fill(0).map(async () => {
+    while (i < items.length) {
+      const idx = i++;
+      results[idx] = await worker(items[idx]);
+    }
+  });
+  await Promise.all(lanes);
+  return results;
+}
+
+async function checkVulnerabilities(wpRoot) {
+  const wpVersion = detectWpCoreVersion(wpRoot);
+  const plugins = detectInstalledPlugins(wpRoot);
+  const themes = detectInstalledThemes(wpRoot);
+
+  const corePromise = wpVersion
+    ? fetchJsonWithTimeout(`${VULN_API_BASE}/wordpress/${encodeURIComponent(wpVersion)}`)
+    : Promise.resolve({ error: "wp version not detected" });
+
+  const pluginResults = await runWithConcurrency(plugins, async (p) => {
+    const apiResult = await fetchJsonWithTimeout(`${VULN_API_BASE}/plugin/${encodeURIComponent(p.slug)}`);
+    const { vulns, error } = flattenVulnRecords(apiResult, p.version);
+    return { slug: p.slug, name: p.name, installed_version: p.version, vulnerabilities: vulns, fetch_error: error || apiResult?.error };
+  });
+
+  const themeResults = await runWithConcurrency(themes, async (t) => {
+    const apiResult = await fetchJsonWithTimeout(`${VULN_API_BASE}/theme/${encodeURIComponent(t.slug)}`);
+    const { vulns, error } = flattenVulnRecords(apiResult, t.version);
+    return { slug: t.slug, name: t.name, installed_version: t.version, vulnerabilities: vulns, fetch_error: error || apiResult?.error };
+  });
+
+  const coreApi = await corePromise;
+  const coreVulns = wpVersion ? flattenVulnRecords(coreApi, wpVersion).vulns : [];
+
+  const pluginsWithVulns = pluginResults.filter((p) => p.vulnerabilities.length > 0);
+  const themesWithVulns = themeResults.filter((t) => t.vulnerabilities.length > 0);
+
+  return {
+    source: "wpvulnerability.com (aggregates WPScan, Patchstack, WP.org)",
+    wp_core: { installed_version: wpVersion, vulnerabilities: coreVulns, fetch_error: coreApi?.error || null },
+    plugins: {
+      total_checked: pluginResults.length,
+      with_vulnerabilities: pluginsWithVulns,
+      clean: pluginResults.length - pluginsWithVulns.length,
+    },
+    themes: {
+      total_checked: themeResults.length,
+      with_vulnerabilities: themesWithVulns,
+      clean: themeResults.length - themesWithVulns.length,
+    },
+    severity: (coreVulns.length || pluginsWithVulns.length || themesWithVulns.length) > 0 ? "high" : "none",
+    note: "Known vulnerabilities affecting installed versions. Patch immediately; if exploitation predates patching, it may be the entry point for the active compromise.",
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const checkVulns = args.includes("--check-vulns");
   const repoRoot = process.cwd();
   const wpRoot = detectWpRoot(repoRoot);
 
@@ -246,6 +482,7 @@ function main() {
   const knownMalwareFiles = scanKnownMalwareFilenames(wpRoot);
   const patternScan = scanMalwarePatterns(wpRoot);
   const recentCore = scanRecentCoreModifications(wpRoot);
+  const vulnReport = checkVulns ? await checkVulnerabilities(wpRoot) : null;
 
   const report = {
     tool: { name: "detect_compromise_signals", version: 1 },
@@ -295,6 +532,10 @@ function main() {
     },
   };
 
+  if (vulnReport) {
+    report.signals.known_vulnerabilities = vulnReport;
+  }
+
   const anyHigh = Object.values(report.signals).some((s) => s.severity === "high");
   const anyReview = Object.values(report.signals).some((s) => s.severity === "review");
   report.summary = {
@@ -309,4 +550,7 @@ function main() {
   process.stdout.write(JSON.stringify(report, null, 2) + "\n");
 }
 
-main();
+main().catch((err) => {
+  process.stderr.write(`detect_compromise_signals failed: ${err?.stack || err}\n`);
+  process.exit(1);
+});

--- a/skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs
+++ b/skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
+const TOOL_HEADER = { name: "detect_compromise_signals", version: 1 };
+
 const DEFAULT_IGNORES = new Set([
   ".git",
   "node_modules",
@@ -24,11 +26,11 @@ const SUSPICIOUS_PHP_EXTS = new Set([
 ]);
 
 const MALWARE_PATTERNS = [
-  { name: "eval_gzinflate_base64", regex: /eval\s*\(\s*gzinflate\s*\(\s*base64_decode/i },
-  { name: "eval_base64_decode",    regex: /eval\s*\(\s*base64_decode/i },
-  { name: "eval_request_param",    regex: /eval\s*\(\s*\$_(POST|GET|REQUEST|COOKIE|SERVER)/i },
-  { name: "assert_request_param",  regex: /assert\s*\(\s*\$_(POST|GET|REQUEST|COOKIE)/i },
-  { name: "exec_request_param",    regex: /(system|shell_exec|passthru|exec|popen|proc_open)\s*\(\s*\$_/i },
+  { name: "eval_gzinflate_base64",   regex: /eval\s*\(\s*gzinflate\s*\(\s*base64_decode/i },
+  { name: "eval_base64_decode",      regex: /eval\s*\(\s*base64_decode/i },
+  { name: "eval_request_param",      regex: /eval\s*\(\s*\$_(POST|GET|REQUEST|COOKIE|SERVER)/i },
+  { name: "assert_request_param",    regex: /assert\s*\(\s*\$_(POST|GET|REQUEST|COOKIE)/i },
+  { name: "exec_request_param",      regex: /(system|shell_exec|passthru|exec|popen|proc_open)\s*\(\s*\$_/i },
   { name: "preg_replace_e_modifier", regex: /preg_replace\s*\(\s*['"][^'"]*\/e['"]/i },
 ];
 
@@ -51,174 +53,149 @@ const WP_FLAVORED_DIR_BAIT = [
 ];
 
 function statSafe(p) {
-  try {
-    return fs.statSync(p);
-  } catch {
-    return null;
-  }
+  try { return fs.statSync(p); } catch { return null; }
 }
 
 function readFileSafe(p, maxBytes = 128 * 1024) {
   try {
     const buf = fs.readFileSync(p);
-    if (buf.byteLength > maxBytes) return buf.subarray(0, maxBytes).toString("utf8");
-    return buf.toString("utf8");
+    return buf.byteLength > maxBytes ? buf.subarray(0, maxBytes).toString("utf8") : buf.toString("utf8");
   } catch {
     return null;
   }
 }
 
+// Walks rootDir breadth-first. Returns { files, truncated, depthCapped } so
+// callers can distinguish "no matches" from "scan hit a cap" — important for
+// a malware scanner where the second must NOT read as clean.
 function findFilesRecursive(rootDir, predicate, { maxFiles = 6000, maxDepth = 12 } = {}) {
-  const results = [];
+  const files = [];
   const queue = [{ dir: rootDir, depth: 0 }];
   let truncated = false;
   let depthCapped = false;
 
-  while (queue.length > 0 && results.length < maxFiles) {
+  outer:
+  while (queue.length > 0) {
     const { dir, depth } = queue.shift();
     if (depth > maxDepth) { depthCapped = true; continue; }
 
     let entries;
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
 
     for (const ent of entries) {
       const fullPath = path.join(dir, ent.name);
-
       if (ent.isDirectory()) {
         if (DEFAULT_IGNORES.has(ent.name)) continue;
         queue.push({ dir: fullPath, depth: depth + 1 });
-      } else if (ent.isFile()) {
-        if (predicate(ent.name, fullPath)) {
-          results.push(fullPath);
-          if (results.length >= maxFiles) {
-            truncated = true;
-            break;
-          }
-        }
+      } else if (ent.isFile() && predicate(ent.name, fullPath)) {
+        files.push(fullPath);
+        if (files.length >= maxFiles) { truncated = true; break outer; }
       }
     }
   }
 
-  if (queue.length > 0 && results.length >= maxFiles) truncated = true;
-
-  results.truncated = truncated;
-  results.depthCapped = depthCapped;
-  return results;
+  return { files, truncated, depthCapped };
 }
 
 function detectWpRoot(repoRoot) {
-  const candidates = [
-    repoRoot,
-    path.join(repoRoot, "wordpress"),
-    path.join(repoRoot, "wp"),
-    path.join(repoRoot, "public"),
-    path.join(repoRoot, "public_html"),
-  ];
-  for (const c of candidates) {
-    if (statSafe(path.join(c, "wp-includes"))) return c;
+  for (const sub of ["", "wordpress", "wp", "public", "public_html"]) {
+    const candidate = sub ? path.join(repoRoot, sub) : repoRoot;
+    if (statSafe(path.join(candidate, "wp-includes"))) return candidate;
   }
   return null;
 }
 
+function listDirSafe(dir, { onlyDirs = false } = {}) {
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    return onlyDirs ? entries.filter((e) => e.isDirectory()) : entries;
+  } catch {
+    return [];
+  }
+}
+
 function scanPhpInUploads(wpRoot) {
   const uploadsDir = path.join(wpRoot, "wp-content", "uploads");
-  if (!statSafe(uploadsDir)) return [];
-  return findFilesRecursive(uploadsDir, (name) => {
-    const ext = path.extname(name).toLowerCase();
-    return SUSPICIOUS_PHP_EXTS.has(ext);
-  }, { maxFiles: 500 });
+  if (!statSafe(uploadsDir)) return { files: [], truncated: false, depthCapped: false };
+  return findFilesRecursive(
+    uploadsDir,
+    (name) => SUSPICIOUS_PHP_EXTS.has(path.extname(name).toLowerCase()),
+    { maxFiles: 500 }
+  );
 }
 
 function scanMuPlugins(wpRoot) {
   const muDir = path.join(wpRoot, "wp-content", "mu-plugins");
   if (!statSafe(muDir)) return { exists: false, entries: [] };
-  let entries = [];
-  try {
-    entries = fs.readdirSync(muDir);
-  } catch {
-    return { exists: true, entries: [] };
-  }
-  return { exists: true, entries };
+  return { exists: true, entries: listDirSafe(muDir).map((e) => e.name) };
 }
 
+// Drop-ins live directly in wp-content/ (no wp-content/drop-ins/ subdirectory
+// exists in stock WP). Reference: https://developer.wordpress.org/reference/functions/_get_dropins/
+const KNOWN_DROP_INS = new Set([
+  "advanced-cache.php",
+  "db.php",
+  "db-error.php",
+  "install.php",
+  "maintenance.php",
+  "object-cache.php",
+  "php-error.php",
+  "fatal-error-handler.php",
+  // Multisite-only
+  "sunrise.php",
+  "blog-deleted.php",
+  "blog-inactive.php",
+  "blog-suspended.php",
+]);
+
 function scanDropIns(wpRoot) {
-  // Drop-ins live directly in wp-content/ (no wp-content/drop-ins/ subdirectory exists in stock WP).
-  // Reference: https://developer.wordpress.org/reference/functions/_get_dropins/
-  const wpContent = path.join(wpRoot, "wp-content");
-  const knownDropIns = new Set([
-    "advanced-cache.php",
-    "db.php",
-    "db-error.php",
-    "install.php",
-    "maintenance.php",
-    "object-cache.php",
-    "php-error.php",
-    "fatal-error-handler.php",
-    // Multisite-only
-    "sunrise.php",
-    "blog-deleted.php",
-    "blog-inactive.php",
-    "blog-suspended.php",
-  ]);
-  let present = [];
-  try {
-    const wpContentEntries = fs.readdirSync(wpContent);
-    present = wpContentEntries.filter((n) => knownDropIns.has(n));
-  } catch {
-    // ignore
-  }
-  return { present };
+  return {
+    present: listDirSafe(path.join(wpRoot, "wp-content"))
+      .map((e) => e.name)
+      .filter((n) => KNOWN_DROP_INS.has(n)),
+  };
 }
 
 function scanWpFlavoredBaitDirs(wpRoot) {
   const pluginsDir = path.join(wpRoot, "wp-content", "plugins");
   if (!statSafe(pluginsDir)) return [];
-  let entries = [];
-  try {
-    entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  return entries
-    .filter((e) => e.isDirectory())
+  return listDirSafe(pluginsDir, { onlyDirs: true })
     .filter((e) => WP_FLAVORED_DIR_BAIT.some((rx) => rx.test(e.name)))
     .map((e) => e.name);
 }
 
 function scanKnownMalwareFilenames(wpRoot) {
-  return findFilesRecursive(wpRoot, (name) => KNOWN_MALWARE_FILENAMES.has(name.toLowerCase()), { maxFiles: 50 });
+  return findFilesRecursive(
+    wpRoot,
+    (name) => KNOWN_MALWARE_FILENAMES.has(name.toLowerCase()),
+    { maxFiles: 50 }
+  );
 }
 
 function scanMalwarePatterns(wpRoot, { maxFilesScanned = 4000, maxFileBytes = 256 * 1024 } = {}) {
-  const hits = [];
-  const phpFiles = findFilesRecursive(
+  const walk = findFilesRecursive(
     wpRoot,
     (name) => SUSPICIOUS_PHP_EXTS.has(path.extname(name).toLowerCase()),
     { maxFiles: maxFilesScanned }
   );
 
+  const hits = [];
   let filesReadTruncated = 0;
-  for (const file of phpFiles) {
+  for (const file of walk.files) {
     const st = statSafe(file);
     if (st && st.size > maxFileBytes) filesReadTruncated += 1;
     const content = readFileSafe(file, maxFileBytes);
     if (!content) continue;
     for (const pattern of MALWARE_PATTERNS) {
-      if (pattern.regex.test(content)) {
-        hits.push({ file, pattern: pattern.name });
-      }
+      if (pattern.regex.test(content)) hits.push({ file, pattern: pattern.name });
     }
   }
 
   return {
-    filesScanned: phpFiles.length,
+    filesScanned: walk.files.length,
     hits,
-    fileListTruncated: phpFiles.truncated === true,
-    depthCapped: phpFiles.depthCapped === true,
+    fileListTruncated: walk.truncated,
+    depthCapped: walk.depthCapped,
     filesReadTruncated,  // count of files where only the first maxFileBytes were scanned
     maxFilesScanned,
     maxFileBytes,
@@ -227,20 +204,14 @@ function scanMalwarePatterns(wpRoot, { maxFilesScanned = 4000, maxFileBytes = 25
 
 function scanRecentCoreModifications(wpRoot, days = 30) {
   const cutoffMs = Date.now() - days * 24 * 60 * 60 * 1000;
-  const coreDirs = ["wp-admin", "wp-includes"].map((d) => path.join(wpRoot, d));
   const recent = [];
-  for (const dir of coreDirs) {
+  for (const sub of ["wp-admin", "wp-includes"]) {
+    const dir = path.join(wpRoot, sub);
     if (!statSafe(dir)) continue;
-    const files = findFilesRecursive(
-      dir,
-      (name) => name.endsWith(".php"),
-      { maxFiles: 5000 }
-    );
-    for (const f of files) {
+    const walk = findFilesRecursive(dir, (name) => name.endsWith(".php"), { maxFiles: 5000 });
+    for (const f of walk.files) {
       const st = statSafe(f);
-      if (st && st.mtimeMs > cutoffMs) {
-        recent.push({ file: f, mtime: new Date(st.mtimeMs).toISOString() });
-      }
+      if (st && st.mtimeMs > cutoffMs) recent.push({ file: f, mtime: new Date(st.mtimeMs).toISOString() });
     }
   }
   return recent;
@@ -249,64 +220,46 @@ function scanRecentCoreModifications(wpRoot, days = 30) {
 // ---------------------------------------------------------------------------
 // Vulnerability lookup (optional, only when --check-vulns is passed)
 // ---------------------------------------------------------------------------
-//
-// Queries the wpvulnerability.com API (free, no API key required). The service
-// aggregates vulnerability data from WPScan, Patchstack, and WP.org sources.
-// Reference: https://www.wpvulnerability.com/
-//
-// Swappable: if you'd rather use WPScan or Patchstack directly, replace the
-// VULN_API_BASE constant and the response-shape adapters below.
+// Queries wpvulnerability.com (free, no API key). The service aggregates
+// vulnerability data from WPScan, Patchstack, and WP.org sources.
+// Swappable: replace VULN_API_BASE + flattenVulnRecords to use a different source.
 
 const VULN_API_BASE = "https://www.wpvulnerability.com/api/v3";
 const VULN_FETCH_TIMEOUT_MS = 5000;
 const VULN_CONCURRENCY = 5;
 
 function detectWpCoreVersion(wpRoot) {
-  const versionFile = path.join(wpRoot, "wp-includes", "version.php");
-  const content = readFileSafe(versionFile);
-  if (!content) return null;
-  const m = content.match(/\$wp_version\s*=\s*['"]([^'"]+)['"]/);
+  const content = readFileSafe(path.join(wpRoot, "wp-includes", "version.php"));
+  const m = content?.match(/\$wp_version\s*=\s*['"]([^'"]+)['"]/);
   return m ? m[1] : null;
 }
 
-function parseWpPluginHeader(filePath) {
-  const content = readFileSafe(filePath, 16 * 1024);
+// Parses Plugin Name/Version OR Theme Name/Version from a header block.
+// Plugin headers live in <slug>.php (PHP comment); theme headers in style.css (CSS comment).
+function parseWpHeader(filePath, kind, maxBytes = 16 * 1024) {
+  const content = readFileSafe(filePath, maxBytes);
   if (!content) return null;
-  const nameMatch = content.match(/^[\s*]*Plugin Name:\s*(.+)$/im);
+  const nameRegex = new RegExp(String.raw`^[\s/*]*${kind} Name:\s*(.+)$`, "im");
+  const nameMatch = content.match(nameRegex);
   if (!nameMatch) return null;
-  const versionMatch = content.match(/^[\s*]*Version:\s*(.+)$/im);
-  return {
-    name: nameMatch[1].trim(),
-    version: versionMatch ? versionMatch[1].trim() : null,
-  };
+  const versionMatch = content.match(/^[\s/*]*Version:\s*(.+)$/im);
+  return { name: nameMatch[1].trim(), version: versionMatch ? versionMatch[1].trim() : null };
 }
 
 function detectInstalledPlugins(wpRoot) {
   const pluginsDir = path.join(wpRoot, "wp-content", "plugins");
   if (!statSafe(pluginsDir)) return [];
   const plugins = [];
-  let entries;
-  try {
-    entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  for (const ent of entries) {
-    if (!ent.isDirectory()) continue;
+  for (const ent of listDirSafe(pluginsDir, { onlyDirs: true })) {
     const slug = ent.name;
     const pluginDir = path.join(pluginsDir, slug);
-    // The main plugin file is usually <slug>.php; fall back to scanning .php files in the root
-    const candidates = [path.join(pluginDir, `${slug}.php`)];
-    try {
-      const dirEntries = fs.readdirSync(pluginDir);
-      for (const f of dirEntries) {
-        if (f.endsWith(".php") && !candidates.includes(path.join(pluginDir, f))) {
-          candidates.push(path.join(pluginDir, f));
-        }
-      }
-    } catch { /* ignore */ }
-    for (const candidate of candidates) {
-      const header = parseWpPluginHeader(candidate);
+    // Try <slug>.php first (the common case), then any other .php at the dir root.
+    const phpFiles = listDirSafe(pluginDir)
+      .filter((e) => e.isFile && e.isFile() && e.name.endsWith(".php"))
+      .map((e) => path.join(pluginDir, e.name))
+      .sort((a) => (path.basename(a) === `${slug}.php` ? -1 : 1));
+    for (const candidate of phpFiles) {
+      const header = parseWpHeader(candidate, "Plugin");
       if (header) {
         plugins.push({ slug, name: header.name, version: header.version });
         break;
@@ -316,36 +269,14 @@ function detectInstalledPlugins(wpRoot) {
   return plugins;
 }
 
-function parseWpThemeHeader(styleCssPath) {
-  const content = readFileSafe(styleCssPath, 8 * 1024);
-  if (!content) return null;
-  const nameMatch = content.match(/^[\s\/*]*Theme Name:\s*(.+)$/im);
-  if (!nameMatch) return null;
-  const versionMatch = content.match(/^[\s\/*]*Version:\s*(.+)$/im);
-  return {
-    name: nameMatch[1].trim(),
-    version: versionMatch ? versionMatch[1].trim() : null,
-  };
-}
-
 function detectInstalledThemes(wpRoot) {
   const themesDir = path.join(wpRoot, "wp-content", "themes");
   if (!statSafe(themesDir)) return [];
   const themes = [];
-  let entries;
-  try {
-    entries = fs.readdirSync(themesDir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  for (const ent of entries) {
-    if (!ent.isDirectory()) continue;
+  for (const ent of listDirSafe(themesDir, { onlyDirs: true })) {
     const slug = ent.name;
-    const styleCss = path.join(themesDir, slug, "style.css");
-    const header = parseWpThemeHeader(styleCss);
-    if (header) {
-      themes.push({ slug, name: header.name, version: header.version });
-    }
+    const header = parseWpHeader(path.join(themesDir, slug, "style.css"), "Theme", 8 * 1024);
+    if (header) themes.push({ slug, name: header.name, version: header.version });
   }
   return themes;
 }
@@ -356,8 +287,7 @@ async function fetchJsonWithTimeout(url, timeoutMs = VULN_FETCH_TIMEOUT_MS) {
   try {
     const res = await fetch(url, { signal: controller.signal, headers: { "User-Agent": "wp-abuse-detect-script/1" } });
     if (!res.ok) return { error: `HTTP ${res.status}`, url };
-    const data = await res.json();
-    return { data, url };
+    return { data: await res.json(), url };
   } catch (e) {
     return { error: String(e?.message || e), url };
   } finally {
@@ -365,8 +295,10 @@ async function fetchJsonWithTimeout(url, timeoutMs = VULN_FETCH_TIMEOUT_MS) {
   }
 }
 
+// Returns negative / 0 / positive for a<b / a=b / a>b on dot-separated numeric versions.
+// Pre-release suffixes (e.g. "1.2.3-beta") are treated as equal to the base "1.2.3" —
+// fine for matching vuln-record version constraints, which use numeric thresholds.
 function compareVersions(a, b) {
-  // Returns negative if a<b, 0 if equal, positive if a>b. Handles X.Y.Z and pre-release suffixes loosely.
   const pa = String(a).split(/[.+-]/).map((p) => parseInt(p, 10));
   const pb = String(b).split(/[.+-]/).map((p) => parseInt(p, 10));
   const len = Math.max(pa.length, pb.length);
@@ -378,21 +310,23 @@ function compareVersions(a, b) {
   return 0;
 }
 
+const OPERATOR_PREDICATES = {
+  "<=": (cmp) => cmp <= 0,
+  "<":  (cmp) => cmp < 0,
+  "=":  (cmp) => cmp === 0,
+  ">=": (cmp) => cmp >= 0,
+  ">":  (cmp) => cmp > 0,
+};
+
 function vulnAffectsInstalledVersion(vuln, installedVersion) {
   if (!installedVersion) return { affected: null, reason: "version_unknown" };
-  // wpvulnerability.com vuln records vary in shape; check operator-style fields, fallback to "patched_in"
-  const ops = vuln?.operator || vuln?.affected || null;
+  // wpvulnerability.com vuln records vary in shape; check operator-style fields, fallback to "patched_in".
+  const ops = vuln?.operator || vuln?.affected;
   if (Array.isArray(ops)) {
     for (const op of ops) {
-      const v = op?.version;
-      const operator = op?.operator;
-      if (!v || !operator) continue;
-      const cmp = compareVersions(installedVersion, v);
-      if (operator === "<=" && cmp <= 0) return { affected: true };
-      if (operator === "<" && cmp < 0) return { affected: true };
-      if (operator === "=" && cmp === 0) return { affected: true };
-      if (operator === ">=" && cmp >= 0) return { affected: true };
-      if (operator === ">" && cmp > 0) return { affected: true };
+      const predicate = OPERATOR_PREDICATES[op?.operator];
+      if (!op?.version || !predicate) continue;
+      if (predicate(compareVersions(installedVersion, op.version))) return { affected: true };
     }
     return { affected: false };
   }
@@ -402,13 +336,13 @@ function vulnAffectsInstalledVersion(vuln, installedVersion) {
 }
 
 function flattenVulnRecords(apiResult, installedVersion) {
-  // wpvulnerability.com response shape varies; this code is best-effort and may need adjustment.
-  if (!apiResult?.data) return { error: apiResult?.error, vulns: [], unknown_match: [] };
+  if (!apiResult?.data) return { error: apiResult?.error || null, vulns: [], unknown_match: [] };
   const candidates = apiResult.data?.vulnerabilities || apiResult.data?.vulns || [];
-  const matched = [];
-  const unknownMatch = [];  // records where we couldn't determine if the installed version is affected
+  const vulns = [];
+  const unknown_match = [];
   for (const v of candidates) {
     const { affected, reason } = vulnAffectsInstalledVersion(v, installedVersion);
+    if (affected === false) continue;
     const record = {
       id: v.id || v.cve || v.title?.slice(0, 40) || "unknown",
       title: v.title || v.summary || null,
@@ -418,13 +352,10 @@ function flattenVulnRecords(apiResult, installedVersion) {
       patched_in: v.patched_in || v.fixed_in || null,
       url: v.source_url || v.url || null,
     };
-    if (affected === true) {
-      matched.push(record);
-    } else if (affected === null) {
-      unknownMatch.push({ ...record, match_uncertainty_reason: reason });
-    }
+    if (affected === true) vulns.push(record);
+    else unknown_match.push({ ...record, match_uncertainty_reason: reason });
   }
-  return { vulns: matched, unknown_match: unknownMatch };
+  return { vulns, unknown_match, error: null };
 }
 
 async function runWithConcurrency(items, worker, concurrency = VULN_CONCURRENCY) {
@@ -440,6 +371,19 @@ async function runWithConcurrency(items, worker, concurrency = VULN_CONCURRENCY)
   return results;
 }
 
+async function lookupComponentVulns(kind /* "plugin" | "theme" */, comp) {
+  const apiResult = await fetchJsonWithTimeout(`${VULN_API_BASE}/${kind}/${encodeURIComponent(comp.slug)}`);
+  const { vulns, unknown_match, error } = flattenVulnRecords(apiResult, comp.version);
+  return {
+    slug: comp.slug,
+    name: comp.name,
+    installed_version: comp.version,
+    vulnerabilities: vulns,
+    vulnerabilities_uncertain_match: unknown_match,
+    fetch_error: error || apiResult?.error || null,
+  };
+}
+
 async function checkVulnerabilities(wpRoot) {
   const wpVersion = detectWpCoreVersion(wpRoot);
   const plugins = detectInstalledPlugins(wpRoot);
@@ -449,41 +393,19 @@ async function checkVulnerabilities(wpRoot) {
     ? fetchJsonWithTimeout(`${VULN_API_BASE}/wordpress/${encodeURIComponent(wpVersion)}`)
     : Promise.resolve({ error: "wp version not detected" });
 
-  const pluginResults = await runWithConcurrency(plugins, async (p) => {
-    const apiResult = await fetchJsonWithTimeout(`${VULN_API_BASE}/plugin/${encodeURIComponent(p.slug)}`);
-    const { vulns, unknown_match, error } = flattenVulnRecords(apiResult, p.version);
-    return {
-      slug: p.slug,
-      name: p.name,
-      installed_version: p.version,
-      vulnerabilities: vulns,
-      vulnerabilities_uncertain_match: unknown_match,
-      fetch_error: error || apiResult?.error,
-    };
-  });
+  const [pluginResults, themeResults, coreApi] = await Promise.all([
+    runWithConcurrency(plugins, (p) => lookupComponentVulns("plugin", p)),
+    runWithConcurrency(themes,  (t) => lookupComponentVulns("theme", t)),
+    corePromise,
+  ]);
 
-  const themeResults = await runWithConcurrency(themes, async (t) => {
-    const apiResult = await fetchJsonWithTimeout(`${VULN_API_BASE}/theme/${encodeURIComponent(t.slug)}`);
-    const { vulns, unknown_match, error } = flattenVulnRecords(apiResult, t.version);
-    return {
-      slug: t.slug,
-      name: t.name,
-      installed_version: t.version,
-      vulnerabilities: vulns,
-      vulnerabilities_uncertain_match: unknown_match,
-      fetch_error: error || apiResult?.error,
-    };
-  });
-
-  const coreApi = await corePromise;
-  const core = wpVersion ? flattenVulnRecords(coreApi, wpVersion) : { vulns: [], unknown_match: [] };
-
+  const core = wpVersion ? flattenVulnRecords(coreApi, wpVersion) : { vulns: [], unknown_match: [], error: null };
   const pluginsWithVulns = pluginResults.filter((p) => p.vulnerabilities.length > 0);
   const themesWithVulns = themeResults.filter((t) => t.vulnerabilities.length > 0);
 
   return {
     experimental: true,
-    privacy_note: "This check sends a list of your installed plugin/theme slugs (not versions or contents) to wpvulnerability.com. On a compromised box, that inventory may be sensitive — do not run --check-vulns from a network you don't want the request traffic associated with. Skip this flag if in doubt.",
+    privacy_note: "This check sends a list of your installed plugin/theme slugs (not versions or contents) to wpvulnerability.com. On a compromised box that inventory may be sensitive — do not run --check-vulns from a network you don't want the request traffic associated with. Skip this flag if in doubt.",
     source: "wpvulnerability.com (aggregates WPScan, Patchstack, WP.org). Response shape varies — adapter is best-effort.",
     wp_core: {
       installed_version: wpVersion,
@@ -491,129 +413,124 @@ async function checkVulnerabilities(wpRoot) {
       vulnerabilities_uncertain_match: core.unknown_match,
       fetch_error: coreApi?.error || null,
     },
-    plugins: {
-      total_checked: pluginResults.length,
-      with_vulnerabilities: pluginsWithVulns,
-      clean: pluginResults.length - pluginsWithVulns.length,
-    },
-    themes: {
-      total_checked: themeResults.length,
-      with_vulnerabilities: themesWithVulns,
-      clean: themeResults.length - themesWithVulns.length,
-    },
+    plugins: { total_checked: pluginResults.length, with_vulnerabilities: pluginsWithVulns, clean: pluginResults.length - pluginsWithVulns.length },
+    themes:  { total_checked: themeResults.length,  with_vulnerabilities: themesWithVulns,  clean: themeResults.length  - themesWithVulns.length  },
     severity: (core.vulns.length || pluginsWithVulns.length || themesWithVulns.length) > 0 ? "high" : "none",
-    note: "Known vulnerabilities affecting installed versions. Patch immediately; if exploitation predates patching, this is the likely entry point. Records under 'vulnerabilities_uncertain_match' could not be confirmed as affecting your version — manually verify each.",
+    note: "Known vulnerabilities affecting installed versions. Patch immediately; if exploitation predates patching, this is the likely entry point. Records under 'vulnerabilities_uncertain_match' could not be confirmed as affecting your version — verify manually.",
   };
 }
 
+function buildSignals({ phpInUploads, muPlugins, dropIns, baitDirs, knownMalwareFiles, patternScan, recentCore }) {
+  const truncationNote = (s) =>
+    s.fileListTruncated || s.filesReadTruncated > 0 || s.depthCapped
+      ? `SCAN TRUNCATED — file list capped at ${s.maxFilesScanned}, file bodies capped at ${s.maxFileBytes} bytes. A zero hit count does NOT mean clean. Run wp core verify-checksums + wp plugin verify-checksums --all and a full external scanner.`
+      : "Heuristic regex match — investigate each file before deletion.";
+
+  return {
+    php_in_uploads: {
+      count: phpInUploads.files.length,
+      files: phpInUploads.files.slice(0, 50),
+      severity: phpInUploads.files.length > 0 ? "high" : "none",
+      truncated: phpInUploads.truncated,
+      note: "PHP files inside wp-content/uploads/ are never legitimate.",
+    },
+    mu_plugins: {
+      exists: muPlugins.exists,
+      entries: muPlugins.entries,
+      severity: muPlugins.exists && muPlugins.entries.length > 0 ? "review" : "none",
+      note: "Auto-loaded; commonly missed during cleanup. Review every entry.",
+    },
+    drop_ins: {
+      present_in_wp_content: dropIns.present,
+      severity: dropIns.present.length > 0 ? "review" : "none",
+      note: "Drop-ins (object-cache.php, advanced-cache.php, db.php, etc.) auto-load from wp-content/. Verify each is legitimate (caching plugin, hosting provider, etc.).",
+    },
+    wp_flavored_bait_directories: {
+      directories: baitDirs,
+      severity: baitDirs.length > 0 ? "high" : "none",
+      note: "Plugin directories with WP-mimicking names are a known compromise pattern.",
+    },
+    known_malware_filenames: {
+      files: knownMalwareFiles.files,
+      severity: knownMalwareFiles.files.length > 0 ? "high" : "none",
+      truncated: knownMalwareFiles.truncated,
+      note: "Known web shell / malware-family file names.",
+    },
+    malware_pattern_hits: {
+      files_scanned: patternScan.filesScanned,
+      hits: patternScan.hits.slice(0, 200),
+      hit_count: patternScan.hits.length,
+      severity: patternScan.hits.length > 0 ? "high" : "none",
+      file_list_truncated: patternScan.fileListTruncated,
+      files_read_truncated: patternScan.filesReadTruncated,
+      depth_capped: patternScan.depthCapped,
+      note: truncationNote(patternScan),
+    },
+    recent_core_modifications: {
+      days_window: 30,
+      files: recentCore.slice(0, 50),
+      count: recentCore.length,
+      severity: recentCore.length > 0 ? "review" : "none",
+      note: "Recent mtime in wp-admin/wp-includes can mean either (a) a legitimate WP core update or (b) tampering. Mtimes reflect extraction/download time, not release date. Use wp core verify-checksums to distinguish — only checksum mismatches are evidence of tampering.",
+    },
+  };
+}
+
+function summarize(signals) {
+  const anyHigh = Object.values(signals).some((s) => s.severity === "high");
+  const anyReview = Object.values(signals).some((s) => s.severity === "review");
+  const pat = signals.malware_pattern_hits;
+  const scanTruncated = Boolean(pat.file_list_truncated || pat.files_read_truncated > 0 || pat.depth_capped
+    || signals.php_in_uploads.truncated || signals.known_malware_filenames.truncated);
+
+  let overall_severity, recommended_next_step;
+  if (anyHigh) {
+    overall_severity = "high";
+    recommended_next_step = "Multiple high-confidence indicators present. Proceed with full investigation per skill step 3 — but DO NOT skip the manual checks: this scan covers a subset of compromise patterns, not all.";
+  } else if (anyReview || scanTruncated) {
+    overall_severity = "review";
+    recommended_next_step = scanTruncated
+      ? "Scan was TRUNCATED (large site exceeded scan caps). A zero hit count is NOT evidence of clean. Run wp core verify-checksums, wp plugin verify-checksums --all, and a full external scanner (Sucuri, Wordfence, MalCare) before declaring clean."
+      : "Manually inspect 'review' signals before declaring clean.";
+  } else {
+    overall_severity = "none";
+    recommended_next_step = "No high-confidence indicators in this scan. Compromise still possible via paths this scan does not cover (cloaked SEO spam, DB-only injections, host-level, files past size cap). Consider an external scanner.";
+  }
+
+  return { overall_severity, scan_truncated: scanTruncated, recommended_next_step };
+}
+
 async function main() {
-  const args = process.argv.slice(2);
-  const checkVulns = args.includes("--check-vulns");
+  const checkVulns = process.argv.slice(2).includes("--check-vulns");
   const repoRoot = process.cwd();
   const wpRoot = detectWpRoot(repoRoot);
 
   if (!wpRoot) {
     process.stdout.write(JSON.stringify({
-      tool: { name: "detect_compromise_signals", version: 1 },
+      tool: TOOL_HEADER,
       project: { wpRootFound: false, repoRoot },
       message: "No WordPress install detected (no wp-includes/ found). Run skills/wp-project-triage/scripts/detect_wp_project.mjs first.",
     }, null, 2) + "\n");
     return;
   }
 
-  const phpInUploads = scanPhpInUploads(wpRoot);
-  const muPlugins = scanMuPlugins(wpRoot);
-  const dropIns = scanDropIns(wpRoot);
-  const baitDirs = scanWpFlavoredBaitDirs(wpRoot);
-  const knownMalwareFiles = scanKnownMalwareFilenames(wpRoot);
-  const patternScan = scanMalwarePatterns(wpRoot);
-  const recentCore = scanRecentCoreModifications(wpRoot);
-  const vulnReport = checkVulns ? await checkVulnerabilities(wpRoot) : null;
+  const signals = buildSignals({
+    phpInUploads:       scanPhpInUploads(wpRoot),
+    muPlugins:          scanMuPlugins(wpRoot),
+    dropIns:            scanDropIns(wpRoot),
+    baitDirs:           scanWpFlavoredBaitDirs(wpRoot),
+    knownMalwareFiles:  scanKnownMalwareFilenames(wpRoot),
+    patternScan:        scanMalwarePatterns(wpRoot),
+    recentCore:         scanRecentCoreModifications(wpRoot),
+  });
+  if (checkVulns) signals.known_vulnerabilities = await checkVulnerabilities(wpRoot);
 
-  const report = {
-    tool: { name: "detect_compromise_signals", version: 1 },
+  process.stdout.write(JSON.stringify({
+    tool: TOOL_HEADER,
     project: { wpRoot, repoRoot },
-    signals: {
-      php_in_uploads: {
-        count: phpInUploads.length,
-        files: phpInUploads.slice(0, 50),
-        severity: phpInUploads.length > 0 ? "high" : "none",
-        note: "PHP files inside wp-content/uploads/ are never legitimate.",
-      },
-      mu_plugins: {
-        exists: muPlugins.exists,
-        entries: muPlugins.entries,
-        severity: muPlugins.exists && muPlugins.entries.length > 0 ? "review" : "none",
-        note: "Auto-loaded; commonly missed during cleanup. Review every entry.",
-      },
-      drop_ins: {
-        present_in_wp_content: dropIns.present,
-        severity: dropIns.present.length > 0 ? "review" : "none",
-        note: "Drop-ins (object-cache.php, advanced-cache.php, db.php, etc.) auto-load from wp-content/. Verify each is legitimate (caching plugin, hosting provider, etc.).",
-      },
-      wp_flavored_bait_directories: {
-        directories: baitDirs,
-        severity: baitDirs.length > 0 ? "high" : "none",
-        note: "Plugin directories with WP-mimicking names are a known compromise pattern.",
-      },
-      known_malware_filenames: {
-        files: knownMalwareFiles,
-        severity: knownMalwareFiles.length > 0 ? "high" : "none",
-        note: "Known web shell / malware-family file names.",
-      },
-      malware_pattern_hits: {
-        files_scanned: patternScan.filesScanned,
-        hits: patternScan.hits.slice(0, 200),
-        hit_count: patternScan.hits.length,
-        severity: patternScan.hits.length > 0 ? "high" : "none",
-        file_list_truncated: patternScan.fileListTruncated,
-        files_read_truncated: patternScan.filesReadTruncated,
-        depth_capped: patternScan.depthCapped,
-        note: patternScan.fileListTruncated || patternScan.filesReadTruncated > 0 || patternScan.depthCapped
-          ? `SCAN TRUNCATED — file list capped at ${patternScan.maxFilesScanned}, file bodies capped at ${patternScan.maxFileBytes} bytes. A zero hit count does NOT mean clean. Run wp core verify-checksums + wp plugin verify-checksums --all and a full external scanner.`
-          : "Heuristic regex match — investigate each file before deletion.",
-      },
-      recent_core_modifications: {
-        days_window: 30,
-        files: recentCore.slice(0, 50),
-        count: recentCore.length,
-        severity: recentCore.length > 0 ? "review" : "none",
-        note: "Recent mtime in wp-admin/wp-includes can mean either (a) a legitimate WP core update or (b) tampering. Mtimes reflect extraction/download time, not release date. Use wp core verify-checksums to distinguish — only checksum mismatches are evidence of tampering.",
-      },
-    },
-  };
-
-  if (vulnReport) {
-    report.signals.known_vulnerabilities = vulnReport;
-  }
-
-  const anyHigh = Object.values(report.signals).some((s) => s.severity === "high");
-  const anyReview = Object.values(report.signals).some((s) => s.severity === "review");
-  const scanTruncated = report.signals.malware_pattern_hits.file_list_truncated
-    || report.signals.malware_pattern_hits.files_read_truncated > 0
-    || report.signals.malware_pattern_hits.depth_capped;
-
-  let overall, next;
-  if (anyHigh) {
-    overall = "high";
-    next = "Multiple high-confidence indicators present. Proceed with full investigation per skill step 3 — but DO NOT skip the manual checks: this scan covers a subset of compromise patterns, not all.";
-  } else if (anyReview || scanTruncated) {
-    overall = "review";
-    next = scanTruncated
-      ? "Scan was TRUNCATED (large site exceeded scan caps). A zero hit count is NOT evidence of clean. Run wp core verify-checksums, wp plugin verify-checksums --all, and a full external scanner (Sucuri, Wordfence, MalCare) before declaring clean."
-      : "Manually inspect 'review' signals before declaring clean.";
-  } else {
-    overall = "none";
-    next = "No high-confidence indicators in this scan. Compromise still possible via paths this scan does not cover (cloaked SEO spam, DB-only injections, host-level, files past size cap). Consider an external scanner.";
-  }
-
-  report.summary = {
-    overall_severity: overall,
-    scan_truncated: scanTruncated,
-    recommended_next_step: next,
-  };
-
-  process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+    signals,
+    summary: summarize(signals),
+  }, null, 2) + "\n");
 }
 
 main().catch((err) => {

--- a/skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs
+++ b/skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs
@@ -71,10 +71,12 @@ function readFileSafe(p, maxBytes = 128 * 1024) {
 function findFilesRecursive(rootDir, predicate, { maxFiles = 6000, maxDepth = 12 } = {}) {
   const results = [];
   const queue = [{ dir: rootDir, depth: 0 }];
+  let truncated = false;
+  let depthCapped = false;
 
   while (queue.length > 0 && results.length < maxFiles) {
     const { dir, depth } = queue.shift();
-    if (depth > maxDepth) continue;
+    if (depth > maxDepth) { depthCapped = true; continue; }
 
     let entries;
     try {
@@ -92,12 +94,19 @@ function findFilesRecursive(rootDir, predicate, { maxFiles = 6000, maxDepth = 12
       } else if (ent.isFile()) {
         if (predicate(ent.name, fullPath)) {
           results.push(fullPath);
-          if (results.length >= maxFiles) break;
+          if (results.length >= maxFiles) {
+            truncated = true;
+            break;
+          }
         }
       }
     }
   }
 
+  if (queue.length > 0 && results.length >= maxFiles) truncated = true;
+
+  results.truncated = truncated;
+  results.depthCapped = depthCapped;
   return results;
 }
 
@@ -184,7 +193,7 @@ function scanKnownMalwareFilenames(wpRoot) {
   return findFilesRecursive(wpRoot, (name) => KNOWN_MALWARE_FILENAMES.has(name.toLowerCase()), { maxFiles: 50 });
 }
 
-function scanMalwarePatterns(wpRoot, { maxFilesScanned = 4000 } = {}) {
+function scanMalwarePatterns(wpRoot, { maxFilesScanned = 4000, maxFileBytes = 256 * 1024 } = {}) {
   const hits = [];
   const phpFiles = findFilesRecursive(
     wpRoot,
@@ -192,8 +201,11 @@ function scanMalwarePatterns(wpRoot, { maxFilesScanned = 4000 } = {}) {
     { maxFiles: maxFilesScanned }
   );
 
+  let filesReadTruncated = 0;
   for (const file of phpFiles) {
-    const content = readFileSafe(file, 256 * 1024);
+    const st = statSafe(file);
+    if (st && st.size > maxFileBytes) filesReadTruncated += 1;
+    const content = readFileSafe(file, maxFileBytes);
     if (!content) continue;
     for (const pattern of MALWARE_PATTERNS) {
       if (pattern.regex.test(content)) {
@@ -202,7 +214,15 @@ function scanMalwarePatterns(wpRoot, { maxFilesScanned = 4000 } = {}) {
     }
   }
 
-  return { filesScanned: phpFiles.length, hits };
+  return {
+    filesScanned: phpFiles.length,
+    hits,
+    fileListTruncated: phpFiles.truncated === true,
+    depthCapped: phpFiles.depthCapped === true,
+    filesReadTruncated,  // count of files where only the first maxFileBytes were scanned
+    maxFilesScanned,
+    maxFileBytes,
+  };
 }
 
 function scanRecentCoreModifications(wpRoot, days = 30) {
@@ -359,7 +379,7 @@ function compareVersions(a, b) {
 }
 
 function vulnAffectsInstalledVersion(vuln, installedVersion) {
-  if (!installedVersion) return true; // assume affected when version unknown
+  if (!installedVersion) return { affected: null, reason: "version_unknown" };
   // wpvulnerability.com vuln records vary in shape; check operator-style fields, fallback to "patched_in"
   const ops = vuln?.operator || vuln?.affected || null;
   if (Array.isArray(ops)) {
@@ -368,38 +388,43 @@ function vulnAffectsInstalledVersion(vuln, installedVersion) {
       const operator = op?.operator;
       if (!v || !operator) continue;
       const cmp = compareVersions(installedVersion, v);
-      if (operator === "<=" && cmp <= 0) return true;
-      if (operator === "<" && cmp < 0) return true;
-      if (operator === "=" && cmp === 0) return true;
-      if (operator === ">=" && cmp >= 0) return true;
-      if (operator === ">" && cmp > 0) return true;
+      if (operator === "<=" && cmp <= 0) return { affected: true };
+      if (operator === "<" && cmp < 0) return { affected: true };
+      if (operator === "=" && cmp === 0) return { affected: true };
+      if (operator === ">=" && cmp >= 0) return { affected: true };
+      if (operator === ">" && cmp > 0) return { affected: true };
     }
-    return false;
+    return { affected: false };
   }
   const patchedIn = vuln?.patched_in || vuln?.fixed_in;
-  if (patchedIn) return compareVersions(installedVersion, patchedIn) < 0;
-  return true;
+  if (patchedIn) return { affected: compareVersions(installedVersion, patchedIn) < 0 };
+  return { affected: null, reason: "no_version_constraints_in_record" };
 }
 
 function flattenVulnRecords(apiResult, installedVersion) {
-  // wpvulnerability.com response shape: { ..., vulnerabilities: [ { id, title, source, ..., operator: [...] } ] }
-  if (!apiResult?.data) return { error: apiResult?.error, vulns: [] };
+  // wpvulnerability.com response shape varies; this code is best-effort and may need adjustment.
+  if (!apiResult?.data) return { error: apiResult?.error, vulns: [], unknown_match: [] };
   const candidates = apiResult.data?.vulnerabilities || apiResult.data?.vulns || [];
   const matched = [];
+  const unknownMatch = [];  // records where we couldn't determine if the installed version is affected
   for (const v of candidates) {
-    if (vulnAffectsInstalledVersion(v, installedVersion)) {
-      matched.push({
-        id: v.id || v.cve || v.title?.slice(0, 40) || "unknown",
-        title: v.title || v.summary || null,
-        source: v.source || null,
-        severity: v.severity || v.cvss?.severity || null,
-        score: v.cvss?.score || null,
-        patched_in: v.patched_in || v.fixed_in || null,
-        url: v.source_url || v.url || null,
-      });
+    const { affected, reason } = vulnAffectsInstalledVersion(v, installedVersion);
+    const record = {
+      id: v.id || v.cve || v.title?.slice(0, 40) || "unknown",
+      title: v.title || v.summary || null,
+      source: v.source || null,
+      severity: v.severity || v.cvss?.severity || null,
+      score: v.cvss?.score || null,
+      patched_in: v.patched_in || v.fixed_in || null,
+      url: v.source_url || v.url || null,
+    };
+    if (affected === true) {
+      matched.push(record);
+    } else if (affected === null) {
+      unknownMatch.push({ ...record, match_uncertainty_reason: reason });
     }
   }
-  return { vulns: matched };
+  return { vulns: matched, unknown_match: unknownMatch };
 }
 
 async function runWithConcurrency(items, worker, concurrency = VULN_CONCURRENCY) {
@@ -426,25 +451,46 @@ async function checkVulnerabilities(wpRoot) {
 
   const pluginResults = await runWithConcurrency(plugins, async (p) => {
     const apiResult = await fetchJsonWithTimeout(`${VULN_API_BASE}/plugin/${encodeURIComponent(p.slug)}`);
-    const { vulns, error } = flattenVulnRecords(apiResult, p.version);
-    return { slug: p.slug, name: p.name, installed_version: p.version, vulnerabilities: vulns, fetch_error: error || apiResult?.error };
+    const { vulns, unknown_match, error } = flattenVulnRecords(apiResult, p.version);
+    return {
+      slug: p.slug,
+      name: p.name,
+      installed_version: p.version,
+      vulnerabilities: vulns,
+      vulnerabilities_uncertain_match: unknown_match,
+      fetch_error: error || apiResult?.error,
+    };
   });
 
   const themeResults = await runWithConcurrency(themes, async (t) => {
     const apiResult = await fetchJsonWithTimeout(`${VULN_API_BASE}/theme/${encodeURIComponent(t.slug)}`);
-    const { vulns, error } = flattenVulnRecords(apiResult, t.version);
-    return { slug: t.slug, name: t.name, installed_version: t.version, vulnerabilities: vulns, fetch_error: error || apiResult?.error };
+    const { vulns, unknown_match, error } = flattenVulnRecords(apiResult, t.version);
+    return {
+      slug: t.slug,
+      name: t.name,
+      installed_version: t.version,
+      vulnerabilities: vulns,
+      vulnerabilities_uncertain_match: unknown_match,
+      fetch_error: error || apiResult?.error,
+    };
   });
 
   const coreApi = await corePromise;
-  const coreVulns = wpVersion ? flattenVulnRecords(coreApi, wpVersion).vulns : [];
+  const core = wpVersion ? flattenVulnRecords(coreApi, wpVersion) : { vulns: [], unknown_match: [] };
 
   const pluginsWithVulns = pluginResults.filter((p) => p.vulnerabilities.length > 0);
   const themesWithVulns = themeResults.filter((t) => t.vulnerabilities.length > 0);
 
   return {
-    source: "wpvulnerability.com (aggregates WPScan, Patchstack, WP.org)",
-    wp_core: { installed_version: wpVersion, vulnerabilities: coreVulns, fetch_error: coreApi?.error || null },
+    experimental: true,
+    privacy_note: "This check sends a list of your installed plugin/theme slugs (not versions or contents) to wpvulnerability.com. On a compromised box, that inventory may be sensitive — do not run --check-vulns from a network you don't want the request traffic associated with. Skip this flag if in doubt.",
+    source: "wpvulnerability.com (aggregates WPScan, Patchstack, WP.org). Response shape varies — adapter is best-effort.",
+    wp_core: {
+      installed_version: wpVersion,
+      vulnerabilities: core.vulns,
+      vulnerabilities_uncertain_match: core.unknown_match,
+      fetch_error: coreApi?.error || null,
+    },
     plugins: {
       total_checked: pluginResults.length,
       with_vulnerabilities: pluginsWithVulns,
@@ -455,8 +501,8 @@ async function checkVulnerabilities(wpRoot) {
       with_vulnerabilities: themesWithVulns,
       clean: themeResults.length - themesWithVulns.length,
     },
-    severity: (coreVulns.length || pluginsWithVulns.length || themesWithVulns.length) > 0 ? "high" : "none",
-    note: "Known vulnerabilities affecting installed versions. Patch immediately; if exploitation predates patching, it may be the entry point for the active compromise.",
+    severity: (core.vulns.length || pluginsWithVulns.length || themesWithVulns.length) > 0 ? "high" : "none",
+    note: "Known vulnerabilities affecting installed versions. Patch immediately; if exploitation predates patching, this is the likely entry point. Records under 'vulnerabilities_uncertain_match' could not be confirmed as affecting your version — manually verify each.",
   };
 }
 
@@ -520,14 +566,19 @@ async function main() {
         hits: patternScan.hits.slice(0, 200),
         hit_count: patternScan.hits.length,
         severity: patternScan.hits.length > 0 ? "high" : "none",
-        note: "Heuristic regex match — investigate each file before deletion.",
+        file_list_truncated: patternScan.fileListTruncated,
+        files_read_truncated: patternScan.filesReadTruncated,
+        depth_capped: patternScan.depthCapped,
+        note: patternScan.fileListTruncated || patternScan.filesReadTruncated > 0 || patternScan.depthCapped
+          ? `SCAN TRUNCATED — file list capped at ${patternScan.maxFilesScanned}, file bodies capped at ${patternScan.maxFileBytes} bytes. A zero hit count does NOT mean clean. Run wp core verify-checksums + wp plugin verify-checksums --all and a full external scanner.`
+          : "Heuristic regex match — investigate each file before deletion.",
       },
       recent_core_modifications: {
         days_window: 30,
         files: recentCore.slice(0, 50),
         count: recentCore.length,
-        severity: recentCore.length > 0 ? "high" : "none",
-        note: "Core .php files in wp-admin/wp-includes should match release timestamps. Recent unexpected mtimes are a red flag.",
+        severity: recentCore.length > 0 ? "review" : "none",
+        note: "Recent mtime in wp-admin/wp-includes can mean either (a) a legitimate WP core update or (b) tampering. Mtimes reflect extraction/download time, not release date. Use wp core verify-checksums to distinguish — only checksum mismatches are evidence of tampering.",
       },
     },
   };
@@ -538,13 +589,28 @@ async function main() {
 
   const anyHigh = Object.values(report.signals).some((s) => s.severity === "high");
   const anyReview = Object.values(report.signals).some((s) => s.severity === "review");
+  const scanTruncated = report.signals.malware_pattern_hits.file_list_truncated
+    || report.signals.malware_pattern_hits.files_read_truncated > 0
+    || report.signals.malware_pattern_hits.depth_capped;
+
+  let overall, next;
+  if (anyHigh) {
+    overall = "high";
+    next = "Multiple high-confidence indicators present. Proceed with full investigation per skill step 3 — but DO NOT skip the manual checks: this scan covers a subset of compromise patterns, not all.";
+  } else if (anyReview || scanTruncated) {
+    overall = "review";
+    next = scanTruncated
+      ? "Scan was TRUNCATED (large site exceeded scan caps). A zero hit count is NOT evidence of clean. Run wp core verify-checksums, wp plugin verify-checksums --all, and a full external scanner (Sucuri, Wordfence, MalCare) before declaring clean."
+      : "Manually inspect 'review' signals before declaring clean.";
+  } else {
+    overall = "none";
+    next = "No high-confidence indicators in this scan. Compromise still possible via paths this scan does not cover (cloaked SEO spam, DB-only injections, host-level, files past size cap). Consider an external scanner.";
+  }
+
   report.summary = {
-    overall_severity: anyHigh ? "high" : anyReview ? "review" : "none",
-    recommended_next_step: anyHigh
-      ? "Proceed with full investigation per skill step 3. Treat as confirmed compromise."
-      : anyReview
-        ? "Manually inspect 'review' signals before declaring clean."
-        : "No high-confidence indicators found. Compromise still possible via paths this scan does not cover (cloaked SEO spam, DB-only injections, host-level). Consider an external scanner.",
+    overall_severity: overall,
+    scan_truncated: scanTruncated,
+    recommended_next_step: next,
   };
 
   process.stdout.write(JSON.stringify(report, null, 2) + "\n");

--- a/skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs
+++ b/skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs
@@ -1,0 +1,312 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const DEFAULT_IGNORES = new Set([
+  ".git",
+  "node_modules",
+  "vendor",
+  "dist",
+  "build",
+  "coverage",
+  ".next",
+  ".turbo",
+]);
+
+const SUSPICIOUS_PHP_EXTS = new Set([
+  ".php",
+  ".phtml",
+  ".phar",
+  ".php3",
+  ".php4",
+  ".php5",
+  ".php7",
+  ".pht",
+]);
+
+const MALWARE_PATTERNS = [
+  { name: "eval_gzinflate_base64", regex: /eval\s*\(\s*gzinflate\s*\(\s*base64_decode/i },
+  { name: "eval_base64_decode",    regex: /eval\s*\(\s*base64_decode/i },
+  { name: "eval_request_param",    regex: /eval\s*\(\s*\$_(POST|GET|REQUEST|COOKIE|SERVER)/i },
+  { name: "assert_request_param",  regex: /assert\s*\(\s*\$_(POST|GET|REQUEST|COOKIE)/i },
+  { name: "exec_request_param",    regex: /(system|shell_exec|passthru|exec|popen|proc_open)\s*\(\s*\$_/i },
+  { name: "preg_replace_e_modifier", regex: /preg_replace\s*\(\s*['"][^'"]*\/e['"]/i },
+];
+
+const KNOWN_MALWARE_FILENAMES = new Set([
+  "wp-vcd.php",
+  "wp-tmp.php",
+  "wp-feed.php",
+  "c99.php",
+  "r57.php",
+  "wso.php",
+  "b374k.php",
+]);
+
+const WP_FLAVORED_DIR_BAIT = [
+  /^wp-config-php$/,
+  /^wp-content-update$/,
+  /^wp-includes-update$/,
+  /^wordpress-update$/,
+  /^akismet-update$/,
+];
+
+function statSafe(p) {
+  try {
+    return fs.statSync(p);
+  } catch {
+    return null;
+  }
+}
+
+function readFileSafe(p, maxBytes = 128 * 1024) {
+  try {
+    const buf = fs.readFileSync(p);
+    if (buf.byteLength > maxBytes) return buf.subarray(0, maxBytes).toString("utf8");
+    return buf.toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+function findFilesRecursive(rootDir, predicate, { maxFiles = 6000, maxDepth = 12 } = {}) {
+  const results = [];
+  const queue = [{ dir: rootDir, depth: 0 }];
+
+  while (queue.length > 0 && results.length < maxFiles) {
+    const { dir, depth } = queue.shift();
+    if (depth > maxDepth) continue;
+
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const ent of entries) {
+      const fullPath = path.join(dir, ent.name);
+
+      if (ent.isDirectory()) {
+        if (DEFAULT_IGNORES.has(ent.name)) continue;
+        queue.push({ dir: fullPath, depth: depth + 1 });
+      } else if (ent.isFile()) {
+        if (predicate(ent.name, fullPath)) {
+          results.push(fullPath);
+          if (results.length >= maxFiles) break;
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+function detectWpRoot(repoRoot) {
+  const candidates = [
+    repoRoot,
+    path.join(repoRoot, "wordpress"),
+    path.join(repoRoot, "wp"),
+    path.join(repoRoot, "public"),
+    path.join(repoRoot, "public_html"),
+  ];
+  for (const c of candidates) {
+    if (statSafe(path.join(c, "wp-includes"))) return c;
+  }
+  return null;
+}
+
+function scanPhpInUploads(wpRoot) {
+  const uploadsDir = path.join(wpRoot, "wp-content", "uploads");
+  if (!statSafe(uploadsDir)) return [];
+  return findFilesRecursive(uploadsDir, (name) => {
+    const ext = path.extname(name).toLowerCase();
+    return SUSPICIOUS_PHP_EXTS.has(ext);
+  }, { maxFiles: 500 });
+}
+
+function scanMuPlugins(wpRoot) {
+  const muDir = path.join(wpRoot, "wp-content", "mu-plugins");
+  if (!statSafe(muDir)) return { exists: false, entries: [] };
+  let entries = [];
+  try {
+    entries = fs.readdirSync(muDir);
+  } catch {
+    return { exists: true, entries: [] };
+  }
+  return { exists: true, entries };
+}
+
+function scanDropIns(wpRoot) {
+  // Drop-ins live directly in wp-content/ (no wp-content/drop-ins/ subdirectory exists in stock WP).
+  // Reference: https://developer.wordpress.org/reference/functions/_get_dropins/
+  const wpContent = path.join(wpRoot, "wp-content");
+  const knownDropIns = new Set([
+    "advanced-cache.php",
+    "db.php",
+    "db-error.php",
+    "install.php",
+    "maintenance.php",
+    "object-cache.php",
+    "php-error.php",
+    "fatal-error-handler.php",
+    // Multisite-only
+    "sunrise.php",
+    "blog-deleted.php",
+    "blog-inactive.php",
+    "blog-suspended.php",
+  ]);
+  let present = [];
+  try {
+    const wpContentEntries = fs.readdirSync(wpContent);
+    present = wpContentEntries.filter((n) => knownDropIns.has(n));
+  } catch {
+    // ignore
+  }
+  return { present };
+}
+
+function scanWpFlavoredBaitDirs(wpRoot) {
+  const pluginsDir = path.join(wpRoot, "wp-content", "plugins");
+  if (!statSafe(pluginsDir)) return [];
+  let entries = [];
+  try {
+    entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => e.isDirectory())
+    .filter((e) => WP_FLAVORED_DIR_BAIT.some((rx) => rx.test(e.name)))
+    .map((e) => e.name);
+}
+
+function scanKnownMalwareFilenames(wpRoot) {
+  return findFilesRecursive(wpRoot, (name) => KNOWN_MALWARE_FILENAMES.has(name.toLowerCase()), { maxFiles: 50 });
+}
+
+function scanMalwarePatterns(wpRoot, { maxFilesScanned = 4000 } = {}) {
+  const hits = [];
+  const phpFiles = findFilesRecursive(
+    wpRoot,
+    (name) => SUSPICIOUS_PHP_EXTS.has(path.extname(name).toLowerCase()),
+    { maxFiles: maxFilesScanned }
+  );
+
+  for (const file of phpFiles) {
+    const content = readFileSafe(file, 256 * 1024);
+    if (!content) continue;
+    for (const pattern of MALWARE_PATTERNS) {
+      if (pattern.regex.test(content)) {
+        hits.push({ file, pattern: pattern.name });
+      }
+    }
+  }
+
+  return { filesScanned: phpFiles.length, hits };
+}
+
+function scanRecentCoreModifications(wpRoot, days = 30) {
+  const cutoffMs = Date.now() - days * 24 * 60 * 60 * 1000;
+  const coreDirs = ["wp-admin", "wp-includes"].map((d) => path.join(wpRoot, d));
+  const recent = [];
+  for (const dir of coreDirs) {
+    if (!statSafe(dir)) continue;
+    const files = findFilesRecursive(
+      dir,
+      (name) => name.endsWith(".php"),
+      { maxFiles: 5000 }
+    );
+    for (const f of files) {
+      const st = statSafe(f);
+      if (st && st.mtimeMs > cutoffMs) {
+        recent.push({ file: f, mtime: new Date(st.mtimeMs).toISOString() });
+      }
+    }
+  }
+  return recent;
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const wpRoot = detectWpRoot(repoRoot);
+
+  if (!wpRoot) {
+    process.stdout.write(JSON.stringify({
+      tool: { name: "detect_compromise_signals", version: 1 },
+      project: { wpRootFound: false, repoRoot },
+      message: "No WordPress install detected (no wp-includes/ found). Run skills/wp-project-triage/scripts/detect_wp_project.mjs first.",
+    }, null, 2) + "\n");
+    return;
+  }
+
+  const phpInUploads = scanPhpInUploads(wpRoot);
+  const muPlugins = scanMuPlugins(wpRoot);
+  const dropIns = scanDropIns(wpRoot);
+  const baitDirs = scanWpFlavoredBaitDirs(wpRoot);
+  const knownMalwareFiles = scanKnownMalwareFilenames(wpRoot);
+  const patternScan = scanMalwarePatterns(wpRoot);
+  const recentCore = scanRecentCoreModifications(wpRoot);
+
+  const report = {
+    tool: { name: "detect_compromise_signals", version: 1 },
+    project: { wpRoot, repoRoot },
+    signals: {
+      php_in_uploads: {
+        count: phpInUploads.length,
+        files: phpInUploads.slice(0, 50),
+        severity: phpInUploads.length > 0 ? "high" : "none",
+        note: "PHP files inside wp-content/uploads/ are never legitimate.",
+      },
+      mu_plugins: {
+        exists: muPlugins.exists,
+        entries: muPlugins.entries,
+        severity: muPlugins.exists && muPlugins.entries.length > 0 ? "review" : "none",
+        note: "Auto-loaded; commonly missed during cleanup. Review every entry.",
+      },
+      drop_ins: {
+        present_in_wp_content: dropIns.present,
+        severity: dropIns.present.length > 0 ? "review" : "none",
+        note: "Drop-ins (object-cache.php, advanced-cache.php, db.php, etc.) auto-load from wp-content/. Verify each is legitimate (caching plugin, hosting provider, etc.).",
+      },
+      wp_flavored_bait_directories: {
+        directories: baitDirs,
+        severity: baitDirs.length > 0 ? "high" : "none",
+        note: "Plugin directories with WP-mimicking names are a known compromise pattern.",
+      },
+      known_malware_filenames: {
+        files: knownMalwareFiles,
+        severity: knownMalwareFiles.length > 0 ? "high" : "none",
+        note: "Known web shell / malware-family file names.",
+      },
+      malware_pattern_hits: {
+        files_scanned: patternScan.filesScanned,
+        hits: patternScan.hits.slice(0, 200),
+        hit_count: patternScan.hits.length,
+        severity: patternScan.hits.length > 0 ? "high" : "none",
+        note: "Heuristic regex match — investigate each file before deletion.",
+      },
+      recent_core_modifications: {
+        days_window: 30,
+        files: recentCore.slice(0, 50),
+        count: recentCore.length,
+        severity: recentCore.length > 0 ? "high" : "none",
+        note: "Core .php files in wp-admin/wp-includes should match release timestamps. Recent unexpected mtimes are a red flag.",
+      },
+    },
+  };
+
+  const anyHigh = Object.values(report.signals).some((s) => s.severity === "high");
+  const anyReview = Object.values(report.signals).some((s) => s.severity === "review");
+  report.summary = {
+    overall_severity: anyHigh ? "high" : anyReview ? "review" : "none",
+    recommended_next_step: anyHigh
+      ? "Proceed with full investigation per skill step 3. Treat as confirmed compromise."
+      : anyReview
+        ? "Manually inspect 'review' signals before declaring clean."
+        : "No high-confidence indicators found. Compromise still possible via paths this scan does not cover (cloaked SEO spam, DB-only injections, host-level). Consider an external scanner.",
+  };
+
+  process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+}
+
+main();


### PR DESCRIPTION
Closes #61

## Summary

Adds a new skill `wp-abuse-and-compromise-response` covering response to a suspected or confirmed WordPress site compromise: defacement, redirect injection, SEO spam, phishing-page host, mailer abuse, cryptominer, and supply-chain plugin attack.

The skill walks AI assistants through:
1. Triage (with immediate **salts rotation** to kill active sessions without tipping off the attacker)
2. Contain — preserve evidence
3. Classify the compromise type
4. Investigate (file/DB/log + local-machine malware scan)
5. Clean (backup-restore path OR manual cleanup)
6. Full credential rotation
7. Verify clean
8. Post-cleanup hardening

This is response-focused. Upfront prevention (nonces, capability checks, sanitization/escaping) is the planned `wp-security` skill's territory — the two are complementary, not overlapping.

## What's included

- `skills/wp-abuse-and-compromise-response/SKILL.md` — procedural overview (167 lines, in range with wp-performance and wp-plugin-development)
- `skills/wp-abuse-and-compromise-response/references/`:
  - `signals.md` — full signal-to-category taxonomy across 9 compromise categories
  - `investigation.md` — DB queries, log triage, file-system patterns
  - `common-injection-points.md` — catalog of where attackers hide (mu-plugins, autoload options, drop-ins, etc.)
  - `hardening.md` — post-cleanup hardening checklist
- `skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs` — deterministic fast-scan helper, JSON output, matches `detect_*.mjs` convention
- `eval/scenarios/abuse-confirmed-redirect-cleanup.json` — happy path
- `eval/scenarios/abuse-suspected-but-unconfirmed.json` — cloaking/SEO-spam triage
- `eval/scenarios/abuse-reinfection-after-cleanup.json` — focuses AI on persistence mechanisms

## Registry updates

- `README.md` — added skill to the available-skills table
- `docs/ai-authorship.md` — added authorship disclosure row
- `skills/wordpress-router/references/decision-tree.md` — added compromise/hacked/defaced/malware/redirect/SEO-spam/phishing/mailer/cryptominer/reinfection intent → route to this skill

## Alignment with WordPress.org canonical guidance

The skill was audited against the [hacked-site FAQ](https://wordpress.org/documentation/article/faq-my-site-was-hacked/) and the [hardening guide](https://developer.wordpress.org/advanced-administration/security/hardening/) before submission. Key alignments:

- **Salts-first then full-credential rotation** — kills sessions immediately (matching WP.org's reset-first intent) without sending password-change emails that would tip off the attacker. Full credential rotation runs after cleanup.
- **Local-machine malware scan** in investigation — WP.org explicitly flags the owner's box as a major compromise vector.
- **DB user privilege restriction** in hardening — runtime user with SELECT/INSERT/UPDATE/DELETE only.
- **HTTP basic auth on `/wp-admin/`** in hardening.
- **File permission floors** — files 644 / dirs 755 / wp-config.php 440 (per WP.org, not 600).

## Validation

- `node eval/harness/run.mjs` — passes
- `node skills/wp-abuse-and-compromise-response/scripts/detect_compromise_signals.mjs` — returns valid JSON
- All 3 eval scenarios parse as valid JSON
- SKILL.md headers match repo convention (`## When to use`, `## Inputs required`, `## Procedure` with `### 0) Triage` first, `## Verification`, `## Failure modes / debugging`, `## Escalation`)
- Frontmatter contains required `WordPress 6.9` and `PHP 7.2.24` substrings

## AI authorship disclosure

Per the established `docs/ai-authorship.md` table format:

- AI tool: Claude Opus 4.7
- Source material: WordPress.org canonical hardening + hacked-site FAQ docs, WP-CLI command reference, established compromise-response patterns
- Reviewed by: community contributor with hosting-provider abuse-response operational background
- Testing: eval scenarios written; not yet run against an AI assistant on real tasks (marked "Pending" in the disclosure)

## Opinionated calls (open to feedback)

1. **Salts-first rotation** vs WP.org's full-credential reset-first — both are valid. This skill prefers salts-first to avoid attacker-tipoff via password-change emails, with full rotation after cleanup. Acknowledged in SKILL.md §1.
2. **`mu-plugins/` listed first** in the persistence catalog — most commonly-missed hiding place across the WP community.
3. **`wp-config.php` reconstructed from scratch**, not cleaned — diffing isn't reliable enough; rebuild from known DB creds + fresh salts.
4. **Explicit Y/N confirmation gate** before destructive cleanup — prevents AI from being overconfident.
5. **Anonymized real-world supply-chain note** in signals.md §8 references the pattern of a multi-plugin slider/popup/widget vendor with tens of thousands of installs becoming a high-value supply-chain target, without naming any vendor or host.

## Out of scope

- Bypassing Cloudflare / bot protection. Inaccessible is a valid verdict.
- Real-time forensic timeline reconstruction — escalates to specialist services.
- Multi-site network-level cleanup — single-site focus first.
- Server-level non-WP malware — escalates to host.