### PR TITLE
Add plugin security guidance for escaping and AJAX

### DIFF
--- a/skills/wp-plugin-development/references/security.md
+++ b/skills/wp-plugin-development/references/security.md
@@ -23,7 +23,24 @@ Practical rules:
 - use `wp_unslash()` before sanitizing when needed
 - use prepared statements for SQL; avoid interpolating user input into queries
 
+## Output escaping contexts
+
+Escape at output, using the function that matches the context:
+
+* HTML text: `esc_html()`
+* HTML attribute: `esc_attr()`
+* URL: `esc_url()`
+* textarea: `esc_textarea()`
+* JSON/script data: `wp_json_encode()`
+* allowed HTML: `wp_kses_post()` or `wp_kses()`
+
+## AJAX handlers
+
+* For `wp_ajax_*`, verify nonce and check capabilities.
+* For `wp_ajax_nopriv_*`, assume unauthenticated attacker-controlled traffic.
+* Return JSON with `wp_send_json_success()` or `wp_send_json_error()`.
+* Do not expose private data from AJAX responses.
+
 Common review guidance:
 
 - https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/
-

--- a/skills/wp-plugin-development/references/security.md
+++ b/skills/wp-plugin-development/references/security.md
@@ -31,8 +31,11 @@ Escape at output, using the function that matches the context:
 * HTML attribute: `esc_attr()`
 * URL: `esc_url()`
 * textarea: `esc_textarea()`
-* JSON/script data: `wp_json_encode()`
-* allowed HTML: `wp_kses_post()` or `wp_kses()`
+* JavaScript strings: `esc_js()`
+
+For JSON data, prefer `wp_json_encode()` and pass data through WordPress script APIs such as `wp_add_inline_script()` or `wp_localize_script()`.
+
+For user-provided HTML, restrict allowed markup with `wp_kses_post()` or `wp_kses()` before output.
 
 ## AJAX handlers
 


### PR DESCRIPTION
This PR expands the plugin security guidance in `wp-plugin-development` by adding practical review criteria for output escaping and AJAX handlers.

The goal is to help AI coding assistants generate and review WordPress plugins using safer patterns and more consistent security practices.

## Key Changes

### Output Escaping Guidance

Added a dedicated section covering context-specific escaping functions:

* HTML text: `esc_html()`
* HTML attributes: `esc_attr()`
* URLs: `esc_url()`
* Textareas: `esc_textarea()`
* JSON and script data: `wp_json_encode()`
* Allowed HTML: `wp_kses_post()` and `wp_kses()`

This reinforces the existing "sanitize on input, escape on output" guidance with concrete implementation recommendations.

### AJAX Security Guidance

Added a new section covering secure AJAX handler development:

* Verify nonces and capabilities for `wp_ajax_*` actions
* Treat `wp_ajax_nopriv_*` requests as attacker-controlled input
* Use `wp_send_json_success()` and `wp_send_json_error()` for responses
* Avoid exposing private or sensitive data through AJAX endpoints

### Improved Review Coverage

The additional guidance helps AI assistants identify and prevent common plugin security issues including:

* Missing output escaping
* Incorrect escaping contexts
* Weak AJAX authorization checks
* Information disclosure through AJAX responses

These additions complement the existing nonce, capability, sanitization, and SQL safety recommendations already present in the security reference.
