### PR TITLE
blueprint: document hosted-Playground GitHub install gotchas (CORS, git:directory vs zip)

### DIFF
--- a/skills/blueprint/SKILL.md
+++ b/skills/blueprint/SKILL.md
@@ -80,6 +80,13 @@ Resources tell Playground where to find files. Used by `installPlugin`, `install
 - When using a branch or tag name for `ref`, you **must** set `refType` (`"branch"` | `"tag"` | `"commit"` | `"refname"`). Without it, only `"HEAD"` resolves reliably.
 - `path` selects a subdirectory (defaults to repo root).
 
+**CORS matters for any `url` resource fetched in the browser.** A **direct**
+`github.com/OWNER/REPO/archive/<ref>.zip` is not usable in a hosted demo: GitHub serves archive
+zips with `Access-Control-Allow-Origin: https://render.githubusercontent.com` (a fixed origin),
+so a client-side fetch from `playground.wordpress.net` is CORS-blocked. CORS-permissive sources
+that work: `wordpress-playground-cors-proxy.net/?<url>` (the official proxy),
+`raw.githubusercontent.com` (single files), `downloads.wordpress.org`, and `wordpress.org/plugins`.
+
 ### literal:directory — Inline File Trees
 
 ```json
@@ -267,6 +274,32 @@ Then activate it with a separate step:
 }
 ```
 
+`git:directory` ships the raw repo tree — fine for a no-build plugin. It is not the right tool
+for a **build-required** plugin (compiled JS/CSS, Composer autoload), which would ship un-built
+source. In that case, install a `.zip` via `resource:"url"` instead:
+
+### Installing a GitHub-hosted zip in the browser (hosted demos & PR previews)
+
+**Track a branch (bleeding edge) — GitHub source archive via the CORS proxy:**
+
+```json
+{
+  "step": "installPlugin",
+  "pluginData": {
+    "resource": "url",
+    "url": "https://wordpress-playground-cors-proxy.net/?https://github.com/user/repo/archive/refs/heads/main.zip"
+  },
+  "options": { "activate": true, "targetFolderName": "my-plugin" }
+}
+```
+
+The source archive extracts to a `repo-main/` folder containing the whole repo; `targetFolderName`
+renames it to a clean plugin dir. For a **build-required** plugin (compiles JS/CSS, Composer
+autoload) the raw source archive ships un-built code — install a CI-built zip instead.
+
+**Pin to a released version (stable demo):** `wordpress.org/plugins` slug if published, else a
+CI-built **release asset** — `.../releases/latest/download/PLUGIN.zip` via the proxy.
+
 ## Common Mistakes
 
 | Mistake | Correct |
@@ -277,7 +310,8 @@ Then activate it with a separate step:
 | Path separators in `files` keys | Use nested objects for subdirectories |
 | `runPHP` without `wp-load.php` | Always `require '/wordpress/wp-load.php';` for WP functions |
 | Invented top-level keys | Only documented keys work — schema rejects unknown properties |
-| Inventing proxy URLs for GitHub | Use `git:directory` resource type |
+| Inventing proxy URLs for GitHub | Use `git:directory`, or a `.zip` `url` via the official `wordpress-playground-cors-proxy.net/?<url>` |
+| Direct `github.com/.../archive/<ref>.zip` as a `url` | CORS-blocked — wrap it in `wordpress-playground-cors-proxy.net/?<url>` |
 | Omitting `refType` with branch/tag `ref` | Required — only `"HEAD"` works without it |
 | Resource references in `literal:directory` `files` values | Values must be plain strings (content) or objects (subdirectories) — never resource refs |
 | `features.debug` or other invented feature keys | `features` only supports `networking` and `intl` — use `constants: { "WP_DEBUG": true }` for debug mode |


### PR DESCRIPTION
## What

Two reproducible, non-obvious gotchas for installing from GitHub in the *hosted browser* Playground, plus two Common Mistakes rows. All in `skills/blueprint/SKILL.md` (+35/−1).

## Why

A blueprint that passes schema validation can still fail at runtime in the browser, for reasons the skill doesn't currently cover:

- **A direct `github.com/OWNER/REPO/archive/<ref>.zip` URL is CORS-blocked** from `playground.wordpress.net` — GitHub serves archive zips with a fixed `Access-Control-Allow-Origin: https://render.githubusercontent.com`, so a client-side fetch is rejected. The fix is the official `wordpress-playground-cors-proxy.net/?<url>` proxy; the skill now lists which sources are CORS-permissive.
- **`git:directory` ships the raw repo tree**, so it's the wrong tool for a build-required plugin (compiled JS/CSS, Composer autoload) — those need a prebuilt `.zip`. The skill now says when to prefer which, with a minimal proxy-install example.

Scoped deliberately to durable, tool-agnostic facts — no repo-specific workflows and no bug-contingent notes.