### PR TITLE
fix: align wp-patterns compatibility frontmatter with WP 7.0 contract

### DIFF
--- a/skills/wp-patterns/SKILL.md
+++ b/skills/wp-patterns/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: wp-patterns
 description: "Generate technically correct, design-distinctive WordPress block patterns. Use when creating block patterns, starter page patterns, template patterns, template part patterns, or improving pattern design quality. Covers pattern registration (PHP headers, auto/manual), block markup syntax, theme.json design tokens, categories, template types, accessibility, and i18n/escaping."
-compatibility: "WordPress 6.9 with PHP 7.2.24 or later. Requires 6.0+ for auto-registration, 6.7+ for full preset support. Patterns use block markup (HTML comments with JSON), PHP file headers, and theme.json presets."
+compatibility: "Targets WordPress 7.0+ (PHP 7.4.0+). Requires 6.0+ for auto-registration, 6.7+ for full preset support. Patterns use block markup (HTML comments with JSON), PHP file headers, and theme.json presets."
 ---
 
 # WordPress Block Patterns


### PR DESCRIPTION
### What does this PR do?
Updates the `compatibility:` frontmatter in `skills/wp-patterns/SKILL.md` to target **WordPress 7.0+ (PHP 7.4.0+)**.

Addresses https://github.com/WordPress/agent-skills/issues/80

### Why is this change necessary?
During PR #70 (`chore: Update target WordPress version to 7.0 and minimum PHP to 7.4.0`), `eval/harness/run.mjs` was updated to strictly require every skill to declare compatibility with `WordPress 7.0` and `PHP 7.4.0`. 

`skills/wp-patterns/SKILL.md` was accidentally overlooked and still declared `WordPress 6.9 with PHP 7.2.24 or later`, causing `node eval/harness/run.mjs` to fail immediately out of the box when cloning `trunk`.

### Verification
- Ran `node eval/harness/run.mjs` locally.
- Confirmed that frontmatter validation and triage sanity checks now pass successfully:
  ```
  OK: skills frontmatter and triage report sanity checks passed.
  ```

### Checklist
- [x] I have verified `node eval/harness/run.mjs` passes.
- [x] I have preserved historical version notes in the body/frontmatter where applicable (`Requires 6.0+ for auto-registration, 6.7+ for full preset support`).
```
