### PR TITLE
Migrate skill evaluation scenarios from markdown to JSON format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,12 +36,14 @@ node shared/scripts/scaffold-skill.mjs <skill-name> "<description>"
 
 ### 3. Add Evaluation Scenarios
 
-Every skill needs test scenarios under `eval/scenarios/`. These are simple markdown files describing:
-- A realistic prompt/task
-- What the AI should do
-- How to verify it worked
+Every skill needs test scenarios under `eval/scenarios/`. Scenarios are **JSON files only** (see `eval/scenarios/README.md`) — add one as `eval/scenarios/<skill-name>.json` with these fields:
+- `name` — a short description of the scenario
+- `skills` — the skill(s) it should route through
+- `query` — a realistic prompt/task
+- `expected_behavior` — the steps the AI should take, in order
+- `success_criteria` — how to verify it worked
 
-This is a great low-barrier contribution—you're essentially writing "what should happen when someone asks X?"
+This is a great low-barrier contribution—you're essentially writing "what should happen when someone asks X?" `node shared/scripts/scaffold-skill.mjs <skill-name> "<description>"` creates a starter scenario file for you.
 
 ### 4. Report Issues
 

--- a/docs/authoring-guide.md
+++ b/docs/authoring-guide.md
@@ -49,7 +49,7 @@ Then ask the model to output:
 1. `skills/<skill-name>/SKILL.md`
 2. Any `references/*.md` files it mentions
 3. Any `scripts/*` stubs needed for deterministic checks
-4. One scenario markdown file under `eval/scenarios/`
+4. One scenario JSON file (`<skill-name>.json`, with `name`, `skills`, `query`, `expected_behavior`, `success_criteria`) under `eval/scenarios/`
 
 ## Suggested initial domain skills (v1)
 

--- a/shared/scripts/scaffold-skill.mjs
+++ b/shared/scripts/scaffold-skill.mjs
@@ -9,7 +9,7 @@ function usage() {
       "",
       "Notes:",
       "- <skill-name> must be lowercase unicode letters/digits with hyphens (no leading/trailing hyphen, no --).",
-      "- Creates skills/<skill-name>/SKILL.md and eval/scenarios/<skill-name>.md",
+      "- Creates skills/<skill-name>/SKILL.md and eval/scenarios/<skill-name>.json",
       "",
     ].join("\n")
   );
@@ -44,7 +44,7 @@ function main() {
   const repoRoot = process.cwd();
   const skillDir = path.join(repoRoot, "skills", skillName);
   const skillMd = path.join(skillDir, "SKILL.md");
-  const scenarioPath = path.join(repoRoot, "eval", "scenarios", `${skillName}.md`);
+  const scenarioPath = path.join(repoRoot, "eval", "scenarios", `${skillName}.json`);
 
   assert(!fs.existsSync(skillDir), `Skill directory already exists: ${path.relative(repoRoot, skillDir)}`);
   fs.mkdirSync(skillDir, { recursive: true });
@@ -53,8 +53,14 @@ function main() {
   fs.writeFileSync(skillMd, skillBody, "utf8");
 
   fs.mkdirSync(path.dirname(scenarioPath), { recursive: true });
-  const scenario = `# Scenario: ${skillName}\n\n## Prompt\n\n## Expected behavior\n\n- Uses \`${skillName}\` when the prompt matches its description.\n- Follows the skill procedure and verifies results.\n`;
-  fs.writeFileSync(scenarioPath, scenario, "utf8");
+  const scenario = {
+    name: `TODO: describe the scenario for ${skillName}`,
+    skills: [skillName],
+    query: "TODO: a realistic user prompt that should route to this skill",
+    expected_behavior: [`Step 1: Route to ${skillName} because the task matches its description`, "TODO: add the remaining expected steps"],
+    success_criteria: [`Routes to ${skillName}`, "TODO: add the remaining pass/fail checks"],
+  };
+  fs.writeFileSync(scenarioPath, `${JSON.stringify(scenario, null, 2)}\n`, "utf8");
 
   process.stdout.write(`OK: created ${path.relative(repoRoot, skillMd)} and ${path.relative(repoRoot, scenarioPath)}\n`);
 }


### PR DESCRIPTION
Resolves https://github.com/WordPress/agent-skills/issues/94

## Summary
- `shared/scripts/scaffold-skill.mjs` now generates `eval/scenarios/<skill-name>.json` (matching the real `name`/`skills`/`query`/`expected_behavior`/`success_criteria` schema) instead of a markdown file that nothing else in the repo used
- `docs/authoring-guide.md` and `CONTRIBUTING.md` updated to describe the JSON schema instead of "markdown files" — now consistent with `eval/scenarios/README.md`, which was already correct

## Test plan
- [x] `node eval/harness/run.mjs` passes
- [x] `node shared/scripts/scaffold-skill.mjs <name> "<desc>"` generates a valid `eval/scenarios/<name>.json` matching the schema (verified locally, then removed as a throwaway test)