### PR TITLE
feat: require every skill to have an eval scenario

### DIFF
--- a/eval/harness/run.mjs
+++ b/eval/harness/run.mjs
@@ -77,6 +77,27 @@ function runJsonCommand(command, args, cwd) {
   }
 }
 
+function scenarioSkillCoverage(repoRoot) {
+  // Which skills are exercised by at least one eval scenario. Scenarios are
+  // JSON files declaring the skills they route through (see
+  // eval/scenarios/README.md).
+  const scenariosRoot = path.join(repoRoot, "eval", "scenarios");
+  const covered = new Set();
+  if (!fs.existsSync(scenariosRoot)) return covered;
+  for (const entry of fs.readdirSync(scenariosRoot)) {
+    if (!entry.endsWith(".json")) continue;
+    const scenarioPath = path.join(scenariosRoot, entry);
+    let scenario;
+    try {
+      scenario = JSON.parse(readUtf8(scenarioPath));
+    } catch (error) {
+      throw new Error(`Invalid JSON in eval/scenarios/${entry}: ${error.message}`);
+    }
+    for (const skill of scenario.skills ?? []) covered.add(skill);
+  }
+  return covered;
+}
+
 function main() {
   const repoRoot = process.cwd();
 
@@ -116,6 +137,13 @@ function main() {
       `Compatibility contract mismatch in ${path.relative(repoRoot, skillPath)} (expected WP 7.0 + PHP 7.4.0+)`
     );
   }
+
+  const covered = scenarioSkillCoverage(repoRoot);
+  const uncovered = skillDirs.map((dir) => path.basename(dir)).filter((name) => !covered.has(name));
+  assert(
+    uncovered.length === 0,
+    `Skills with no eval scenario (see docs/principles.md): ${uncovered.join(", ")}`
+  );
 
   const triageScript = path.join(repoRoot, "skills", "wp-project-triage", "scripts", "detect_wp_project.mjs");
   assert(fs.existsSync(triageScript), "Missing triage detector script");

--- a/eval/scenarios/wpds-build-settings-panel.json
+++ b/eval/scenarios/wpds-build-settings-panel.json
@@ -1,0 +1,24 @@
+{
+  "name": "Build a settings panel with WPDS components and tokens",
+  "skills": ["wordpress-router", "wp-project-triage", "wpds"],
+  "query": "I'm adding a settings panel to our Gutenberg sidebar plugin: a toggle for 'Enable notifications', a select for digest frequency, and a save button. Build the UI so it matches the WordPress Design System, and don't hardcode any colors or spacing.",
+  "expected_behavior": [
+    "Step 1: Run wordpress-router to classify the repo kind",
+    "Step 2: Run wp-project-triage to detect the tooling and any lint scripts available",
+    "Step 3: Route to wpds because the request is about building WordPress UI to Design System standards",
+    "Step 4: Read the relevant reference-site documentation through the WPDS MCP server before proposing code",
+    "Step 5: Resolve the component set through wpds://components rather than recalling component names from memory",
+    "Step 6: Resolve spacing and color values through wpds://design-tokens instead of hardcoding literals",
+    "Step 7: Produce working TypeScript/React/CSS snippets, the assumed stack unless the repo indicates otherwise",
+    "Step 8: Run any lint scripts surfaced by triage to validate the proposed output",
+    "Step 9: Close with a recap explaining each decision and stating what was left out as non-UI"
+  ],
+  "success_criteria": [
+    "Routes to the wpds skill",
+    "Consults the WPDS MCP server for component and token information rather than searching the web",
+    "Every color and spacing value references a design token, with no hardcoded literals",
+    "Output includes working code snippets in TypeScript, React, and CSS",
+    "Non-UI concerns such as data fetching and string localization are explicitly excluded, not silently solved",
+    "Recap explains the reasoning behind each component and token choice"
+  ]
+}


### PR DESCRIPTION
`docs/principles.md` requires every skill to ship at least one eval scenario, and `docs/authoring-guide.md` repeats it twice — but nothing enforced it. `wpds` had already slipped through with zero scenarios out of 41.

This adds the check to `eval/harness/run.mjs` and writes the missing `wpds` scenario, built against that skill's documented procedure: MCP-sourced components and tokens, no hardcoded colors or spacing, explicit non-UI boundaries.

The coverage helper also surfaces malformed scenario JSON with a clear message, which nothing currently does.

**Verified locally:**

- Harness passes with the new scenario present
- Removing it fails with `Skills with no eval scenario (see docs/principles.md): wpds`
- A malformed scenario reports `Invalid JSON in eval/scenarios/<file>: Unexpected end of JSON input`
- A scenario without a `skills` key is tolerated rather than crashing
- New scenario references only existing skill directories and carries all five documented fields