### PR TITLE
Update wp-patterns compatibility contract to WP 7.0 / PHP 7.4.0

### DIFF
--- a/skills/wp-patterns/SKILL.md
+++ b/skills/wp-patterns/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: wp-patterns
 description: "Generate technically correct, design-distinctive WordPress block patterns. Use when creating block patterns, starter page patterns, template patterns, template part patterns, or improving pattern design quality. Covers pattern registration (PHP headers, auto/manual), block markup syntax, theme.json design tokens, categories, template types, accessibility, and i18n/escaping."
-compatibility: "WordPress 6.9 with PHP 7.2.24 or later. Requires 6.0+ for auto-registration, 6.7+ for full preset support. Patterns use block markup (HTML comments with JSON), PHP file headers, and theme.json presets."
+compatibility: "Targets WordPress 7.0+ (PHP 7.4.0+). Requires 6.0+ for auto-registration, 6.7+ for full preset support. Patterns use block markup (HTML comments with JSON), PHP file headers, and theme.json presets."
 ---
 
 # WordPress Block Patterns


### PR DESCRIPTION
## Problem

CI (`validate`) is failing on trunk for every open PR: the eval harness requires each skill's `compatibility` frontmatter to declare WordPress 7.0 + PHP 7.4.0, but `skills/wp-patterns/SKILL.md` still says "WordPress 6.9 with PHP 7.2.24". The wp-patterns skill (#18) was written before #70 raised the contract, and the two merged past each other.

## Solution

Update the compatibility line to the standard "Targets WordPress 7.0+ (PHP 7.4.0+)" wording used by the other skills, keeping the pattern-specific feature notes (6.0+ auto-registration, 6.7+ preset support). `node eval/harness/run.mjs` passes locally with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)