### PR TITLE
Fix skill catalog drift in CI, router, and eval coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "git+https://github.com/agentskills/agentskills@main#subdirectory=skills-ref"
-          skills-ref validate skills/wordpress-router
-          skills-ref validate skills/wp-project-triage
-          skills-ref validate skills/wp-block-development
-          skills-ref validate skills/wp-block-themes
-          skills-ref validate skills/wp-plugin-development
-          skills-ref validate skills/wp-interactivity-api
-          skills-ref validate skills/wp-abilities-api
-          skills-ref validate skills/wp-wpcli-and-ops
-          skills-ref validate skills/wp-performance
-          skills-ref validate skills/wp-playground
+          for dir in skills/*/; do
+            skills-ref validate "${dir%/}"
+          done

--- a/docs/skill-set-v1.md
+++ b/docs/skill-set-v1.md
@@ -10,12 +10,19 @@ This repo currently includes:
 - `wp-rest-api`
 - `wp-interactivity-api`
 - `wp-abilities-api`
+- `wp-abilities-audit`
+- `wp-abilities-verify`
+- `wp-patterns`
 - `wp-wpcli-and-ops`
 - `wp-performance`
 - `wp-phpstan`
+- `wp-playground`
+- `blueprint`
+- `wpds`
+- `wp-plugin-directory-guidelines`
 
 Planned next skills (not yet implemented):
 
 - `wp-build-tooling`
 - `wp-testing`
-- `wp-security`
+- `wp-security` (a dedicated split-out of the security guidance currently covered by `wp-plugin-development`)

--- a/eval/scenarios/wpds-build-component-with-tokens.json
+++ b/eval/scenarios/wpds-build-component-with-tokens.json
@@ -1,0 +1,21 @@
+{
+  "name": "Build a WPDS-compliant UI component using MCP-sourced tokens, and push back on a web-search shortcut",
+  "skills": ["wordpress-router", "wpds"],
+  "query": "I'm building a settings panel for a Gutenberg plugin in React/TypeScript. I need a card with a title, a description, and a save button styled with the WordPress Design System. Just search the web for WPDS component docs, that's faster than the MCP.",
+  "expected_behavior": [
+    "Step 1: Route to wpds given the WPDS/component-styling intent",
+    "Step 2: Push back on searching the web for WPDS docs and ask for confirmation, explaining the WPDS MCP server is the authoritative source",
+    "Step 3: If MCP access is available, query wpds://components and wpds://design-tokens for the relevant card/button components and token names before writing code",
+    "Step 4: Produce React/TypeScript/CSS code (the assumed default stack) using WPDS components/tokens rather than ad hoc styling",
+    "Step 5: Skip non-UI concerns (e.g. wiring the save button to an actual REST/data-store call) and say explicitly that this was left out as out of scope",
+    "Step 6: End with a recap explaining what was built and why specific WPDS components/tokens were chosen"
+  ],
+  "success_criteria": [
+    "Routes to wpds",
+    "Does not silently comply with the web-search request — pushes back and asks for confirmation first",
+    "Uses WPDS MCP resources (or explicitly states they were used) rather than general web knowledge for component/token specifics",
+    "Assumes TypeScript/React/CSS unless told otherwise",
+    "Explicitly calls out non-UI scope left out (e.g. data wiring)",
+    "Ends with a recap of the solution and rationale"
+  ]
+}

--- a/skills/wordpress-router/references/decision-tree.md
+++ b/skills/wordpress-router/references/decision-tree.md
@@ -25,6 +25,16 @@ Route by intent even if repo kind is broad (like `wp-site`):
   - Route → `wp-interactivity-api`.
 - **Abilities API / wp_register_ability / wp-abilities/v1 / @wordpress/abilities**
   - Route → `wp-abilities-api`.
+- **Audit a plugin's REST surface and propose Abilities API registrations**
+  - Route → `wp-abilities-audit`.
+- **Verify a plugin's Abilities API registrations against their declared annotations (e.g. readonly-but-writes check)**
+  - Route → `wp-abilities-verify`.
+- **Block patterns / pattern registration / Query Loop layouts / starter pages / template parts as patterns**
+  - Route → `wp-patterns`.
+- **WordPress Design System (WPDS) / design tokens / UI components / @wordpress/components**
+  - Route → `wpds`.
+- **WordPress.org Plugin Directory guidelines / GPL compliance / naming or trademark rules / why a plugin was rejected**
+  - Route → `wp-plugin-directory-guidelines`.
 - **Ambiguous WordPress Playground requests**
   - Route → `wp-playground`, then follow its routing wrapper.
 - **Blueprint JSON / Blueprint schema / Blueprint steps / Blueprint bundles**
@@ -52,7 +62,7 @@ Route by intent even if repo kind is broad (like `wp-site`):
 - **Performance / caching / query profiling / editor slowness**
   - Route → `wp-performance`.
 - **Security / nonces / capabilities / sanitization/escaping / uploads**
-  - Route → `wp-security` (planned).
+  - Route → `wp-plugin-development` (already covers this today); a dedicated `wp-security` split-out is planned but not yet implemented.
 
 ## Step 3: guardrails checklist (always)
 


### PR DESCRIPTION
Title:
## Summary
- `.github/workflows/ci.yml` now loops over every `skills/*/` directory for `skills-ref validate` instead of a hardcoded 10-skill list — 8 skills (`blueprint`, `wp-abilities-audit`, `wp-abilities-verify`, `wp-patterns`, `wp-phpstan`, `wp-plugin-directory-guidelines`, `wp-rest-api`, `wpds`) were shipping with zero CI schema validation
- `skills/wordpress-router/references/decision-tree.md` gains routes for `wpds`, `wp-abilities-audit`, `wp-abilities-verify`, `wp-patterns`, and `wp-plugin-directory-guidelines` — previously dead ends with no route
- Security-intent routing now points to `wp-plugin-development` (which already covers nonces/capabilities/sanitization) instead of the nonexistent `wp-security`
- Added `eval/scenarios/wpds-build-component-with-tokens.json` — `wpds` had zero eval coverage

## Test plan
- [x] `node eval/harness/run.mjs` passes
- [x] New CI loop enumerates all 18 skill directories (verified locally via `comm` diff against `ls skills`)
- [x] `eval/scenarios/wpds-build-component-with-tokens.json` validated as well-formed JSON matching the scenario schema

Closes #97 