### PR TITLE
Fix Plugin/Theme header detection in PHP docblocks

### DIFF
--- a/skills/wp-plugin-development/scripts/detect_plugins.mjs
+++ b/skills/wp-plugin-development/scripts/detect_plugins.mjs
@@ -78,7 +78,7 @@ function parsePluginHeader(contents) {
     ["Domain Path", "domainPath"],
   ];
   for (const [label, key] of pairs) {
-    const m = contents.match(new RegExp(`^\\s*${label}:\\s*(.+)\\s*$`, "im"));
+    const m = contents.match(new RegExp(`^\\s*\\*?\\s*${label}:\\s*(.+)\\s*$`, "im"));
     if (m) header[key] = m[1].trim();
   }
   if (!header.name) return null;

--- a/skills/wp-project-triage/scripts/detect_wp_project.mjs
+++ b/skills/wp-project-triage/scripts/detect_wp_project.mjs
@@ -124,7 +124,7 @@ function findFilesRecursive(repoRoot, predicate, { maxFiles = 6000, maxDepth = 8
 function detectPluginHeaderFromPhpFile(filePath) {
   const contents = readFileSafe(filePath, 128 * 1024);
   if (!contents) return null;
-  const headerMatch = contents.match(/^\s*Plugin Name:\s*(.+)\s*$/im);
+  const headerMatch = contents.match(/^\s*\*?\s*Plugin Name:\s*(.+)\s*$/im);
   if (!headerMatch) return null;
   return headerMatch[1].trim();
 }
@@ -132,7 +132,7 @@ function detectPluginHeaderFromPhpFile(filePath) {
 function detectThemeHeaderFromStyleCss(filePath) {
   const contents = readFileSafe(filePath, 128 * 1024);
   if (!contents) return null;
-  const headerMatch = contents.match(/^\s*Theme Name:\s*(.+)\s*$/im);
+  const headerMatch = contents.match(/^\s*\*?\s*Theme Name:\s*(.+)\s*$/im);
   if (!headerMatch) return null;
   return headerMatch[1].trim();
 }


### PR DESCRIPTION
## Summary

`detectPluginHeaderFromPhpFile` and `parsePluginHeader` failed on standard WordPress plugin headers because the regex required only leading whitespace before the label:

```js
/^\s*Plugin Name:\s*(.+)\s*$/im
```

A typical header line is ` * Plugin Name: Foo` — the `*` is not whitespace — so detection returned `null` / `count: 0` for every normal plugin.

### Before

```js
contents.match(/^\s*Plugin Name:\s*(.+)\s*$/im)
// Theme Name similarly
new RegExp(`^\\s*${label}:\\s*(.+)\\s*$`, "im")
```

### After

```js
contents.match(/^\s*\*?\s*Plugin Name:\s*(.+)\s*$/im)
contents.match(/^\s*\*?\s*Theme Name:\s*(.+)\s*$/im)
new RegExp(`^\\s*\\*?\\s*${label}:\\s*(.+)\\s*$`, "im")
```

Optional docblock star keeps bare `Plugin Name:` / `Theme Name:` lines working (e.g. theme `style.css`).

## Files

- `skills/wp-project-triage/scripts/detect_wp_project.mjs`
- `skills/wp-plugin-development/scripts/detect_plugins.mjs`

## Verification (local fixtures)

Against a docblock-style plugin (` * Plugin Name: WP Hello Plugin`):

- `detect_wp_project` → `primary: "wp-plugin"`, `detectedPluginName: "WP Hello Plugin"`
- `detect_plugins` → `count: 1`

Against empty non-WP dir: still `unknown` / `count: 0`.

Against block theme fixture: still `wp-block-theme` with `detectedThemeName` set.