### PR TITLE
wp-core-upgrade: add new skill for upgrading projects to newer WordPress core versions

### DIFF
--- a/eval/scenarios/wp-core-upgrade.json
+++ b/eval/scenarios/wp-core-upgrade.json
@@ -1,0 +1,25 @@
+{
+  "name": "Audit plugin for WordPress 6.9 compatibility",
+  "skills": ["wordpress-router", "wp-project-triage", "wp-core-upgrade"],
+  "query": "I need to upgrade my plugin to be compatible with WordPress 6.9. Can you audit the codebase and tell me what needs to change?",
+  "expected_behavior": [
+    "Step 1: Run wordpress-router to classify repo kind",
+    "Step 2: Run wp-project-triage to understand plugin structure, PHP tooling, and test suite",
+    "Step 3: Route to wp-core-upgrade skill",
+    "Step 4: Fetch the WordPress 6.9 Field Guide from make.wordpress.org using ?output_format=markdown",
+    "Step 5: Identify relevant dev notes based on plugin type (PHP, blocks, REST API, etc.)",
+    "Step 6: Fetch and read each relevant dev note as Markdown",
+    "Step 7: Search the codebase for functions, hooks, and patterns mentioned in breaking-change and deprecation notes",
+    "Step 8: Produce a scoped upgrade checklist grouped by severity (breaking changes first)",
+    "Step 9: Include source URLs from make.wordpress.org for every finding",
+    "Step 10: Mark items as 'not applicable' with a reason when a release note area does not affect this plugin"
+  ],
+  "success_criteria": [
+    "Fetches content from make.wordpress.org (field guide and/or dev notes)",
+    "Does not fabricate findings — every item is backed by a source URL",
+    "Searches the actual codebase before declaring a finding applicable or not",
+    "Output is a prioritized checklist with breaking changes at the top",
+    "Deprecations are distinguished from breaking changes",
+    "Not-applicable areas are explicitly listed with reasoning"
+  ]
+}

