### PR TITLE
Fix detect_plugins missing docblock plugin headers

### DIFF
--- a/skills/wp-plugin-development/scripts/detect_plugins.mjs
+++ b/skills/wp-plugin-development/scripts/detect_plugins.mjs
@@ -64,6 +64,12 @@ function findFilesRecursive(repoRoot, predicate, { maxFiles = 6000, maxDepth = 1
   return { results, truncated: false };
 }
 
+function cleanupHeaderValue(value) {
+  // Mirrors WordPress core's _cleanup_header_comment(): drop a trailing `*/` or `?>`
+  // so single-line docblocks like `/* Version: 1.0.0 */` yield just the value.
+  return value.replace(/\s*(?:\*\/|\?>).*/, "").trim();
+}
+
 function parsePluginHeader(contents) {
   // WordPress reads plugin headers from the top of the file. We only need key fields.
   const header = {};
@@ -78,8 +84,13 @@ function parsePluginHeader(contents) {
     ["Domain Path", "domainPath"],
   ];
   for (const [label, key] of pairs) {
-    const m = contents.match(new RegExp(`^\\s*${label}:\\s*(.+)\\s*$`, "im"));
-    if (m) header[key] = m[1].trim();
+    // Headers normally live in a docblock, so the label is preceded by ` * `. Core allows
+    // the same leading comment characters (`^[ \t\/*#@]*` in get_file_data()); `^\s*` does
+    // not, and would skip every conventionally formatted plugin.
+    const m = contents.match(new RegExp(`^[ \\t/*#@]*${label}:(.*)$`, "im"));
+    if (!m) continue;
+    const value = cleanupHeaderValue(m[1]);
+    if (value) header[key] = value;
   }
   if (!header.name) return null;
   return header;


### PR DESCRIPTION
## The bug

`skills/wp-plugin-development/scripts/detect_plugins.mjs` reports `count: 0` for conventionally formatted WordPress plugins.

`parsePluginHeader()` matched each header with:

```js
new RegExp(`^\\s*${label}:\\s*(.+)\\s*$`, "im")
```

`^\s*` does not allow the leading `*` of a docblock, so ` * Plugin Name: ...` never matches. The looser `/Plugin Name:/i` guard in `main()` passes first, so the file is opened and then silently discarded — the detector returns an empty list rather than an error, which makes the failure easy to miss.

Since plugin headers are conventionally written inside `/** ... */`, this misses essentially every real plugin.

## The fix

Allow the same leading comment characters WordPress core allows in [`get_file_data()`](https://developer.wordpress.org/reference/functions/get_file_data/) — `^[ \t\/*#@]*` — and strip a trailing `*/` or `?>` the way core's `_cleanup_header_comment()` does, so single-line headers like `/* Plugin Name: Foo */` yield just the value.

## Verification

Against a real plugin ([Herm71/rcid-core-functionality](https://github.com/Herm71/rcid-core-functionality), a standard `/** ... */` header in `plugin.php`):

| | before | after |
|---|---|---|
| `count` | `0` | `1` |
| `name` | — | `Ruth Chafin Interior Design Core Functionality` |

Also checked against four header styles plus a control:

| fixture | header style | detected |
|---|---|---|
| `a.php` | `/** * Plugin Name: ... */` docblock | yes, all fields |
| `b.php` | `/*` + bare lines + `*/` | yes |
| `c.php` | `/* Plugin Name: One Liner */` | yes, `*/` stripped |
| `d.php` | `# Plugin Name: ...` | yes |
| `e.php` | no header | correctly skipped |

`Author URI:` still does not bleed into the `Author` field.

`node eval/harness/run.mjs` passes.

Reported downstream as Herm71/rcid-core-functionality#15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)