--- a/skills/wp-core-upgrade/SKILL.md
+++ b/skills/wp-core-upgrade/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: wp-core-upgrade
+description: "Use when a developer needs to upgrade a WordPress plugin, theme, or site to be compatible with a newer WordPress core version: fetches official dev notes and field guides from make.wordpress.org, identifies breaking changes and deprecations that apply to the project, and produces an upgrade checklist or patch recommendations."
+compatibility: "Targets WordPress 6.5+ (PHP 7.2.24+). Filesystem-based agent with bash + node. Requires web access to fetch make.wordpress.org dev notes."
+---
+
+# WP Core Upgrade
+
+## When to use
+
+Use this skill when a developer needs to:
+
+- Upgrade a plugin, theme, or full site to target a new WordPress core version
+- Audit existing code for compatibility with an upcoming or recently released WP version
+- Understand which breaking changes, deprecations, or new APIs from a WP release apply to their codebase
+- Get a prioritized checklist or implementation plan for a WP version migration
+
+## Inputs required
+
+- The **target WordPress version** (e.g., 6.9, 7.0).
+- The **project type**: plugin, theme (classic or block), or full site.
+- The **repo root** (or the paths to plugin/theme directories if it's a full site).
+- Optionally: the **current WordPress version** the project targets (to scope the range of relevant release notes).
+
+If any of these are unclear, ask one targeted question before proceeding.
+
+## Procedure
+
+### 0) Triage the project
+
+1. Run triage to understand project structure and tooling:
+   - `node skills/wp-project-triage/scripts/detect_wp_project.mjs`
+2. Note the project kind, PHP version, build tooling, and test suite present — these affect which release notes are relevant.
+
+### 1) Fetch the release notes for the target version
+
+Use the make.wordpress.org blog as the authoritative source. Dev notes and field guides are published for each release under the Core team blog.
+
+Read `references/make-blog-sources.md` for:
+- The URL patterns to find dev notes for a given WP version
+- How to use `?output_format=markdown` to get content as Markdown
+- What a field guide vs. a dev note is, and which to read first
+
+**Fetch strategy:**
+
+1. Start with the **Field Guide** post for the target version — it links to all relevant dev notes in one place.
+2. For each dev note that appears potentially relevant (based on title), fetch the full content as Markdown.
+3. Group what you find into categories: breaking changes, deprecations, new APIs, editor changes, performance, database.
+
+**Important:** Treat source URLs as required evidence. If a finding has no source URL, mark it incomplete rather than presenting it as settled.
+
+### 2) Identify which changes apply to the project
+
+With the fetched release notes and the triage report in hand:
+
+1. Scan the project for code patterns related to each release note. Search for function names, hook names, filter names, or class names mentioned in the notes.
+2. Flag findings by severity:
+   - **High**: Breaking changes — code will fail or behave incorrectly without a fix.
+   - **Medium**: Deprecations — code still works but will break in a future version.
+   - **Low**: New APIs or improvements the project could optionally adopt.
+3. Discard release notes whose scope doesn't touch this project type (e.g., a database schema change is not relevant to a simple shortcode plugin).
+
+Read `references/analysis-strategy.md` for search patterns and decision rules for common categories.
+
+### 3) Produce the primary output
+
+Choose the output format based on the mode:
+
+- **Audit / research mode** (no code changes requested): produce an upgrade checklist with items grouped by severity. Each item should include: what the issue is, where in the codebase it appears, the recommended fix, and the source URL.
+- **Implementation mode** (code changes requested): provide concrete patch recommendations with before/after code snippets, then apply them. Verify after each logical change.
+
+Format the checklist as a markdown task list. Example:
+
+```markdown
+## Breaking Changes (must fix)
+- [ ] Replace `deprecated_function()` calls (found in `includes/helpers.php:42`) — see https://make.wordpress.org/...
+
+## Deprecations (fix before next major)
+- [ ] ...
+
+## Optional improvements
+- [ ] ...
+```
+
+### 4) Version-bump environment files (if present)
+
+If the repo has local environment config, update the target WP version:
+
+- `.wp-env.json` / `wp-env.json` → update `"core"` version
+- `docker-compose.yml` → update WP image tag if pinned
+- `composer.json` → update `"roots/wordpress"` or `"johnpbloch/wordpress"` constraint if WP is a Composer dependency
+
+### 5) Implement changes (implementation mode only)
+
+Apply fixes in dependency order — fix breaking changes before deprecations. After each logical group of changes:
+
+1. Run any existing tests: PHPUnit, PHPCS, Jest/Playwright if present.
+2. Verify the site/plugin/theme still activates and functions correctly.
+
+If the repo has `@wordpress/scripts` or `@wordpress/env`, use those for build and test steps.
+
+## Verification
+
+- All high-severity findings are addressed or explicitly acknowledged as out-of-scope.
+- Every finding links to a source URL from make.wordpress.org.
+- If environment files were updated, the updated version matches the target WP version.
+- Existing tests pass (or failures are documented with a path to resolution).
+
+## Failure modes / debugging
+
+- **Can't find a field guide for the target version**: Search `https://make.wordpress.org/core/?s=field+guide+<version>` and look for the "X.Y Field Guide" post. Field guides are usually published 1–2 weeks before release.
+- **Dev note content is behind a login or 404**: Some draft notes may not yet be public. Proceed with what is available and note the gap.
+- **Too many release notes to process**: Read breaking changes and deprecations first (highest impact). Defer new-API notes to a follow-up pass.
+- **Uncertain whether a change applies**: Search the codebase for the exact function/hook name. If not found, mark as "not applicable" with a note.
+- **Composer-managed WordPress version not updating**: Check that the version constraint is not pinned too tightly (e.g., `"=6.8.0"`) and run `composer update`.
+
+## Escalation
+
+- If a breaking change has no clear migration path in the dev notes, check the WordPress Core Trac ticket or GitHub Gutenberg issue linked in the note before guessing.
+- For complex PHP deprecations (removed functions with no drop-in replacement), consult the WordPress Developer Resources or open a support thread on make.wordpress.org.
+- If the project uses a third-party plugin or theme as a dependency, escalate compatibility checks for that dependency to its own issue tracker.

--- a/skills/wp-core-upgrade/references/analysis-strategy.md
+++ b/skills/wp-core-upgrade/references/analysis-strategy.md
@@ -1,0 +1,109 @@
+# Analysis Strategy
+
+## Goal
+
+Determine which changes in a WordPress release actually affect *this* codebase, and discard everything else. A clean, scoped finding list is more useful than an exhaustive dump of every dev note.
+
+## Step 1: Categorize findings from release notes
+
+After fetching the dev notes, sort every change into one of these buckets:
+
+| Category | Examples |
+|----------|---------|
+| Breaking changes | Removed functions, changed function signatures, removed hooks, behavior changes |
+| Deprecations | Functions/classes/hooks flagged for removal in a future version |
+| Core API changes | New hooks, changed return values, modified globals |
+| Editor / block API | Block registration changes, block.json schema, editor hooks |
+| Frontend / templates | Template tag changes, query changes, markup changes |
+| Performance | Asset loading changes, caching changes, script module system |
+| Database / schema | New tables, changed column types, query behavior |
+| Admin | Admin page changes, Settings API changes |
+| Tooling | Build tool changes, test harness changes |
+
+## Step 2: Match against the project
+
+For each finding, decide if it's relevant by searching the codebase.
+
+### Quick search commands
+
+```bash
+# Search for a specific function or hook name
+grep -r "function_name" . --include="*.php" -l
+
+# Search for a filter/action hook
+grep -r "add_filter\|add_action" . --include="*.php" | grep "hook_name"
+
+# Search for a class name
+grep -r "ClassName" . --include="*.php" -l
+
+# Search for a block.json field
+grep -r "apiVersion" . --include="*.json"
+
+# Search for script enqueue patterns
+grep -r "wp_enqueue_script\|wp_enqueue_style" . --include="*.php" | grep "handle_name"
+```
+
+### Relevance decision rules
+
+| Finding type | Relevant if... |
+|-------------|----------------|
+| Removed PHP function | Project calls it (grep for the function name) |
+| Deprecated PHP function | Project calls it and will target the future version where it's removed |
+| Hook removed/renamed | Project hooks into it (grep `add_filter` or `add_action` + hook name) |
+| Changed function signature | Project calls it with the old signature |
+| block.json schema change | Project has `block.json` files |
+| Script module change | Project uses `wp_enqueue_script_module` or `viewScriptModule` |
+| Database schema change | Project queries the affected table directly |
+| Admin UI change | Project adds admin pages or Settings API fields |
+| Template tag change | Theme uses the tag in templates |
+
+## Step 3: Severity classification
+
+Assign severity to each relevant finding:
+
+- **High (must fix before upgrading)**: The code will throw a PHP fatal, produce incorrect output, or cause a security issue on the target version.
+- **Medium (fix before the following major)**: The code uses a deprecated API that will be removed in the next major version. Works today, breaks later.
+- **Low (optional improvement)**: A new API exists that could improve the code, but the old way still works.
+
+## Step 4: Scope filtering by project type
+
+Apply these filters before presenting findings to avoid noise:
+
+| If project is... | Skip these categories |
+|-----------------|----------------------|
+| Simple shortcode plugin (no blocks) | Editor / block API, script modules |
+| Classic theme (no JS interactivity) | Script modules, Interactivity API |
+| Block theme (no PHP business logic) | Core PHP API, database |
+| CLI-only plugin | Admin UI, frontend, editor |
+| REST API endpoint plugin | Frontend, editor, template tags |
+
+## Step 5: Output format
+
+Structure findings as a markdown checklist, sorted by severity:
+
+```markdown
+## Breaking Changes (fix before upgrading)
+
+- [ ] **[Function name removed]** — `old_function()` was removed. Found in `src/helpers.php:12`.
+  Replace with `new_function()`.
+  Source: https://make.wordpress.org/core/...
+
+## Deprecations (fix before next major)
+
+- [ ] **[Hook renamed]** — `old_hook` is deprecated in favour of `new_hook`. Found in `plugin.php:45`.
+  Source: https://make.wordpress.org/core/...
+
+## Not applicable
+
+The following release note areas were reviewed and found not to affect this project:
+- Database schema changes (project does not query `wp_*` tables directly)
+- Script module changes (project does not use `viewScriptModule`)
+```
+
+The "Not applicable" section is important: it shows you read the notes and made an active decision, rather than silently skipping them.
+
+## Handling uncertainty
+
+- If you find a function call but cannot confirm it maps to the changed WP function (e.g., same name in a third-party library), note the ambiguity.
+- If the dev note describes behavioral change without a clear search pattern, note this as "requires manual review" rather than asserting it applies or doesn't.
+- Never mark something "not applicable" without at least one grep to confirm absence.

--- a/skills/wp-core-upgrade/references/make-blog-sources.md
+++ b/skills/wp-core-upgrade/references/make-blog-sources.md
@@ -1,0 +1,75 @@
+# make.wordpress.org Blog Sources
+
+## Overview
+
+The official source for WordPress Core release notes is the Core team blog at `make.wordpress.org/core`. Every release cycle produces two types of posts:
+
+- **Field Guide**: A single curated post that links to all dev notes for a release. Published 1–2 weeks before the final release. Best starting point.
+- **Dev Notes**: Individual posts covering specific changes in depth. Each post focuses on one area (e.g., HTML API changes, block editor updates, REST API changes).
+
+## Finding the Field Guide
+
+Search URL pattern:
+```
+https://make.wordpress.org/core/?s=field+guide+X.Y
+```
+
+Replace `X.Y` with the target version (e.g., `6.9`, `7.0`).
+
+The field guide post title follows the pattern: **"WordPress X.Y Field Guide"**. It contains a list of links to all dev notes for that release — use it as your index.
+
+## Finding Dev Notes Directly
+
+Dev notes are tagged. Use the tag URL pattern:
+```
+https://make.wordpress.org/core/tag/dev-notes-X-Y/
+```
+
+Replace dots with hyphens in the version (e.g., `dev-notes-6-9` for 6.9).
+
+Alternatively, search:
+```
+https://make.wordpress.org/core/?s=dev+notes+X.Y
+```
+
+## Getting Markdown Output
+
+The make.wordpress.org blog supports returning posts as Markdown. Append `?output_format=markdown` to any post URL:
+
+```
+https://make.wordpress.org/core/2025/11/25/wordpress-6-9-field-guide/?output_format=markdown
+```
+
+This returns the post body as Markdown, which is easier to parse and process than HTML.
+
+## URL Patterns for Common Versions
+
+Use these as starting points and follow the links in the field guide to find individual dev notes.
+
+| Version | Field Guide Search URL |
+|---------|----------------------|
+| 6.5 | `https://make.wordpress.org/core/?s=field+guide+6.5` |
+| 6.6 | `https://make.wordpress.org/core/?s=field+guide+6.6` |
+| 6.7 | `https://make.wordpress.org/core/?s=field+guide+6.7` |
+| 6.8 | `https://make.wordpress.org/core/?s=field+guide+6.8` |
+| 6.9 | `https://make.wordpress.org/core/?s=field+guide+6.9` |
+| 7.0 | `https://make.wordpress.org/core/?s=field+guide+7.0` |
+
+## What to Read First
+
+For any upgrade audit, prioritize in this order:
+
+1. **Field Guide** — index of all changes for the release
+2. **Breaking changes dev notes** — anything with "breaking", "removed", or "deprecated" in the title
+3. **Area-specific dev notes** based on the project type:
+   - Plugin (PHP-heavy): Core API, hooks/filters, database, admin, REST API
+   - Block theme / Gutenberg: Editor, block API, script modules, theme.json
+   - Classic theme: Frontend, template tags, deprecated template functions
+   - Full site: all of the above
+
+## Handling Unavailable Posts
+
+If a URL returns a 404 or requires authentication:
+- The dev note may not yet be published (common for upcoming releases).
+- Try the cached version via the WordPress.org RSS feed: `https://make.wordpress.org/core/feed/?s=field+guide+X.Y`
+- Note the gap in your findings and do not fabricate content.


### PR DESCRIPTION
## Summary


Adds a new `wp-core-upgrade` skill that helps developers upgrade WordPress plugins, themes, and sites to be compatible with newer WordPress core versions.

- **`skills/wp-core-upgrade/SKILL.md`** — Core skill: triages the project, fetches official dev notes and field guides from `make.wordpress.org` (using `?output_format=markdown`), filters findings to what actually applies to the project, and produces a prioritized upgrade checklist or concrete patch recommendations.
- **`references/make-blog-sources.md`** — URL patterns for finding field guides and dev notes for any WP version, plus guidance on the Markdown output format.
- **`references/analysis-strategy.md`** — How to categorize, scope-filter, and severity-rank findings; includes search command patterns and rules for declaring a finding "not applicable".
- **`eval/scenarios/wp-core-upgrade.json`** — Eval scenario covering an audit-mode upgrade request for WordPress 6.9.

The skill is intentionally version-agnostic: it teaches the agent *how* to find and use the authoritative sources dynamically, rather than bundling pre-summarized notes for a fixed version. This means it works for past and future releases without requiring a new skill file per version.

## Test plan

- [ ] Skill directory structure matches the required layout (`SKILL.md`, `references/`, no scripts needed)
- [ ] Frontmatter fields (`name`, `description`, `compatibility`) are present and accurate
- [ ] All required SKILL.md sections are present: When to use, Inputs required, Procedure, Verification, Failure modes, Escalation
- [ ] Eval scenario is valid JSON with `name`, `skills`, `query`, `expected_behavior`, and `success_criteria`
- [ ] `node eval/harness/run.mjs` passes (if harness covers new scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)